### PR TITLE
Modernize Styling and Theming to MUI v6 and React 19

### DIFF
--- a/src/Unosquare.PassCore.Web/ClientApp/App.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/App.tsx
@@ -1,39 +1,15 @@
 import './vendor';
 
-import { StyledEngineProvider, createTheme, responsiveFontSizes, ThemeProvider } from '@mui/material/styles';
-
+import { ThemeProvider } from '@mui/material/styles';
 import * as React from 'react';
 import * as ReactDOMClient from 'react-dom/client';
 import { Main } from './Main';
+import { passcoreTheme } from './theme';
 
-const theme = createTheme({
-    palette: {
-        error: {
-            main: '#f44336',
-        },
-        primary: {
-            main: '#304FF3',
-        },
-        secondary: {
-            main: '#fff',
-        },
-        text: {
-            primary: '#191919',
-            secondary: '#000',
-        },
-    },
-    zIndex: {
-        appBar: 1201,
-    },
-});
-
-const passcoreTheme = responsiveFontSizes(theme);
 const rootNode = document.getElementById('rootNode');
-const root = ReactDOMClient.createRoot(rootNode);
+const root = ReactDOMClient.createRoot(rootNode!);
 root.render(
-    <StyledEngineProvider injectFirst>
-        <ThemeProvider theme={passcoreTheme}>
-            <Main />
-        </ThemeProvider>
-    </StyledEngineProvider>,
+    <ThemeProvider theme={passcoreTheme}>
+        <Main />
+    </ThemeProvider>,
 );

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/ChangePassword.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/ChangePassword.tsx
@@ -35,20 +35,6 @@ export const ChangePassword: React.FC = () => {
         12: alerts.errorPwnedPassword,
     };
 
-    const paperStyle = {
-        borderRadius: '10px',
-        minHeight: '550px',
-        maxWidth: '650px',
-        width: '100%',
-        marginTop: '75px',
-        zIndex: 1,
-    };
-
-    const buttonStyle = {
-        margin: recaptcha?.siteKey ? '25px 0 0 180px' : '100px 0 0 180px',
-        width: '240px',
-    };
-
     const handleSubmit = () => {
         if (!isSubmitting) {
             setIsSubmitting(true);
@@ -88,7 +74,10 @@ export const ChangePassword: React.FC = () => {
 
     return (
         <>
-            <Paper sx={paperStyle} elevation={6}>
+            <Paper
+                elevation={6}
+                sx={{ borderRadius: '10px', minHeight: 550, mt: '75px', zIndex: 1 }}
+            >
                 <ChangePasswordForm
                     submitData={submit}
                     toSubmitData={toSubmitData}
@@ -102,8 +91,12 @@ export const ChangePassword: React.FC = () => {
                     type="button"
                     variant="contained"
                     color="primary"
-                    disabled={disabled || isSubmitting} // disable if form is not validated or submitting
-                    sx={buttonStyle}
+                    disabled={disabled || isSubmitting}
+                    sx={{
+                        mt: recaptcha?.siteKey ? '25px' : '100px',
+                        ml: '180px',
+                        width: 240,
+                    }}
                     onClick={handleSubmit}
                 >
                     {changePasswordButtonLabel}

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/ChangePasswordForm.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/ChangePasswordForm.tsx
@@ -1,4 +1,4 @@
-import FormGroup from '@mui/material/FormGroup';
+import Stack from '@mui/material/Stack';
 import * as React from 'react';
 import TextField from '@mui/material/TextField';
 import { GlobalContext } from '../Provider/GlobalContext';
@@ -176,22 +176,14 @@ export const ChangePasswordForm: React.FC<IChangePasswordFormProps> = ({
         }));
     };
 
-    const formGroupStyle = {
-        width: '80%',
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
-        alignItems: 'stretch',
-        paddingTop: '16px',
-        margin: '0 auto',
-    };
-
     return (
-        <FormGroup row={false} sx={formGroupStyle}>
+        <Stack
+            spacing={2}
+            sx={{ width: '80%', mx: 'auto', pt: 2 }}
+        >
             <TextField
                 autoFocus
                 slotProps={{ htmlInput: { tabIndex: 1 } }}
-                sx={{ flex: 1, margin: 'auto' }}
                 id="username"
                 label={usernameLabel}
                 variant="standard"
@@ -205,7 +197,6 @@ export const ChangePasswordForm: React.FC<IChangePasswordFormProps> = ({
             />
             <TextField
                 slotProps={{ htmlInput: { tabIndex: 2 } }}
-                sx={{ flex: 1, margin: 'auto' }}
                 label={currentPasswordLabel}
                 variant="standard"
                 id="currentPassword"
@@ -224,7 +215,6 @@ export const ChangePasswordForm: React.FC<IChangePasswordFormProps> = ({
                 <>
                     <TextField
                         slotProps={{ htmlInput: { tabIndex: 3 } }}
-                        sx={{ flex: 1, margin: 'auto' }}
                         label={newPasswordLabel}
                         variant="standard"
                         id="newPassword"
@@ -243,7 +233,6 @@ export const ChangePasswordForm: React.FC<IChangePasswordFormProps> = ({
                     </Typography>
                     <TextField
                         slotProps={{ htmlInput: { tabIndex: 4 } }}
-                        sx={{ flex: 1, margin: 'auto' }}
                         label={newPasswordVerifyLabel}
                         variant="standard"
                         id="newPasswordVerify"
@@ -261,6 +250,6 @@ export const ChangePasswordForm: React.FC<IChangePasswordFormProps> = ({
             {recaptcha?.siteKey && recaptcha.siteKey !== '' && (
                 <ReCaptcha setToken={setReCaptchaToken} shouldReset={false} />
             )}
-        </FormGroup>
+        </Stack>
     );
 };

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/ClientAppBar.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/ClientAppBar.tsx
@@ -14,17 +14,14 @@ export const ClientAppBar: React.FC = () => {
     return (
         <AppBar
             position="fixed"
-            style={{
-                backgroundColor: '#304FF3',
-                height: '64px',
-            }}
             elevation={0}
+            sx={{ height: 64 }}
         >
             <Box
                 display="flex"
                 justifyContent="space-between"
                 alignItems="center"
-                height="64px"
+                sx={{ height: 64 }}
                 width="100%"
                 padding="0 24px"
             >
@@ -44,7 +41,7 @@ export const ClientAppBar: React.FC = () => {
                     </Tooltip>
                 ) : (
                     <IconButton color="secondary" size="large" disabled>
-                        <HelpIcon style={{ opacity: 0.5 }} />
+                        <HelpIcon sx={{ opacity: 0.5 }} />
                     </IconButton>
                 )}
             </Box>

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/EntryPoint.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/EntryPoint.tsx
@@ -1,3 +1,4 @@
+import Container from '@mui/material/Container';
 import * as React from 'react';
 import { ChangePassword } from './ChangePassword';
 import { ClientAppBar } from './ClientAppBar';
@@ -6,13 +7,9 @@ import { Footer } from './Footer';
 export const EntryPoint: React.FC = () => (
     <>
         <ClientAppBar />
-        <main
-            style={{
-                marginLeft: 'calc((100% - 650px)/2)',
-            }}
-        >
+        <Container maxWidth="sm" component="main">
             <ChangePassword />
             <Footer />
-        </main>
+        </Container>
     </>
 );

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/Footer.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/Footer.tsx
@@ -8,22 +8,19 @@ import osiLogo from 'url:../assets/images/osi.png';
 import passcoreLogo from 'url:../assets/images/passcore-logo.png';
 
 export const Footer: React.FC = () => (
-    <Box
-        marginTop="40px"
-        width="650px"
-    >
+    <Box marginTop="40px">
         <Box
             display="flex"
             justifyContent="space-between"
             alignItems="center"
         >
             <Box>
-                <img src={passcoreLogo.default || passcoreLogo} style={{ marginLeft: '15px', maxWidth: '125px' }} alt="PassCore Logo" />
+                <img src={passcoreLogo} style={{ marginLeft: '15px', maxWidth: '125px' }} alt="PassCore Logo" />
             </Box>
             <Box>
-                <img src={osiLogo.default || osiLogo} style={{ margin: '0 10px 0 40px', maxHeight: '30px' }} alt="OSI Logo" />
-                <img src={mitLogo.default || mitLogo} style={{ marginRight: '10px', maxHeight: '30px' }} alt="MIT Logo" />
-                <img src={uslogo.default || uslogo} style={{ maxHeight: '30px' }} alt="US Logo" />
+                <img src={osiLogo} style={{ margin: '0 10px 0 40px', maxHeight: '30px' }} alt="OSI Logo" />
+                <img src={mitLogo} style={{ marginRight: '10px', maxHeight: '30px' }} alt="MIT Logo" />
+                <img src={uslogo} style={{ maxHeight: '30px' }} alt="US Logo" />
             </Box>
         </Box>
         <Box

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/GlobalSnackbar.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/GlobalSnackbar.tsx
@@ -1,60 +1,7 @@
-import IconButton from '@mui/material/IconButton';
 import Snackbar, { SnackbarOrigin } from '@mui/material/Snackbar';
-import SnackbarContent from '@mui/material/SnackbarContent';
-import Typography from '@mui/material/Typography';
-import CheckCircle from '@mui/icons-material/CheckCircle';
-import Close from '@mui/icons-material/Close';
-import Error from '@mui/icons-material/Error';
-import Info from '@mui/icons-material/Info';
-import Warning from '@mui/icons-material/Warning';
-import makeStyles from '@mui/styles/makeStyles';
+import Alert from '@mui/material/Alert';
 import * as React from 'react';
-import { Theme } from '@mui/material/styles';
 import { SnackbarMessageType } from '../types/Components';
-
-import { amber, blue, green, red } from '@mui/material/colors';
-
-const useStyles = makeStyles(({ palette }: Theme) => ({
-    closeIcon: {
-        color: '#fff !important',
-        fontSize: '20px  !important',
-    },
-    error: {
-        backgroundColor: palette ? `${palette.error.main} !important` : `${red[600]} !important`,
-        display: 'flex !important',
-    },
-    icon: {
-        fontSize: '20px  !important',
-        marginRight: '15px  !important',
-    },
-    iconMobile: {
-        fontSize: '34px  !important',
-        marginRight: '15px  !important',
-    },
-    info: {
-        backgroundColor: palette ? `${palette.primary.main} !important` : `${blue[600]} !important`,
-        display: 'flex !important',
-    },
-    success: {
-        backgroundColor: `${green[600]} !important`,
-        display: 'flex !important',
-    },
-    text: {
-        alignItems: 'center',
-        color: '#fff !important',
-        display: 'inline-flex !important',
-        fontSize: '18px !important',
-    },
-    textMobile: {
-        color: '#fff !important',
-        display: 'inline-flex !important',
-        fontSize: '28px !important',
-    },
-    warning: {
-        backgroundColor: `${amber[700]} !important`,
-        display: 'flex !important',
-    },
-}));
 
 export interface GlobalSnackbarProps {
     message: { messageText: string; messageType: SnackbarMessageType };
@@ -62,51 +9,30 @@ export interface GlobalSnackbarProps {
     mobile: boolean;
 }
 
+const severityMap: Record<SnackbarMessageType, 'success' | 'error' | 'warning' | 'info'> = {
+    success: 'success',
+    error: 'error',
+    warning: 'warning',
+    info: 'info',
+};
+
 export const GlobalSnackbar: React.FC<GlobalSnackbarProps> = ({
     message,
     milliSeconds = 2500,
     mobile = false,
 }) => {
-    const classes = useStyles({});
     const [open, setOpen] = React.useState(false);
 
-    const getIconStyle = (): string => (mobile ? classes.iconMobile : classes.icon);
-
-    const getIcon = (): JSX.Element => {
-        switch (message.messageType) {
-            case 'info':
-                return <Info className={getIconStyle()} />;
-            case 'warning':
-                return <Warning className={getIconStyle()} />;
-            case 'error':
-                return <Error className={getIconStyle()} />;
-            default:
-                return <CheckCircle className={getIconStyle()} />;
-        }
-    };
-
-    const getStyle = (): string => {
-        switch (message.messageType) {
-            case 'info':
-                return classes.info;
-            case 'warning':
-                return classes.warning;
-            case 'error':
-                return classes.error;
-            default:
-                return classes.success;
-        }
-    };
-
-    const getTextStyle = (): string => (mobile ? classes.textMobile : classes.text);
-    const onClose = (): void => setOpen(false);
-
     React.useEffect(() => {
-        if (message && message.messageText !== '') {
+        if (message?.messageText) {
             setOpen(true);
-            setTimeout(() => setOpen(false), milliSeconds);
+            const timer = setTimeout(() => setOpen(false), milliSeconds);
+            return () => {
+                clearTimeout(timer);
+            };
         }
-    }, [message]);
+        return undefined;
+    }, [message, milliSeconds]);
 
     const anchorOrigin: SnackbarOrigin = {
         horizontal: mobile ? 'center' : 'right',
@@ -114,22 +40,15 @@ export const GlobalSnackbar: React.FC<GlobalSnackbarProps> = ({
     };
 
     return (
-        <Snackbar anchorOrigin={anchorOrigin} className={getStyle()} open={open}>
-            <SnackbarContent
-                className={getStyle()}
-                message={
-                    <Typography className={getTextStyle()}>
-                        {getIcon()} {message.messageText}
-                    </Typography>
-                }
-                action={
-                    !mobile && (
-                        <IconButton onClick={onClose} size="large">
-                            <Close className={classes.closeIcon} />
-                        </IconButton>
-                    )
-                }
-            />
+        <Snackbar anchorOrigin={anchorOrigin} open={open}>
+            <Alert
+                severity={severityMap[message.messageType]}
+                onClose={mobile ? undefined : () => setOpen(false)}
+                variant="filled"
+                sx={{ fontSize: mobile ? '1.2rem' : undefined }}
+            >
+                {message.messageText}
+            </Alert>
         </Snackbar>
     );
 };

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/LoadingIcon.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/LoadingIcon.tsx
@@ -1,8 +1,8 @@
 import CircularProgress from '@mui/material/CircularProgress';
-import styled from '@mui/styles/styled';
+import { styled } from '@mui/material/styles';
 
-export const LoadingIcon = styled(CircularProgress)(() => ({
-    display: 'block !important',
-    margin: 'auto !important',
-    marginBottom: '15px !important',
-}));
+export const LoadingIcon = styled(CircularProgress)({
+    display: 'block',
+    margin: 'auto',
+    marginBottom: '15px',
+});

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/PasswordGenerator.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/PasswordGenerator.tsx
@@ -1,3 +1,4 @@
+import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton/IconButton';
 import InputAdornment from '@mui/material/InputAdornment/InputAdornment';
 import TextField from '@mui/material/TextField/TextField';
@@ -51,9 +52,9 @@ export const PasswordGenerator: React.FC<IPasswordGenProps> = ({
     }, [sendMessage, setValue]);
 
     return isLoading ? (
-        <div style={{ paddingTop: '30px' }}>
+        <Box sx={{ paddingTop: '30px' }}>
             <LoadingIcon />
-        </div>
+        </Box>
     ) : (
         <TextField
             id="generatedPassword"
@@ -61,32 +62,34 @@ export const PasswordGenerator: React.FC<IPasswordGenProps> = ({
             label="New Password"
             value={value}
             type={visibility ? 'text' : 'password'}
-            style={{
-                height: '20px',
-                margin: '30px 0 30px 0',
+            sx={{
+                height: 20,
+                my: '30px',
             }}
-            InputProps={{
-                endAdornment: (
-                    <InputAdornment position="end">
-                        <IconButton
-                            aria-label="Toggle password visibility"
-                            onMouseDown={onMouseDownVisibility}
-                            onMouseUp={onMouseUpVisibility}
-                            tabIndex={-1}
-                            size="large"
-                        >
-                            {visibility ? <Visibility /> : <VisibilityOff />}
-                        </IconButton>
-                        <IconButton
-                            aria-label="Copy password to clipboard"
-                            onClick={copyPassword}
-                            tabIndex={-1}
-                            size="large"
-                        >
-                            <FileCopy />
-                        </IconButton>
-                    </InputAdornment>
-                ),
+            slotProps={{
+                input: {
+                    endAdornment: (
+                        <InputAdornment position="end">
+                            <IconButton
+                                aria-label="Toggle password visibility"
+                                onMouseDown={onMouseDownVisibility}
+                                onMouseUp={onMouseUpVisibility}
+                                tabIndex={-1}
+                                size="large"
+                            >
+                                {visibility ? <Visibility /> : <VisibilityOff />}
+                            </IconButton>
+                            <IconButton
+                                aria-label="Copy password to clipboard"
+                                onClick={copyPassword}
+                                tabIndex={-1}
+                                size="large"
+                            >
+                                <FileCopy />
+                            </IconButton>
+                        </InputAdornment>
+                    ),
+                },
             }}
         />
     );

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/PasswordStrengthBar.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/PasswordStrengthBar.tsx
@@ -1,57 +1,39 @@
 import LinearProgress from '@mui/material/LinearProgress';
-import makeStyles from '@mui/styles/makeStyles';
 import * as React from 'react';
 import * as zxcvbn from 'zxcvbn';
-
-const useStyles = makeStyles({
-    progressBar: {
-        color: '#000000',
-        display: 'flex',
-        flexGrow: 1,
-    },
-    progressBarColorHigh: {
-        backgroundColor: '#4caf50',
-    },
-    progressBarColorLow: {
-        backgroundColor: '#ff5722',
-    },
-    progressBarColorMedium: {
-        backgroundColor: '#ffc107',
-    },
-});
+import { strengthColors } from '../theme';
 
 const measureStrength = (password: string): number =>
     Math.min(
-        // @ts-expect-error - this is using zxcvbn, lint etc. doesn't like the import or using default
+        // @ts-expect-error - zxcvbn module type
         zxcvbn.default(password).guesses_log10 * 10,
         100,
     );
+
+const getBarColor = (strength: number): string => {
+    if (strength < 33) return strengthColors.low;
+    if (strength < 66) return strengthColors.medium;
+    return strengthColors.high;
+};
 
 interface IStrengthBarProps {
     newPassword: string;
 }
 
-export const PasswordStrengthBar: React.FC<IStrengthBarProps> = ({ newPassword }: IStrengthBarProps) => {
-    const classes = useStyles({});
-
-    const getProgressColor = (strength: number) => ({
-        barColorPrimary:
-            strength < 33
-                ? classes.progressBarColorLow
-                : strength < 66
-                  ? classes.progressBarColorMedium
-                  : classes.progressBarColorHigh,
-    });
-
-    const newStrength = measureStrength(newPassword);
-    const primeColor = getProgressColor(newStrength);
+export const PasswordStrengthBar: React.FC<IStrengthBarProps> = ({ newPassword }) => {
+    const strength = measureStrength(newPassword);
+    const barColor = getBarColor(strength);
 
     return (
         <LinearProgress
-            classes={primeColor}
             variant="determinate"
-            value={newStrength}
-            className={classes.progressBar}
+            value={strength}
+            sx={{
+                flexGrow: 1,
+                '& .MuiLinearProgress-bar': {
+                    backgroundColor: barColor,
+                },
+            }}
         />
     );
 };

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/ReCaptcha.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/ReCaptcha.tsx
@@ -1,3 +1,4 @@
+import Box from '@mui/material/Box';
 import * as React from 'react';
 import { GlobalContext } from '../Provider/GlobalContext';
 import GoogleReCaptcha from './GoogleReCaptcha';
@@ -28,12 +29,7 @@ export const ReCaptcha: React.FC<IRecaptchaProps> = ({ setToken, shouldReset }: 
     const verifyCallback = (recaptchaToken: any) => setToken(recaptchaToken);
 
     return (
-        <div
-            style={{
-                marginLeft: 'calc(100% - 440px)',
-                marginTop: '25px',
-            }}
-        >
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: '25px' }}>
             <GoogleReCaptcha
                 ref={(el: any) => {
                     captchaRef = el;
@@ -44,6 +40,6 @@ export const ReCaptcha: React.FC<IRecaptchaProps> = ({ setToken, shouldReset }: 
                 onloadCallback={onLoadRecaptcha}
                 onSuccess={verifyCallback}
             />
-        </div>
+        </Box>
     );
 };

--- a/src/Unosquare.PassCore.Web/ClientApp/Dialogs/ChangePasswordDialog.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Dialogs/ChangePasswordDialog.tsx
@@ -1,3 +1,4 @@
+import Box from '@mui/material/Box';
 import Button from '@mui/material/Button/Button';
 import Dialog from '@mui/material/Dialog/Dialog';
 import DialogContent from '@mui/material/DialogContent/DialogContent';
@@ -21,17 +22,11 @@ export const ChangePasswordDialog: React.FC<IChangePasswordDialogProps> = ({
             <DialogTitle>{successAlertTitle}</DialogTitle>
             <DialogContent>
                 <Typography variant="subtitle1">{successAlertBody}</Typography>
-                <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={onClose}
-                    style={{
-                        margin: '10px 0 0 75%',
-                        width: '25%',
-                    }}
-                >
-                    Ok
-                </Button>
+                <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 1 }}>
+                    <Button variant="contained" color="primary" onClick={onClose}>
+                        Ok
+                    </Button>
+                </Box>
             </DialogContent>
         </Dialog>
     );

--- a/src/Unosquare.PassCore.Web/ClientApp/package-lock.json
+++ b/src/Unosquare.PassCore.Web/ClientApp/package-lock.json
@@ -13,7 +13,6 @@
                 "@emotion/styled": "^11.14.1",
                 "@mui/icons-material": "^6.5.0",
                 "@mui/material": "^6.5.0",
-                "@mui/styles": "^6.5.0",
                 "package.json": "^0.0.0",
                 "react": "^19.0.0",
                 "react-dom": "^19.0.0",
@@ -920,47 +919,6 @@
                     "optional": true
                 },
                 "@emotion/styled": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@mui/styles": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@mui/styles/-/styles-6.5.0.tgz",
-            "integrity": "sha512-DeE/S/l6adnMpKfgx6l7UaQwYuf+gD4FCp6En3Vdg2Er+CTArj4DcHNFVzb8HZ2nNqACwmSm16/P08m1vAxv2w==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.26.0",
-                "@emotion/hash": "^0.9.2",
-                "@mui/private-theming": "^6.4.9",
-                "@mui/types": "~7.2.24",
-                "@mui/utils": "^6.4.9",
-                "clsx": "^2.1.1",
-                "csstype": "^3.1.3",
-                "hoist-non-react-statics": "^3.3.2",
-                "jss": "^10.10.0",
-                "jss-plugin-camel-case": "^10.10.0",
-                "jss-plugin-default-unit": "^10.10.0",
-                "jss-plugin-global": "^10.10.0",
-                "jss-plugin-nested": "^10.10.0",
-                "jss-plugin-props-sort": "^10.10.0",
-                "jss-plugin-rule-value-function": "^10.10.0",
-                "jss-plugin-vendor-prefixer": "^10.10.0",
-                "prop-types": "^15.8.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/mui-org"
-            },
-            "peerDependencies": {
-                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
                     "optional": true
                 }
             }
@@ -3981,16 +3939,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/css-vendor": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
-            "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.8.3",
-                "is-in-browser": "^1.0.2"
-            }
-        },
         "node_modules/csstype": {
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -5038,12 +4986,6 @@
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
             "license": "MIT"
         },
-        "node_modules/hyphenate-style-name": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
-            "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
-            "license": "BSD-3-Clause"
-        },
         "node_modules/ignore": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5312,12 +5254,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/is-in-browser": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
-            "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g==",
-            "license": "MIT"
         },
         "node_modules/is-map": {
             "version": "2.0.3",
@@ -5608,96 +5544,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/jss": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss/-/jss-10.10.0.tgz",
-            "integrity": "sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "csstype": "^3.0.2",
-                "is-in-browser": "^1.1.3",
-                "tiny-warning": "^1.0.2"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/jss"
-            }
-        },
-        "node_modules/jss-plugin-camel-case": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.10.0.tgz",
-            "integrity": "sha512-z+HETfj5IYgFxh1wJnUAU8jByI48ED+v0fuTuhKrPR+pRBYS2EDwbusU8aFOpCdYhtRc9zhN+PJ7iNE8pAWyPw==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "hyphenate-style-name": "^1.0.3",
-                "jss": "10.10.0"
-            }
-        },
-        "node_modules/jss-plugin-default-unit": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.10.0.tgz",
-            "integrity": "sha512-SvpajxIECi4JDUbGLefvNckmI+c2VWmP43qnEy/0eiwzRUsafg5DVSIWSzZe4d2vFX1u9nRDP46WCFV/PXVBGQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "jss": "10.10.0"
-            }
-        },
-        "node_modules/jss-plugin-global": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.10.0.tgz",
-            "integrity": "sha512-icXEYbMufiNuWfuazLeN+BNJO16Ge88OcXU5ZDC2vLqElmMybA31Wi7lZ3lf+vgufRocvPj8443irhYRgWxP+A==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "jss": "10.10.0"
-            }
-        },
-        "node_modules/jss-plugin-nested": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.10.0.tgz",
-            "integrity": "sha512-9R4JHxxGgiZhurDo3q7LdIiDEgtA1bTGzAbhSPyIOWb7ZubrjQe8acwhEQ6OEKydzpl8XHMtTnEwHXCARLYqYA==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "jss": "10.10.0",
-                "tiny-warning": "^1.0.2"
-            }
-        },
-        "node_modules/jss-plugin-props-sort": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.10.0.tgz",
-            "integrity": "sha512-5VNJvQJbnq/vRfje6uZLe/FyaOpzP/IH1LP+0fr88QamVrGJa0hpRRyAa0ea4U/3LcorJfBFVyC4yN2QC73lJg==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "jss": "10.10.0"
-            }
-        },
-        "node_modules/jss-plugin-rule-value-function": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.10.0.tgz",
-            "integrity": "sha512-uEFJFgaCtkXeIPgki8ICw3Y7VMkL9GEan6SqmT9tqpwM+/t+hxfMUdU4wQ0MtOiMNWhwnckBV0IebrKcZM9C0g==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "jss": "10.10.0",
-                "tiny-warning": "^1.0.2"
-            }
-        },
-        "node_modules/jss-plugin-vendor-prefixer": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.10.0.tgz",
-            "integrity": "sha512-UY/41WumgjW8r1qMCO8l1ARg7NHnfRVWRhZ2E2m0DMYsr2DD91qIXLyNhiX83hHswR7Wm4D+oDYNC1zWCJWtqg==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "css-vendor": "^2.0.8",
-                "jss": "10.10.0"
             }
         },
         "node_modules/jsx-ast-utils": {
@@ -7228,12 +7074,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/tiny-warning": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-            "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-            "license": "MIT"
         },
         "node_modules/tinyglobby": {
             "version": "0.2.16",

--- a/src/Unosquare.PassCore.Web/ClientApp/package.json
+++ b/src/Unosquare.PassCore.Web/ClientApp/package.json
@@ -27,7 +27,6 @@
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^6.5.0",
         "@mui/material": "^6.5.0",
-        "@mui/styles": "^6.5.0",
         "package.json": "^0.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",

--- a/src/Unosquare.PassCore.Web/ClientApp/theme.ts
+++ b/src/Unosquare.PassCore.Web/ClientApp/theme.ts
@@ -1,0 +1,32 @@
+import { createTheme, responsiveFontSizes } from '@mui/material/styles';
+
+const baseTheme = createTheme({
+    palette: {
+        error: {
+            main: '#f44336',
+        },
+        primary: {
+            main: '#304FF3',
+        },
+        secondary: {
+            main: '#ffffff',
+        },
+        text: {
+            primary: '#191919',
+            secondary: '#000000',
+        },
+    },
+    zIndex: {
+        appBar: 1201,
+    },
+});
+
+export const passcoreTheme = responsiveFontSizes(baseTheme);
+
+// Strength bar thresholds — co-located with theme so they can be updated
+// centrally if the palette ever changes.
+export const strengthColors = {
+    low: '#ff5722',
+    medium: '#ffc107',
+    high: '#4caf50',
+} as const;


### PR DESCRIPTION
I have successfully modernized the styling and theming system of the PassCore frontend. This includes:

1. **Theming**: Created `src/Unosquare.PassCore.Web/ClientApp/theme.ts` to centralize all color tokens and theme decisions. Updated `App.tsx` to use this theme and removed the legacy `StyledEngineProvider`.
2. **Component Modernization**: Rewrote `PasswordStrengthBar`, `LoadingIcon`, and `GlobalSnackbar` to remove all usage of `@mui/styles`. They now use the Emotion-based `sx` prop or `styled` utility.
3. **MUI v6 API Adoption**: Updated `PasswordGenerator` to use the modern `slotProps` API for the `TextField` component.
4. **Layout Improvements**: Replaced manual pixel calculations for centering in `EntryPoint.tsx` with MUI's `Container`. Used `Stack` for form field layout in `ChangePasswordForm`.
5. **UI Consistency**: Converted numerous inline style objects and hardcoded hex colors to `sx` props and theme-driven values across the codebase.
6. **Bug Fixes**: Addressed a potential `setTimeout` leak in `GlobalSnackbar` and fixed several TypeScript errors related to asset imports and return paths.
7. **Dependency Cleanup**: Removed `@mui/styles` from `package.json` and updated the lockfile.

The application now leverages modern MUI v6 best practices and is fully compatible with React 19.

---
*PR created automatically by Jules for task [3629481532734049376](https://jules.google.com/task/3629481532734049376) started by @ECRLib*