### PR TITLE
MUI v9 Migration and React 19 Modernization

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -27,10 +27,10 @@ jobs:
         fetch-depth: 0
         submodules: recursive
 
-    - name: Setup .NET 8.0 SDK
+    - name: Setup .NET 10.0 SDK
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '10.0.x'
 
     - name: Setup Node
       uses: actions/setup-node@v6

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -36,6 +36,10 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: 22 # Plan move to 24 if dependencies support it
+        cache: npm
+        cache-dependency-path: |
+          src/Unosquare.PassCore.Web/ClientApp/package-lock.json
+
 
     - name: Extract version and repo info
       if: startsWith(github.ref, 'refs/tags/v')

--- a/src/Unosquare.PassCore.Web/ClientApp/.eslintrc.js
+++ b/src/Unosquare.PassCore.Web/ClientApp/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
         "prettier/prettier": "error",
         "@typescript-eslint/strict-boolean-expressions": "off",
         "@typescript-eslint/ban-ts-comment": "off",
+        "react/react-in-jsx-scope": "off",
     },
     settings: {
         react: {

--- a/src/Unosquare.PassCore.Web/ClientApp/App.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/App.tsx
@@ -1,7 +1,6 @@
 import './vendor';
 
 import { ThemeProvider } from '@mui/material/styles';
-import * as React from 'react';
 import * as ReactDOMClient from 'react-dom/client';
 import { Main } from './Main';
 import { passcoreTheme } from './theme';

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/ChangePassword.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/ChangePassword.tsx
@@ -89,6 +89,7 @@ export function ChangePassword() {
                     sx={{
                         display: 'flex',
                         justifyContent: 'center',
+                        alignItems: 'center',
                         mt: recaptcha?.siteKey ? '25px' : '100px',
                     }}
                 >

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/ChangePassword.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/ChangePassword.tsx
@@ -7,6 +7,7 @@ import { fetchRequest } from '../Utils/FetchRequest';
 import { ChangePasswordForm } from './ChangePasswordForm';
 import { IChangePasswordFormInitialModel } from '../types/Components';
 import { ApiError } from '../types/Providers';
+import Box from '@mui/material/Box';
 
 export function ChangePassword() {
     const [disabled, setDisabled] = useState(true);
@@ -74,10 +75,7 @@ export function ChangePassword() {
 
     return (
         <>
-            <Paper
-                elevation={6}
-                sx={{ borderRadius: '10px', minHeight: 550, mt: '75px', zIndex: 1 }}
-            >
+            <Paper elevation={6} sx={{ borderRadius: '10px', minHeight: 550, mt: '75px', zIndex: 1 }}>
                 <ChangePasswordForm
                     submitData={submit}
                     toSubmitData={toSubmitData}
@@ -87,22 +85,26 @@ export function ChangePassword() {
                     setReCaptchaToken={setToken}
                     ReCaptchaToken={token}
                 />
-                <Button
-                    type="button"
-                    variant="contained"
-                    color="primary"
-                    disabled={disabled || isSubmitting}
+                <Box
                     sx={{
+                        display: 'flex',
+                        justifyContent: 'center',
                         mt: recaptcha?.siteKey ? '25px' : '100px',
-                        ml: '180px',
-                        width: 240,
                     }}
-                    onClick={handleSubmit}
                 >
-                    {changePasswordButtonLabel}
-                </Button>
+                    <Button
+                        type="button"
+                        variant="contained"
+                        color="primary"
+                        disabled={disabled || isSubmitting}
+                        sx={{ width: 240 }}
+                        onClick={handleSubmit}
+                    >
+                        {changePasswordButtonLabel}
+                    </Button>
+                </Box>
             </Paper>
             <ChangePasswordDialog open={dialogIsOpen} onClose={onCloseDialog} />
         </>
     );
-};
+}

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/ChangePassword.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/ChangePassword.tsx
@@ -75,7 +75,7 @@ export function ChangePassword() {
 
     return (
         <>
-            <Paper elevation={6} sx={{ borderRadius: '10px', minHeight: 550, mt: '75px', zIndex: 1 }}>
+            <Paper elevation={6} sx={{ display: 'flex', flexDirection: 'column', borderRadius: '10px', minHeight: 550, mt: '75px', zIndex: 1 }}>
                 <ChangePasswordForm
                     submitData={submit}
                     toSubmitData={toSubmitData}
@@ -88,9 +88,9 @@ export function ChangePassword() {
                 <Box
                     sx={{
                         display: 'flex',
+                        flexGrow: 1,
                         justifyContent: 'center',
                         alignItems: 'center',
-                        mt: recaptcha?.siteKey ? '25px' : '100px',
                     }}
                 >
                     <Button

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/ChangePassword.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/ChangePassword.tsx
@@ -1,6 +1,6 @@
 import Button from '@mui/material/Button';
 import Paper from '@mui/material/Paper';
-import * as React from 'react';
+import { useState, use } from 'react';
 import { ChangePasswordDialog } from '../Dialogs/ChangePasswordDialog';
 import { GlobalContext, SnackbarContext } from '../Provider/GlobalContext';
 import { fetchRequest } from '../Utils/FetchRequest';
@@ -8,17 +8,17 @@ import { ChangePasswordForm } from './ChangePasswordForm';
 import { IChangePasswordFormInitialModel } from '../types/Components';
 import { ApiError } from '../types/Providers';
 
-export const ChangePassword: React.FC = () => {
-    const [disabled, setDisabled] = React.useState(true);
-    const [submit, setSubmit] = React.useState(false);
-    const [dialogIsOpen, setDialog] = React.useState(false);
-    const [token, setToken] = React.useState('');
-    const globalContext = React.useContext(GlobalContext);
+export function ChangePassword() {
+    const [disabled, setDisabled] = useState(true);
+    const [submit, setSubmit] = useState(false);
+    const [dialogIsOpen, setDialog] = useState(false);
+    const [token, setToken] = useState('');
+    const globalContext = use(GlobalContext);
     const { alerts, changePasswordForm, recaptcha } = globalContext;
     const { changePasswordButtonLabel } = changePasswordForm;
-    const { sendMessage } = React.useContext(SnackbarContext);
-    const [shouldReset, setReset] = React.useState(false);
-    const [isSubmitting, setIsSubmitting] = React.useState(false);
+    const { sendMessage } = use(SnackbarContext);
+    const [shouldReset, setReset] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
 
     const errorMessages: Record<number, string> = {
         1: alerts.errorFieldRequired,

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/ChangePasswordForm.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/ChangePasswordForm.tsx
@@ -1,5 +1,5 @@
 import Stack from '@mui/material/Stack';
-import * as React from 'react';
+import { useState, use, useEffect, FocusEvent, ChangeEvent } from 'react';
 import TextField from '@mui/material/TextField';
 import { GlobalContext } from '../Provider/GlobalContext';
 import { IChangePasswordFormInitialModel, IChangePasswordFormProps } from '../types/Components';
@@ -19,7 +19,7 @@ const defaultState: IChangePasswordFormInitialModel = {
     username: new URLSearchParams(window.location.search).get('userName') || '',
 };
 
-export const ChangePasswordForm: React.FC<IChangePasswordFormProps> = ({
+export function ChangePasswordForm({
     submitData,
     toSubmitData,
     onValidated,
@@ -27,12 +27,12 @@ export const ChangePasswordForm: React.FC<IChangePasswordFormProps> = ({
     changeResetState,
     setReCaptchaToken,
     ReCaptchaToken,
-}) => {
-    const [fields, setFields] = React.useState<IChangePasswordFormInitialModel>(defaultState);
-    const [errors, setErrors] = React.useState<{ [key: string]: string | undefined }>({});
-    const context = React.useContext(GlobalContext);
+}: IChangePasswordFormProps) {
+    const [fields, setFields] = useState<IChangePasswordFormInitialModel>(defaultState);
+    const [errors, setErrors] = useState<{ [key: string]: string | undefined }>({});
+    const context = use(GlobalContext);
     const { changePasswordForm, usePasswordGeneration, showPasswordMeter, recaptcha } = context;
-    const [touched, setTouched] = React.useState(() =>
+    const [touched, setTouched] = useState(() =>
         Object.keys(defaultState).reduce(
             (acc, key) => ({ ...acc, [key]: false }),
             {} as Record<keyof IChangePasswordFormInitialModel, boolean>,
@@ -76,7 +76,7 @@ export const ChangePasswordForm: React.FC<IChangePasswordFormProps> = ({
         );
     };
 
-    const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    const handleBlur = (event: FocusEvent<HTMLInputElement>) => {
         const { name } = event.target;
         setTouched((prevTouched) => ({
             ...prevTouched,
@@ -84,7 +84,7 @@ export const ChangePasswordForm: React.FC<IChangePasswordFormProps> = ({
         }));
     };
 
-    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
         const { name, value } = event.target;
         setFields((prevFields) => ({
             ...prevFields,
@@ -144,7 +144,7 @@ export const ChangePasswordForm: React.FC<IChangePasswordFormProps> = ({
         return validationErrors;
     };
 
-    React.useEffect(() => {
+    useEffect(() => {
         validateAllFields().then((validationErrors) => {
             if (!Object.keys(validationErrors).length && submitData) {
                 toSubmitData(fields);
@@ -152,14 +152,14 @@ export const ChangePasswordForm: React.FC<IChangePasswordFormProps> = ({
         });
     }, [submitData, fields, toSubmitData]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         onValidated(
             Object.keys(errors).some((key) => errors[key]) ||
                 (recaptcha?.siteKey && recaptcha.siteKey !== '' && ReCaptchaToken === ''),
         );
     }, [errors, onValidated, recaptcha?.siteKey, ReCaptchaToken]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (shouldReset) {
             setFields({ ...defaultState });
             setErrors({});

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/ClientAppBar.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/ClientAppBar.tsx
@@ -1,14 +1,14 @@
-import AppBar from '@mui/material/AppBar/AppBar';
+import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
-import Tooltip from '@mui/material/Tooltip/Tooltip';
-import Typography from '@mui/material/Typography/Typography';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
 import HelpIcon from '@mui/icons-material/Help';
-import * as React from 'react';
+import { use } from 'react';
 import { GlobalContext } from '../Provider/GlobalContext';
 
-export const ClientAppBar: React.FC = () => {
-    const { changePasswordForm, changePasswordTitle } = React.useContext(GlobalContext);
+export function ClientAppBar() {
+    const { changePasswordForm, changePasswordTitle } = use(GlobalContext);
     const { helpText } = changePasswordForm;
 
     return (
@@ -18,12 +18,14 @@ export const ClientAppBar: React.FC = () => {
             sx={{ height: 64 }}
         >
             <Box
-                display="flex"
-                justifyContent="space-between"
-                alignItems="center"
-                sx={{ height: 64 }}
-                width="100%"
-                padding="0 24px"
+                sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    height: 64,
+                    width: '100%',
+                    px: 3,
+                }}
             >
                 <Typography
                     variant="h6"

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/EntryPoint.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/EntryPoint.tsx
@@ -1,15 +1,16 @@
 import Container from '@mui/material/Container';
-import * as React from 'react';
 import { ChangePassword } from './ChangePassword';
 import { ClientAppBar } from './ClientAppBar';
 import { Footer } from './Footer';
 
-export const EntryPoint: React.FC = () => (
-    <>
-        <ClientAppBar />
-        <Container maxWidth="sm" component="main">
-            <ChangePassword />
-            <Footer />
-        </Container>
-    </>
-);
+export function EntryPoint() {
+    return (
+        <>
+            <ClientAppBar />
+            <Container maxWidth="sm" component="main">
+                <ChangePassword />
+                <Footer />
+            </Container>
+        </>
+    );
+}

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/Footer.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/Footer.tsx
@@ -1,18 +1,20 @@
 import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography/Typography';
-import * as React from 'react';
+import Typography from '@mui/material/Typography';
 import { appVersion } from '../version';
 import mitLogo from 'url:../assets/images/License_icon-mit.svg.png';
 import uslogo from 'url:../assets/images/logo.png';
 import osiLogo from 'url:../assets/images/osi.png';
 import passcoreLogo from 'url:../assets/images/passcore-logo.png';
 
-export const Footer: React.FC = () => (
-    <Box marginTop="40px">
+export function Footer() {
+    return (
+    <Box sx={{ mt: '40px' }}>
         <Box
-            display="flex"
-            justifyContent="space-between"
-            alignItems="center"
+            sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+            }}
         >
             <Box>
                 <img src={passcoreLogo} style={{ marginLeft: '15px', maxWidth: '125px' }} alt="PassCore Logo" />
@@ -24,18 +26,21 @@ export const Footer: React.FC = () => (
             </Box>
         </Box>
         <Box
-            display="flex"
-            flexDirection="column"
-            alignItems="center"
-            justifyContent="space-evenly"
-            marginTop={2}
+            sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'space-evenly',
+                mt: 2,
+            }}
         >
-            <Typography align="center" variant="caption">
+            <Typography variant="caption" sx={{ textAlign: 'center' }}>
                 Powered by PassCore {appVersion} - Open Source Initiative and MIT Licensed
             </Typography>
-            <Typography align="center" variant="caption">
+            <Typography variant="caption" sx={{ textAlign: 'center' }}>
                 Copyright © 2016-{new Date().getFullYear()} Unosquare
             </Typography>
         </Box>
     </Box>
-);
+    );
+}

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/GlobalSnackbar.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/GlobalSnackbar.tsx
@@ -1,6 +1,6 @@
 import Snackbar, { SnackbarOrigin } from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { SnackbarMessageType } from '../types/Components';
 
 export interface GlobalSnackbarProps {
@@ -16,14 +16,14 @@ const severityMap: Record<SnackbarMessageType, 'success' | 'error' | 'warning' |
     info: 'info',
 };
 
-export const GlobalSnackbar: React.FC<GlobalSnackbarProps> = ({
+export function GlobalSnackbar({
     message,
     milliSeconds = 2500,
     mobile = false,
-}) => {
-    const [open, setOpen] = React.useState(false);
+}: GlobalSnackbarProps) {
+    const [open, setOpen] = useState(false);
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (message?.messageText) {
             setOpen(true);
             const timer = setTimeout(() => setOpen(false), milliSeconds);

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/PasswordGenerator.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/PasswordGenerator.tsx
@@ -1,24 +1,24 @@
 import Box from '@mui/material/Box';
-import IconButton from '@mui/material/IconButton/IconButton';
-import InputAdornment from '@mui/material/InputAdornment/InputAdornment';
-import TextField from '@mui/material/TextField/TextField';
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
+import TextField from '@mui/material/TextField';
 import FileCopy from '@mui/icons-material/FileCopy';
 import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
-import * as React from 'react';
+import { use, useState, useEffect } from 'react';
 import { LoadingIcon } from './LoadingIcon';
 import { SnackbarContext } from '../Provider/GlobalContext';
 import { IPasswordGenProps } from '../types/Components';
 import { fetchRequest } from '../Utils/FetchRequest';
 import { PasswordGenResponse } from '../types/Providers'; // Imported shared API type
 
-export const PasswordGenerator: React.FC<IPasswordGenProps> = ({
+export function PasswordGenerator({
     value,
     setValue,
-}: IPasswordGenProps) => {
-    const { sendMessage } = React.useContext(SnackbarContext);
-    const [visibility, setVisibility] = React.useState(false);
-    const [isLoading, setLoading] = React.useState(true);
+}: IPasswordGenProps) {
+    const { sendMessage } = use(SnackbarContext);
+    const [visibility, setVisibility] = useState(false);
+    const [isLoading, setLoading] = useState(true);
 
     const onMouseDownVisibility = () => setVisibility(true);
     const onMouseUpVisibility = () => setVisibility(false);
@@ -28,7 +28,7 @@ export const PasswordGenerator: React.FC<IPasswordGenProps> = ({
         sendMessage('Password copied');
     };
 
-    React.useEffect(() => {
+    useEffect(() => {
         const retrievePassword = async () => {
             try {
                 // Cast response as PasswordGenResponse which expects a payload of type string.

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/PasswordStrengthBar.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/PasswordStrengthBar.tsx
@@ -1,6 +1,5 @@
 import LinearProgress from '@mui/material/LinearProgress';
-import * as React from 'react';
-import * as zxcvbn from 'zxcvbn';
+import zxcvbn from 'zxcvbn';
 import { strengthColors } from '../theme';
 
 const measureStrength = (password: string): number =>
@@ -20,7 +19,7 @@ interface IStrengthBarProps {
     newPassword: string;
 }
 
-export const PasswordStrengthBar: React.FC<IStrengthBarProps> = ({ newPassword }) => {
+export function PasswordStrengthBar({ newPassword }: IStrengthBarProps) {
     const strength = measureStrength(newPassword);
     const barColor = getBarColor(strength);
 

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/PasswordStrengthBar.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/PasswordStrengthBar.tsx
@@ -22,46 +22,83 @@ interface PasswordStrengthBarProps {
     newPassword: string;
 }
 
+type EmptyStrength = {
+    kind: 'empty';
+    strengthPercent: 0;
+    barColor: string;
+    label: string;
+    guessesLog10: null;
+    warning: null;
+    suggestions: null;
+};
+
+type EvaluatedStrength = {
+    kind: 'evaluated';
+    strengthPercent: number;
+    barColor: string;
+    label: string;
+    guessesLog10: number;
+    warning: string | null;
+    suggestions: string[] | null;
+};
+
+type PasswordStrength = EmptyStrength | EvaluatedStrength;
+
 const STRENGTH_LABELS = ['Weak', 'Fair', 'Good', 'Strong', 'Very Strong'] as const;
 const MIN_VISIBLE_PERCENT = 5;
 
 export function PasswordStrengthBar({ newPassword }: PasswordStrengthBarProps) {
     const theme = useTheme();
 
-    const strength = useMemo(() => {
-    if (!newPassword) {
+    const strength = useMemo<PasswordStrength>(() => {
+        if (!newPassword) {
+            return {
+                kind: 'empty' as const,
+                strengthPercent: 0,
+                barColor: theme.palette.grey[500],
+                label: 'Enter password',
+                guessesLog10: null,
+                warning: null,
+                suggestions: null,
+            };
+        }
+
+        const result = zxcvbn(newPassword);
+        const score = result.score;
+
+        const barColor =
+            score <= 1
+                ? theme.palette.error.main
+                : score <= 2
+                  ? theme.palette.warning.main
+                  : score <= 4
+                    ? theme.palette.success.main
+                    : theme.palette.grey[500];
+
         return {
-        kind: 'empty' as const,
-        strengthPercent: 0,
-        barColor: theme.palette.grey[500],
-        label: 'Enter password',
-        guessesLog10: null,
+            kind: 'evaluated' as const,
+            strengthPercent: Math.max(MIN_VISIBLE_PERCENT, (score / 4) * 100),
+            barColor: barColor,
+            label: STRENGTH_LABELS[score],
+            guessesLog10: result.guessesLog10,
+            warning: result.feedback.warning || null,
+            suggestions: result.feedback.suggestions.length ? result.feedback.suggestions : null,
         };
-    }
+    }, [newPassword, theme.palette]);
 
-    const result = zxcvbn(newPassword);
-    const score = result.score;
-
-    return {
-        kind: 'evaluated' as const,
-        strengthPercent: Math.max(MIN_VISIBLE_PERCENT, (score / 4) * 100),
-        barColor: score >= 3
-        ? theme.palette.success.main
-        : score >= 1
-        ? theme.palette.warning.main
-        : theme.palette.error.main,
-        label: STRENGTH_LABELS[score],
-        guessesLog10: result.guessesLog10,
-    };
-    }, [newPassword, theme]);
-
-
-    const tooltipText = strength.kind === 'evaluated'
-        ? `Estimated attack cost: about 10^${strength.guessesLog10.toFixed(1)} guesses.\n\n` +
-          `This estimate assumes a fast offline attack using known patterns, ` +
-          `dictionary words, and common substitutions. Higher values mean a ` +
-          `stronger password.`
-        : 'Enter a password to see an estimated attack difficulty.';
+    const tooltipText =
+        strength.kind === 'evaluated'
+            ? [
+                  strength.warning,
+                  strength.suggestions?.join(' '),
+                  `Estimated attack cost: about 10^${strength.guessesLog10.toFixed(1)} guesses.`,
+                  'This estimate assumes a fast offline attack using known patterns, ' +
+                      'dictionary words, and common substitutions. Higher values mean a ' +
+                      'stronger password.',
+              ]
+                  .filter(Boolean)
+                  .join('\n\n')
+            : 'Enter a password.';
 
     return (
         <Box sx={{ width: '100%', mt: 1.5 }}>

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/PasswordStrengthBar.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/PasswordStrengthBar.tsx
@@ -27,36 +27,37 @@ const MIN_VISIBLE_PERCENT = 5;
 
 export function PasswordStrengthBar({ newPassword }: PasswordStrengthBarProps) {
     const theme = useTheme();
-    const hasPassword = newPassword.length > 0;
 
-    const result = useMemo(() => (hasPassword ? zxcvbn(newPassword) : null), [hasPassword, newPassword]);
+    const strength = useMemo(() => {
+    if (!newPassword) {
+        return {
+        kind: 'empty' as const,
+        strengthPercent: 0,
+        barColor: theme.palette.grey[500],
+        label: 'Enter password',
+        guessesLog10: null,
+        };
+    }
 
-    const score = hasPassword ? result.score : 0;
-    const strengthPercent = hasPassword ? Math.max(MIN_VISIBLE_PERCENT, (score / 4) * 100) : 0;
+    const result = zxcvbn(newPassword);
+    const score = result.score;
 
-    const computedColor = useMemo(() => {
-        switch (score) {
-            case 0:
-                return theme.palette.error.main;
-            case 1:
-            case 2:
-                return theme.palette.warning.main;
-            case 3:
-            case 4:
-                return theme.palette.success.main;
-            default:
-                return theme.palette.grey[500];
-        }
-    }, [score, theme.palette]);
+    return {
+        kind: 'evaluated' as const,
+        strengthPercent: Math.max(MIN_VISIBLE_PERCENT, (score / 4) * 100),
+        barColor: score >= 3
+        ? theme.palette.success.main
+        : score >= 1
+        ? theme.palette.warning.main
+        : theme.palette.error.main,
+        label: STRENGTH_LABELS[score],
+        guessesLog10: result.guessesLog10,
+    };
+    }, [newPassword, theme]);
 
-    const barColor = hasPassword ? computedColor : theme.palette.grey[500];
 
-    const label = hasPassword ? STRENGTH_LABELS[score] : 'Enter password';
-
-    const guessesLog10 = hasPassword ? result.guessesLog10 : 0;
-
-    const tooltipText = hasPassword
-        ? `Estimated attack cost: about 10^${guessesLog10.toFixed(1)} guesses.\n\n` +
+    const tooltipText = strength.kind === 'evaluated'
+        ? `Estimated attack cost: about 10^${strength.guessesLog10.toFixed(1)} guesses.\n\n` +
           `This estimate assumes a fast offline attack using known patterns, ` +
           `dictionary words, and common substitutions. Higher values mean a ` +
           `stronger password.`
@@ -82,31 +83,31 @@ export function PasswordStrengthBar({ newPassword }: PasswordStrengthBarProps) {
                         variant="caption"
                         fontWeight={600}
                         sx={{
-                            color: barColor,
+                            color: strength.barColor,
                             cursor: 'help',
                         }}
                         tabIndex={0}
                     >
-                        {label}
+                        {strength.label}
                     </Typography>
                 </Tooltip>
             </Box>
 
             <LinearProgress
                 variant="determinate"
-                value={strengthPercent}
+                value={strength.strengthPercent}
                 aria-label="Password strength"
                 aria-valuemin={0}
                 aria-valuemax={100}
-                aria-valuenow={Math.round(strengthPercent)}
-                aria-valuetext={label}
+                aria-valuenow={Math.round(strength.strengthPercent)}
+                aria-valuetext={strength.label}
                 sx={{
                     height: 8,
                     borderRadius: 4,
                     backgroundColor: theme.palette.mode === 'light' ? theme.palette.grey[200] : theme.palette.grey[800],
                     '& .MuiLinearProgress-bar': {
                         borderRadius: 4,
-                        backgroundColor: barColor,
+                        backgroundColor: strength.barColor,
                         transition: 'transform 0.4s cubic-bezier(0.4, 0, 0.2, 1)',
                     },
                 }}

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/PasswordStrengthBar.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/PasswordStrengthBar.tsx
@@ -1,38 +1,116 @@
-import LinearProgress from '@mui/material/LinearProgress';
-import zxcvbn from 'zxcvbn';
-import { strengthColors } from '../theme';
+import { useMemo } from 'react';
+import { Box, LinearProgress, Typography, Tooltip, useTheme } from '@mui/material';
+import { zxcvbn, zxcvbnOptions } from '@zxcvbn-ts/core';
+import { dictionary as commonDictionary, adjacencyGraphs } from '@zxcvbn-ts/language-common';
+import { dictionary as enDictionary, translations } from '@zxcvbn-ts/language-en';
 
-const measureStrength = (password: string): number =>
-    Math.min(
-        // @ts-expect-error - zxcvbn module type
-        zxcvbn.default(password).guesses_log10 * 10,
-        100,
-    );
+/**
+ * zxcvbn-ts global configuration
+ * Initialized once at module load
+ */
 
-const getBarColor = (strength: number): string => {
-    if (strength < 33) return strengthColors.low;
-    if (strength < 66) return strengthColors.medium;
-    return strengthColors.high;
-};
+zxcvbnOptions.setOptions({
+    translations,
+    graphs: adjacencyGraphs,
+    dictionary: {
+        ...commonDictionary,
+        ...enDictionary,
+    },
+});
 
-interface IStrengthBarProps {
+interface PasswordStrengthBarProps {
     newPassword: string;
 }
 
-export function PasswordStrengthBar({ newPassword }: IStrengthBarProps) {
-    const strength = measureStrength(newPassword);
-    const barColor = getBarColor(strength);
+const STRENGTH_LABELS = ['Weak', 'Fair', 'Good', 'Strong', 'Very Strong'] as const;
+const MIN_VISIBLE_PERCENT = 5;
+
+export function PasswordStrengthBar({ newPassword }: PasswordStrengthBarProps) {
+    const theme = useTheme();
+    const hasPassword = newPassword.length > 0;
+
+    const result = useMemo(() => (hasPassword ? zxcvbn(newPassword) : null), [hasPassword, newPassword]);
+
+    const score = hasPassword ? result.score : 0;
+    const strengthPercent = hasPassword ? Math.max(MIN_VISIBLE_PERCENT, (score / 4) * 100) : 0;
+
+    const computedColor = useMemo(() => {
+        switch (score) {
+            case 0:
+                return theme.palette.error.main;
+            case 1:
+            case 2:
+                return theme.palette.warning.main;
+            case 3:
+            case 4:
+                return theme.palette.success.main;
+            default:
+                return theme.palette.grey[500];
+        }
+    }, [score, theme.palette]);
+
+    const barColor = hasPassword ? computedColor : theme.palette.grey[500];
+
+    const label = hasPassword ? STRENGTH_LABELS[score] : 'Enter password';
+
+    const guessesLog10 = result.guessesLog10;
+
+    const tooltipText = hasPassword
+        ? `Estimated attack cost: about 10^${guessesLog10.toFixed(1)} guesses.\n\n` +
+          `This estimate assumes a fast offline attack using known patterns, ` +
+          `dictionary words, and common substitutions. Higher values mean a ` +
+          `stronger password.`
+        : 'Enter a password to see an estimated attack difficulty.';
 
     return (
-        <LinearProgress
-            variant="determinate"
-            value={strength}
-            sx={{
-                flexGrow: 1,
-                '& .MuiLinearProgress-bar': {
-                    backgroundColor: barColor,
-                },
-            }}
-        />
+        <Box sx={{ width: '100%', mt: 1.5 }}>
+            <Box display="flex" justifyContent="space-between" mb={0.5}>
+                <Typography variant="caption" color="text.secondary" fontWeight={600}>
+                    Password strength
+                </Typography>
+
+                <Tooltip
+                    title={
+                        <Typography variant="caption" component="div" sx={{ whiteSpace: 'pre-line' }}>
+                            {tooltipText}
+                        </Typography>
+                    }
+                    arrow
+                    placement="top"
+                >
+                    <Typography
+                        variant="caption"
+                        fontWeight={600}
+                        sx={{
+                            color: barColor,
+                            cursor: 'help',
+                        }}
+                        tabIndex={0}
+                    >
+                        {label}
+                    </Typography>
+                </Tooltip>
+            </Box>
+
+            <LinearProgress
+                variant="determinate"
+                value={strengthPercent}
+                aria-label="Password strength"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={Math.round(strengthPercent)}
+                aria-valuetext={label}
+                sx={{
+                    height: 8,
+                    borderRadius: 4,
+                    backgroundColor: theme.palette.mode === 'light' ? theme.palette.grey[200] : theme.palette.grey[800],
+                    '& .MuiLinearProgress-bar': {
+                        borderRadius: 4,
+                        backgroundColor: barColor,
+                        transition: 'transform 0.4s cubic-bezier(0.4, 0, 0.2, 1)',
+                    },
+                }}
+            />
+        </Box>
     );
-};
+}

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/PasswordStrengthBar.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/PasswordStrengthBar.tsx
@@ -53,7 +53,7 @@ export function PasswordStrengthBar({ newPassword }: PasswordStrengthBarProps) {
 
     const label = hasPassword ? STRENGTH_LABELS[score] : 'Enter password';
 
-    const guessesLog10 = result.guessesLog10;
+    const guessesLog10 = hasPassword ? result.guessesLog10 : 0;
 
     const tooltipText = hasPassword
         ? `Estimated attack cost: about 10^${guessesLog10.toFixed(1)} guesses.\n\n` +

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/PasswordStrengthBar.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/PasswordStrengthBar.tsx
@@ -102,53 +102,35 @@ export function PasswordStrengthBar({ newPassword }: PasswordStrengthBarProps) {
 
     return (
         <Box sx={{ width: '100%', mt: 1.5 }}>
-            <Box display="flex" justifyContent="space-between" mb={0.5}>
-                <Typography variant="caption" color="text.secondary" fontWeight={600}>
-                    Password strength
-                </Typography>
-
-                <Tooltip
-                    title={
-                        <Typography variant="caption" component="div" sx={{ whiteSpace: 'pre-line' }}>
-                            {tooltipText}
-                        </Typography>
-                    }
-                    arrow
-                    placement="top"
-                >
-                    <Typography
-                        variant="caption"
-                        fontWeight={600}
-                        sx={{
-                            color: strength.barColor,
-                            cursor: 'help',
-                        }}
-                        tabIndex={0}
-                    >
-                        {strength.label}
+            <Tooltip
+                title={
+                    <Typography variant="caption" component="div" sx={{ whiteSpace: 'pre-line' }}>
+                        {tooltipText}
                     </Typography>
-                </Tooltip>
-            </Box>
-
-            <LinearProgress
-                variant="determinate"
-                value={strength.strengthPercent}
-                aria-label="Password strength"
-                aria-valuemin={0}
-                aria-valuemax={100}
-                aria-valuenow={Math.round(strength.strengthPercent)}
-                aria-valuetext={strength.label}
-                sx={{
-                    height: 8,
-                    borderRadius: 4,
-                    backgroundColor: theme.palette.mode === 'light' ? theme.palette.grey[200] : theme.palette.grey[800],
-                    '& .MuiLinearProgress-bar': {
+                }
+                arrow
+                placement="top"
+            >
+                <LinearProgress
+                    variant="determinate"
+                    value={strength.strengthPercent}
+                    aria-label="Password strength"
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-valuenow={Math.round(strength.strengthPercent)}
+                    aria-valuetext={strength.label}
+                    sx={{
+                        height: 8,
                         borderRadius: 4,
-                        backgroundColor: strength.barColor,
-                        transition: 'transform 0.4s cubic-bezier(0.4, 0, 0.2, 1)',
-                    },
-                }}
-            />
+                        backgroundColor: theme.palette.mode === 'light' ? theme.palette.grey[200] : theme.palette.grey[800],
+                        '& .MuiLinearProgress-bar': {
+                            borderRadius: 4,
+                            backgroundColor: strength.barColor,
+                            transition: 'transform 0.4s cubic-bezier(0.4, 0, 0.2, 1)',
+                        },
+                    }}
+                />
+            </Tooltip>
         </Box>
     );
 }

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/ReCaptcha.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/ReCaptcha.tsx
@@ -1,5 +1,5 @@
 import Box from '@mui/material/Box';
-import * as React from 'react';
+import { use, useEffect } from 'react';
 import { GlobalContext } from '../Provider/GlobalContext';
 import GoogleReCaptcha from './GoogleReCaptcha';
 
@@ -8,13 +8,13 @@ interface IRecaptchaProps {
     shouldReset: boolean;
 }
 
-export const ReCaptcha: React.FC<IRecaptchaProps> = ({ setToken, shouldReset }: IRecaptchaProps) => {
+export function ReCaptcha({ setToken, shouldReset }: IRecaptchaProps) {
     // tslint:disable-next-line
     let captchaRef: any;
 
-    const { siteKey } = React.useContext(GlobalContext).recaptcha;
+    const { siteKey } = use(GlobalContext).recaptcha;
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (captchaRef) {
             captchaRef.reset();
         }

--- a/src/Unosquare.PassCore.Web/ClientApp/Components/SnackbarContainer.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/SnackbarContainer.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { GlobalSnackbar } from './GlobalSnackbar';
 import { Snackbar, snackbarService } from './SnackbarService';
 
-export const SnackbarContainer: React.FC = () => {
-    const [snackbar, setSnackbar] = React.useState<Snackbar>();
+export function SnackbarContainer() {
+    const [snackbar, setSnackbar] = useState<Snackbar>();
 
     const onUpdate = (): void => setSnackbar({ ...snackbarService.getSnackbar() });
 
-    React.useEffect(() => {
+    useEffect(() => {
         snackbarService.subscribe(onUpdate);
     }, []);
 

--- a/src/Unosquare.PassCore.Web/ClientApp/Dialogs/ChangePasswordDialog.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Dialogs/ChangePasswordDialog.tsx
@@ -1,10 +1,10 @@
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button/Button';
-import Dialog from '@mui/material/Dialog/Dialog';
-import DialogContent from '@mui/material/DialogContent/DialogContent';
-import DialogTitle from '@mui/material/DialogTitle/DialogTitle';
-import Typography from '@mui/material/Typography/Typography';
-import * as React from 'react';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Typography from '@mui/material/Typography';
+import { use } from 'react';
 import { GlobalContext } from '../Provider/GlobalContext';
 
 interface IChangePasswordDialogProps {
@@ -12,13 +12,20 @@ interface IChangePasswordDialogProps {
     onClose: () => void;
 }
 
-export const ChangePasswordDialog: React.FC<IChangePasswordDialogProps> = ({
+export function ChangePasswordDialog({
     open,
     onClose,
-}: IChangePasswordDialogProps) => {
-    const { successAlertBody, successAlertTitle } = React.useContext(GlobalContext).alerts;
+}: IChangePasswordDialogProps) {
+    const { successAlertBody, successAlertTitle } = use(GlobalContext).alerts;
     return (
-        <Dialog open={open} disableEscapeKeyDown>
+        <Dialog
+            open={open}
+            onClose={(_event, reason) => {
+                if (reason !== 'backdropClick' && reason !== 'escapeKeyDown') {
+                    onClose();
+                }
+            }}
+        >
             <DialogTitle>{successAlertTitle}</DialogTitle>
             <DialogContent>
                 <Typography variant="subtitle1">{successAlertBody}</Typography>

--- a/src/Unosquare.PassCore.Web/ClientApp/Main.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Main.tsx
@@ -1,6 +1,6 @@
 import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography/Typography';
-import * as React from 'react';
+import Typography from '@mui/material/Typography';
+import { useEffect } from 'react';
 import { LoadingIcon } from './Components/LoadingIcon';
 import { useEffectWithLoading } from './Components/hooks/useEffectWithLoading';
 import { EntryPoint } from './Components/EntryPoint';
@@ -10,10 +10,10 @@ import { SnackbarContextProvider } from './Provider/SnackbarContextProvider';
 import { resolveAppSettings } from './Utils/AppSettings';
 import { IGlobalContext } from './types/Providers';
 
-export const Main: React.FC = () => {
+export function Main() {
     const [settings, isLoading] = useEffectWithLoading<IGlobalContext>(resolveAppSettings, {} as IGlobalContext, []);
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (settings && typeof settings !== 'boolean' && settings.recaptcha?.siteKey) {
             if (settings.recaptcha.siteKey !== '') {
                 loadReCaptcha();
@@ -24,14 +24,15 @@ export const Main: React.FC = () => {
     if (isLoading) {
         return (
             <Box
-                display="flex"
-                flexDirection="column"
-                alignItems="center"
-                justifyContent="center"
-                // height="100vh" // Optional: Make it take up the full viewport height
+                sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                }}
             >
-                <Box key="title" marginBottom={2}> {/* Add some spacing */}
-                    <Typography variant="h3" align="center">
+                <Box key="title" sx={{ mb: 2 }}>
+                    <Typography variant="h3" sx={{ textAlign: 'center' }}>
                         Loading Passcore...
                     </Typography>
                 </Box>
@@ -62,8 +63,8 @@ export const Main: React.FC = () => {
 
     // Handle the boolean case (e.g., render an error message)
     return (
-        <Box display="flex" justifyContent="center" alignItems="center" height="100vh">
-            <Typography variant="h6" color="error">
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+            <Typography variant="h6" sx={{ color: 'error.main' }}>
                 Failed to load application settings. Be sure the settings file exists and file permissions are correct.
             </Typography>
         </Box>

--- a/src/Unosquare.PassCore.Web/ClientApp/Provider/GlobalContext.ts
+++ b/src/Unosquare.PassCore.Web/ClientApp/Provider/GlobalContext.ts
@@ -1,7 +1,7 @@
-import * as React from 'react';
+import { createContext } from 'react';
 import { IGlobalContext, ISnackbarContext } from '../types/Providers';
 
-export const GlobalContext = React.createContext<IGlobalContext>({
+export const GlobalContext = createContext<IGlobalContext>({
     alerts: null,
     applicationTitle: '',
     changePasswordForm: null,
@@ -14,6 +14,6 @@ export const GlobalContext = React.createContext<IGlobalContext>({
     usePasswordGeneration: false,
 });
 
-export const SnackbarContext = React.createContext<ISnackbarContext>({
+export const SnackbarContext = createContext<ISnackbarContext>({
     sendMessage: null,
 });

--- a/src/Unosquare.PassCore.Web/ClientApp/Provider/GlobalContextProvider.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Provider/GlobalContextProvider.tsx
@@ -1,21 +1,21 @@
-import * as React from 'react';
+import { useState, type ReactNode } from 'react';
 import { GlobalContext } from './GlobalContext';
 import { IGlobalContext } from '../types/Providers';
 
 interface IGlobalContextProviderProps {
-    children: React.ReactNode;
+    children: ReactNode;
     settings: IGlobalContext;
 }
 
-export const GlobalContextProvider: React.FC<IGlobalContextProviderProps> = ({
+export function GlobalContextProvider({
     children,
     settings,
-}: IGlobalContextProviderProps) => {
-    const [getProviderValue] = React.useState<IGlobalContext>({ ...settings });
+}: IGlobalContextProviderProps) {
+    const [getProviderValue] = useState<IGlobalContext>({ ...settings });
 
     return (
         <GlobalContext.Provider value={getProviderValue}>
             {children}
         </GlobalContext.Provider>
     );
-};
+}

--- a/src/Unosquare.PassCore.Web/ClientApp/Provider/SnackbarContextProvider.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Provider/SnackbarContextProvider.tsx
@@ -1,15 +1,15 @@
-import * as React from 'react';
+import { useState, type ReactNode } from 'react';
 import { SnackbarContainer } from '../Components/SnackbarContainer';
 import { snackbarService } from '../Components/SnackbarService';
 import { SnackbarContext } from './GlobalContext';
 import { SnackbarMessageType } from '../types/Components';
 
 interface ISnackbarProviderProps {
-    children: React.ReactNode;
+    children: ReactNode;
 }
 
-export const SnackbarContextProvider: React.FC<ISnackbarProviderProps> = ({ children }) => {
-    const [providerValue] = React.useState({
+export function SnackbarContextProvider({ children }: ISnackbarProviderProps) {
+    const [providerValue] = useState({
         sendMessage: async (messageText: string, messageType: SnackbarMessageType = 'success') => {
             return snackbarService.showSnackbar(messageText, messageType);
         },
@@ -21,4 +21,4 @@ export const SnackbarContextProvider: React.FC<ISnackbarProviderProps> = ({ chil
             <SnackbarContainer />
         </SnackbarContext.Provider>
     );
-};
+}

--- a/src/Unosquare.PassCore.Web/ClientApp/Utils/HtmlStringUtils.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Utils/HtmlStringUtils.tsx
@@ -1,5 +1,5 @@
 // HtmlStringUtils.tsx
-import * as React from 'react';
+import type { ReactNode } from 'react';
 
 /**
  * Parses a limited HTML string, extracting plain text and links.
@@ -11,14 +11,14 @@ import * as React from 'react';
  *   unintended or omitted elements (i.e., garbage in, garbage out).
  *
  * @param {string} htmlString - The HTML string to parse.
- * @returns {React.ReactNode[]} - An array of React elements representing the parsed content.
+ * @returns {ReactNode[]} - An array of React elements representing the parsed content.
  */
-export function parsePlainTextAndLinks(htmlString: string): React.ReactNode[] {
+export function parsePlainTextAndLinks(htmlString: string): ReactNode[] {
     // Split the HTML string on anchor tags.
     // The regex captures two groups: the attributes and the inner text of the <a> tag.
     const parts = htmlString.split(/<a\s+([^>]+)>(.*?)<\/a>/).filter(Boolean);
 
-    return parts.reduce<React.ReactNode[]>((elements, part, index) => {
+    return parts.reduce<ReactNode[]>((elements, part, index) => {
         // Expected parts array indices:
         // index % 3 === 0: Plain text segments.
         // index % 3 === 1: Attributes string for the <a> element.
@@ -32,7 +32,7 @@ export function parsePlainTextAndLinks(htmlString: string): React.ReactNode[] {
             const attributes = part.match(/(\w+)=(['"])(.*?)\2\s*/g) || [];
             const attributeMap: { [key: string]: string } = {};
 
-            attributes.forEach((attr) => {
+            attributes.forEach((attr: string) => {
                 const match = attr.match(/(\w+)=(['"])(.*?)\2/);
                 if (match) {
                     const [, key, , value] = match;

--- a/src/Unosquare.PassCore.Web/ClientApp/eslint.config.mjs
+++ b/src/Unosquare.PassCore.Web/ClientApp/eslint.config.mjs
@@ -9,5 +9,10 @@ export default [
   { languageOptions: { globals: { ...globals.browser, ...globals.node } } },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
-  pluginReact.configs.flat.recommended
+  pluginReact.configs.flat.recommended,
+  {
+    rules: {
+      'react/react-in-jsx-scope': 'off'
+    }
+  }
 ]

--- a/src/Unosquare.PassCore.Web/ClientApp/package-lock.json
+++ b/src/Unosquare.PassCore.Web/ClientApp/package-lock.json
@@ -11,9 +11,8 @@
             "dependencies": {
                 "@emotion/react": "^11.14.0",
                 "@emotion/styled": "^11.14.1",
-                "@mui/icons-material": "^6.5.0",
-                "@mui/material": "^6.5.0",
-                "package.json": "^0.0.0",
+                "@mui/icons-material": "^9.0.0",
+                "@mui/material": "^9.0.0",
                 "react": "^19.0.0",
                 "react-dom": "^19.0.0",
                 "zxcvbn": "^4.4.2"
@@ -778,9 +777,9 @@
             ]
         },
         "node_modules/@mui/core-downloads-tracker": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.5.0.tgz",
-            "integrity": "sha512-LGb8t8i6M2ZtS3Drn3GbTI1DVhDY6FJ9crEey2lZ0aN2EMZo8IZBZj9wRf4vqbZHaWjsYgtbOnJw5V8UWbmK2Q==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-9.0.0.tgz",
+            "integrity": "sha512-uwQNGkhv0lf7ufxw6QXev77BW6pWbW+7uxYjU5+rfp4lBkFtMEgJCsarTM3Tn+i0lGx6+Ol2u88JdGXr0GDskA==",
             "license": "MIT",
             "funding": {
                 "type": "opencollective",
@@ -788,12 +787,12 @@
             }
         },
         "node_modules/@mui/icons-material": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-6.5.0.tgz",
-            "integrity": "sha512-VPuPqXqbBPlcVSA0BmnoE4knW4/xG6Thazo8vCLWkOKusko6DtwFV6B665MMWJ9j0KFohTIf3yx2zYtYacvG1g==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-9.0.0.tgz",
+            "integrity": "sha512-oDwyvI6LgjWRC9MBcSGvLkPud9S9ELgSBQFYxa1rYcZn6Br55dn22SyvsPDMsn0G8OndFk53iMT45W5mNqrogw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.26.0"
+                "@babel/runtime": "^7.29.2"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -803,7 +802,7 @@
                 "url": "https://opencollective.com/mui-org"
             },
             "peerDependencies": {
-                "@mui/material": "^6.5.0",
+                "@mui/material": "^9.0.0",
                 "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
                 "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
             },
@@ -814,22 +813,22 @@
             }
         },
         "node_modules/@mui/material": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.5.0.tgz",
-            "integrity": "sha512-yjvtXoFcrPLGtgKRxFaH6OQPtcLPhkloC0BML6rBG5UeldR0nPULR/2E2BfXdo5JNV7j7lOzrrLX2Qf/iSidow==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.0.0.tgz",
+            "integrity": "sha512-+VP/oQCDhDR87NQQgXnNBG8dwy6GNuQLnenS1pZvkbn2dKFSxRSRMybTpH9xUxXP+316mlYDy5CSbYtusnCWtw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.26.0",
-                "@mui/core-downloads-tracker": "^6.5.0",
-                "@mui/system": "^6.5.0",
-                "@mui/types": "~7.2.24",
-                "@mui/utils": "^6.4.9",
+                "@babel/runtime": "^7.29.2",
+                "@mui/core-downloads-tracker": "^9.0.0",
+                "@mui/system": "^9.0.0",
+                "@mui/types": "^9.0.0",
+                "@mui/utils": "^9.0.0",
                 "@popperjs/core": "^2.11.8",
                 "@types/react-transition-group": "^4.4.12",
                 "clsx": "^2.1.1",
-                "csstype": "^3.1.3",
+                "csstype": "^3.2.3",
                 "prop-types": "^15.8.1",
-                "react-is": "^19.0.0",
+                "react-is": "^19.2.4",
                 "react-transition-group": "^4.4.5"
             },
             "engines": {
@@ -842,7 +841,7 @@
             "peerDependencies": {
                 "@emotion/react": "^11.5.0",
                 "@emotion/styled": "^11.3.0",
-                "@mui/material-pigment-css": "^6.5.0",
+                "@mui/material-pigment-css": "^9.0.0",
                 "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
                 "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
                 "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -863,13 +862,13 @@
             }
         },
         "node_modules/@mui/private-theming": {
-            "version": "6.4.9",
-            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.4.9.tgz",
-            "integrity": "sha512-LktcVmI5X17/Q5SkwjCcdOLBzt1hXuc14jYa7NPShog0GBDCDvKtcnP0V7a2s6EiVRlv7BzbWEJzH6+l/zaCxw==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-9.0.0.tgz",
+            "integrity": "sha512-JtuZoaiCqwD6vjgYu6Xp3T7DZkrxJlgtDz5yESzhI34fEX5hHMh2VJUbuL9UOg8xrfIFMrq6dcYoH/7Zi4G0RA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.26.0",
-                "@mui/utils": "^6.4.9",
+                "@babel/runtime": "^7.29.2",
+                "@mui/utils": "^9.0.0",
                 "prop-types": "^15.8.1"
             },
             "engines": {
@@ -890,16 +889,16 @@
             }
         },
         "node_modules/@mui/styled-engine": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.5.0.tgz",
-            "integrity": "sha512-8woC2zAqF4qUDSPIBZ8v3sakj+WgweolpyM/FXf8jAx6FMls+IE4Y8VDZc+zS805J7PRz31vz73n2SovKGaYgw==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-9.0.0.tgz",
+            "integrity": "sha512-9RLGdX4Jg0aQPRuvqh/OLzYSPlgd5zyEw5/1HIRfdavSiOd03WtUaGZH9/w1RoTYuRKwpgy0hpIFaMHIqPVIWg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.26.0",
-                "@emotion/cache": "^11.13.5",
+                "@babel/runtime": "^7.29.2",
+                "@emotion/cache": "^11.14.0",
                 "@emotion/serialize": "^1.3.3",
                 "@emotion/sheet": "^1.4.0",
-                "csstype": "^3.1.3",
+                "csstype": "^3.2.3",
                 "prop-types": "^15.8.1"
             },
             "engines": {
@@ -924,18 +923,18 @@
             }
         },
         "node_modules/@mui/system": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.5.0.tgz",
-            "integrity": "sha512-XcbBYxDS+h/lgsoGe78ExXFZXtuIlSBpn/KsZq8PtZcIkUNJInkuDqcLd2rVBQrDC1u+rvVovdaWPf2FHKJf3w==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.0.0.tgz",
+            "integrity": "sha512-YnC5Zg6j04IxiLc/boAKs0464jfZlLFVa7mf5E8lF0XOtZVUvG6R6gJK50lgUYdaaLdyLfxF6xR7LaPuEpeT/g==",
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.26.0",
-                "@mui/private-theming": "^6.4.9",
-                "@mui/styled-engine": "^6.5.0",
-                "@mui/types": "~7.2.24",
-                "@mui/utils": "^6.4.9",
+                "@babel/runtime": "^7.29.2",
+                "@mui/private-theming": "^9.0.0",
+                "@mui/styled-engine": "^9.0.0",
+                "@mui/types": "^9.0.0",
+                "@mui/utils": "^9.0.0",
                 "clsx": "^2.1.1",
-                "csstype": "^3.1.3",
+                "csstype": "^3.2.3",
                 "prop-types": "^15.8.1"
             },
             "engines": {
@@ -964,10 +963,13 @@
             }
         },
         "node_modules/@mui/types": {
-            "version": "7.2.24",
-            "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
-            "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.0.0.tgz",
+            "integrity": "sha512-i1cuFCAWN44b3AJWO7mh7tuh1sqbQSeVr/94oG0TX5uXivac8XalgE4/6fQZcmGZigzbQ35IXxj/4jLpRIBYZg==",
             "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.29.2"
+            },
             "peerDependencies": {
                 "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
             },
@@ -978,17 +980,17 @@
             }
         },
         "node_modules/@mui/utils": {
-            "version": "6.4.9",
-            "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.9.tgz",
-            "integrity": "sha512-Y12Q9hbK9g+ZY0T3Rxrx9m2m10gaphDuUMgWxyV5kNJevVxXYCLclYUCC9vXaIk1/NdNDTcW2Yfr2OGvNFNmHg==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.0.0.tgz",
+            "integrity": "sha512-bQcqyg/gjULUqTuyUjSAFr6LQGLvtkNtDbJerAtoUn9kGZ0hg5QJiN1PLHMLbeFpe3te1831uq7GFl2ITokGdg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.26.0",
-                "@mui/types": "~7.2.24",
-                "@types/prop-types": "^15.7.14",
+                "@babel/runtime": "^7.29.2",
+                "@mui/types": "^9.0.0",
+                "@types/prop-types": "^15.7.15",
                 "clsx": "^2.1.1",
                 "prop-types": "^15.8.1",
-                "react-is": "^19.0.0"
+                "react-is": "^19.2.4"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -6293,13 +6295,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/package.json": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/package.json/-/package.json-0.0.0.tgz",
-            "integrity": "sha512-4IJoBrMPxhC4cWwViXg7omAK6E/QD3F/DfmD1g20EI4AcV6V/KG5NqqLC2xjCclY1N5V7D+j6rJxi4mXyxIsMg==",
-            "deprecated": "Use pkg.json instead.",
-            "license": "BSD"
         },
         "node_modules/parcel": {
             "version": "2.16.4",

--- a/src/Unosquare.PassCore.Web/ClientApp/package-lock.json
+++ b/src/Unosquare.PassCore.Web/ClientApp/package-lock.json
@@ -13,9 +13,11 @@
                 "@emotion/styled": "^11.14.1",
                 "@mui/icons-material": "^9.0.0",
                 "@mui/material": "^9.0.0",
+                "@zxcvbn-ts/core": "^3.0.4",
+                "@zxcvbn-ts/language-common": "^3.0.4",
+                "@zxcvbn-ts/language-en": "^3.0.2",
                 "react": "^19.0.0",
-                "react-dom": "^19.0.0",
-                "zxcvbn": "^4.4.2"
+                "react-dom": "^19.0.0"
             },
             "devDependencies": {
                 "@eslint/js": "^9.39.4",
@@ -593,76 +595,6 @@
                 "@lezer/common": "^1.0.0"
             }
         },
-        "node_modules/@lmdb/lmdb-darwin-arm64": {
-            "version": "2.8.5",
-            "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.8.5.tgz",
-            "integrity": "sha512-KPDeVScZgA1oq0CiPBcOa3kHIqU+pTOwRFDIhxvmf8CTNvqdZQYp5cCKW0bUk69VygB2PuTiINFWbY78aR2pQw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ]
-        },
-        "node_modules/@lmdb/lmdb-darwin-x64": {
-            "version": "2.8.5",
-            "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.8.5.tgz",
-            "integrity": "sha512-w/sLhN4T7MW1nB3R/U8WK5BgQLz904wh+/SmA2jD8NnF7BLLoUgflCNxOeSPOWp8geP6nP/+VjWzZVip7rZ1ug==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ]
-        },
-        "node_modules/@lmdb/lmdb-linux-arm": {
-            "version": "2.8.5",
-            "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.8.5.tgz",
-            "integrity": "sha512-c0TGMbm2M55pwTDIfkDLB6BpIsgxV4PjYck2HiOX+cy/JWiBXz32lYbarPqejKs9Flm7YVAKSILUducU9g2RVg==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@lmdb/lmdb-linux-arm64": {
-            "version": "2.8.5",
-            "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.8.5.tgz",
-            "integrity": "sha512-vtbZRHH5UDlL01TT5jB576Zox3+hdyogvpcbvVJlmU5PdL3c5V7cj1EODdh1CHPksRl+cws/58ugEHi8bcj4Ww==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@lmdb/lmdb-linux-x64": {
-            "version": "2.8.5",
-            "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.8.5.tgz",
-            "integrity": "sha512-Xkc8IUx9aEhP0zvgeKy7IQ3ReX2N8N1L0WPcQwnZweWmOuKfwpS3GRIYqLtK5za/w3E60zhFfNdS+3pBZPytqQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
         "node_modules/@lmdb/lmdb-win32-x64": {
             "version": "2.8.5",
             "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.8.5.tgz",
@@ -691,76 +623,6 @@
             "engines": {
                 "node": ">=12.0.0"
             }
-        },
-        "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
-            "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ]
-        },
-        "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
-            "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ]
-        },
-        "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
-            "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
-            "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
-            "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
         },
         "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
             "version": "3.0.3",
@@ -1914,153 +1776,6 @@
                 }
             }
         },
-        "node_modules/@parcel/rust-darwin-arm64": {
-            "version": "2.16.4",
-            "resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.4.tgz",
-            "integrity": "sha512-P3Se36H9EO1fOlwXqQNQ+RsVKTGn5ztRSUGbLcT8ba6oOMmU1w7J4R810GgsCbwCuF10TJNUMkuD3Q2Sz15Q3Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 10"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/rust-darwin-x64": {
-            "version": "2.16.4",
-            "resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.4.tgz",
-            "integrity": "sha512-8aNKNyPIx3EthYpmVJevIdHmFsOApXAEYGi3HU69jTxLgSIfyEHDdGE9lEsMvhSrd/SSo4/euAtiV+pqK04wnA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 10"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/rust-linux-arm-gnueabihf": {
-            "version": "2.16.4",
-            "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.4.tgz",
-            "integrity": "sha512-QrvqiSHaWRLc0JBHgUHVvDthfWSkA6AFN+ikV1UGENv4j2r/QgvuwJiG0VHrsL6pH5dRqj0vvngHzEgguke9DA==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/rust-linux-arm64-gnu": {
-            "version": "2.16.4",
-            "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.4.tgz",
-            "integrity": "sha512-f3gBWQHLHRUajNZi3SMmDQiEx54RoRbXtZYQNuBQy7+NolfFcgb1ik3QhkT7xovuTF/LBmaqP3UFy0PxvR/iwQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/rust-linux-arm64-musl": {
-            "version": "2.16.4",
-            "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.4.tgz",
-            "integrity": "sha512-cwml18RNKsBwHyZnrZg4jpecXkWjaY/mCArocWUxkFXjjB97L56QWQM9W86f2/Y3HcFcnIGJwx1SDDKJrV6OIA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/rust-linux-x64-gnu": {
-            "version": "2.16.4",
-            "resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.4.tgz",
-            "integrity": "sha512-0xIjQaN8hiG0F9R8coPYidHslDIrbfOS/qFy5GJNbGA3S49h61wZRBMQqa7JFW4+2T8R0J9j0SKHhLXpbLXrIg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/rust-linux-x64-musl": {
-            "version": "2.16.4",
-            "resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.4.tgz",
-            "integrity": "sha512-fYn21GIecHK9RoZPKwT9NOwxwl3Gy3RYPR6zvsUi0+hpFo19Ph9EzFXN3lT8Pi5KiwQMCU4rsLb5HoWOBM1FeA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
         "node_modules/@parcel/rust-win32-x64-msvc": {
             "version": "2.16.4",
             "resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.4.tgz",
@@ -2478,258 +2193,6 @@
                 "@parcel/watcher-win32-x64": "2.5.6"
             }
         },
-        "node_modules/@parcel/watcher-android-arm64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
-            "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-darwin-arm64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
-            "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-darwin-x64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
-            "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-freebsd-x64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
-            "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-linux-arm-glibc": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
-            "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-linux-arm-musl": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
-            "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-linux-arm64-glibc": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
-            "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-linux-arm64-musl": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
-            "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-linux-x64-glibc": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
-            "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-linux-x64-musl": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
-            "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-win32-arm64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
-            "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-win32-ia32": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
-            "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
         "node_modules/@parcel/watcher-win32-x64": {
             "version": "2.5.6",
             "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
@@ -2835,193 +2298,6 @@
                 "@swc/helpers": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@swc/core-darwin-arm64": {
-            "version": "1.15.30",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.30.tgz",
-            "integrity": "sha512-VvpP+vq08HmGYewMWvrdsxh9s2lthz/808zXm8Yu5kaqeR8Yia2b0eYXleHQ3VAjoStUDk6LzTheBW9KXYQdMA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@swc/core-darwin-x64": {
-            "version": "1.15.30",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.30.tgz",
-            "integrity": "sha512-WiJA0hiZI3nwQAO6mu5RqigtWGDtth4Hiq6rbZxAaQyhIcqKIg5IoMRc1Y071lrNJn29eEDMC86Rq58xgUxlDg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@swc/core-linux-arm-gnueabihf": {
-            "version": "1.15.30",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.30.tgz",
-            "integrity": "sha512-YANuFUo48kIT6plJgCD0keae9HFXfjxsbvsgevqc0hr/07X/p7sAWTFOGYEc2SXcASaK7UvuQqzlbW8pr7R79g==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@swc/core-linux-arm64-gnu": {
-            "version": "1.15.30",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.30.tgz",
-            "integrity": "sha512-VndG8jaR4ugY6u+iVOT0Q+d2fZd7sLgjPgN8W/Le+3EbZKl+cRfFxV7Eoz4gfLqhmneZPdcIzf9T3LkgkmqNLg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@swc/core-linux-arm64-musl": {
-            "version": "1.15.30",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.30.tgz",
-            "integrity": "sha512-1SYGs2l0Yyyi0pR/P/NKz/x0kqxkoiw+BXeJjLUdecSk/KasncWlJrc6hOvFSgKHOBrzgM5jwuluKtlT8dnrcA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@swc/core-linux-ppc64-gnu": {
-            "version": "1.15.30",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.30.tgz",
-            "integrity": "sha512-TXREtiXeRhbfDFbmhnkIsXpKfzbfT73YkV2ZF6w0sfxgjC5zI2ZAbaCOq25qxvegofj2K93DtOpm9RLaBgqR2g==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@swc/core-linux-s390x-gnu": {
-            "version": "1.15.30",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.30.tgz",
-            "integrity": "sha512-DCR2YYeyd6DQE4OuDhImouuNcjXEiEdnn1Y0DyGteugPEDvVuvYk8Xddi+4o2SgWH6jiW8/I+3emZvbep1NC+g==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@swc/core-linux-x64-gnu": {
-            "version": "1.15.30",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.30.tgz",
-            "integrity": "sha512-5Pizw3NgfOJ5BJOBK8TIRa59xFW2avESTOBDPTAYwZYa1JNDs+KMF9lUfjJiJLM5HiMs/wPheA9eiT0q9m2AoA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@swc/core-linux-x64-musl": {
-            "version": "1.15.30",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.30.tgz",
-            "integrity": "sha512-qyqydP/wyH8alcIP4a2hnGSjHLJjm9H7yDFup+CPy9oTahFgLLwnNcv5UHXqO2Qs3AIND+cls5f/Bb6hqpxdgA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@swc/core-win32-arm64-msvc": {
-            "version": "1.15.30",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.30.tgz",
-            "integrity": "sha512-CaQENgDHVGOg1mSF5sQVgvfFHG9kjMor2rkLMLeLOkfZYNj13ppnJ9+lfaBZLZUMMbnlGQnavCJb8PVBUOso7Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@swc/core-win32-ia32-msvc": {
-            "version": "1.15.30",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.30.tgz",
-            "integrity": "sha512-30VdLeGk6fugiUs/kUdJ/pAg7z/zpvVbR11RH60jZ0Z42WIeIniYx0rLEWN7h/pKJ3CopqsQ3RsogCAkRKiA2g==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/@swc/core-win32-x64-msvc": {
@@ -3130,17 +2406,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.58.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
-            "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
+            "version": "8.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
+            "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.58.2",
-                "@typescript-eslint/type-utils": "8.58.2",
-                "@typescript-eslint/utils": "8.58.2",
-                "@typescript-eslint/visitor-keys": "8.58.2",
+                "@typescript-eslint/scope-manager": "8.59.0",
+                "@typescript-eslint/type-utils": "8.59.0",
+                "@typescript-eslint/utils": "8.59.0",
+                "@typescript-eslint/visitor-keys": "8.59.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -3153,7 +2429,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.58.2",
+                "@typescript-eslint/parser": "^8.59.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
@@ -3169,16 +2445,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.58.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
-            "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
+            "version": "8.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
+            "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.58.2",
-                "@typescript-eslint/types": "8.58.2",
-                "@typescript-eslint/typescript-estree": "8.58.2",
-                "@typescript-eslint/visitor-keys": "8.58.2",
+                "@typescript-eslint/scope-manager": "8.59.0",
+                "@typescript-eslint/types": "8.59.0",
+                "@typescript-eslint/typescript-estree": "8.59.0",
+                "@typescript-eslint/visitor-keys": "8.59.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -3194,14 +2470,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.58.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
-            "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+            "version": "8.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
+            "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.58.2",
-                "@typescript-eslint/types": "^8.58.2",
+                "@typescript-eslint/tsconfig-utils": "^8.59.0",
+                "@typescript-eslint/types": "^8.59.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -3216,14 +2492,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.58.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
-            "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+            "version": "8.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
+            "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.58.2",
-                "@typescript-eslint/visitor-keys": "8.58.2"
+                "@typescript-eslint/types": "8.59.0",
+                "@typescript-eslint/visitor-keys": "8.59.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3234,9 +2510,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.58.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
-            "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+            "version": "8.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
+            "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3251,15 +2527,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.58.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
-            "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
+            "version": "8.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
+            "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.58.2",
-                "@typescript-eslint/typescript-estree": "8.58.2",
-                "@typescript-eslint/utils": "8.58.2",
+                "@typescript-eslint/types": "8.59.0",
+                "@typescript-eslint/typescript-estree": "8.59.0",
+                "@typescript-eslint/utils": "8.59.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -3276,9 +2552,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.58.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
-            "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+            "version": "8.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
+            "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3290,16 +2566,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.58.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
-            "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+            "version": "8.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
+            "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.58.2",
-                "@typescript-eslint/tsconfig-utils": "8.58.2",
-                "@typescript-eslint/types": "8.58.2",
-                "@typescript-eslint/visitor-keys": "8.58.2",
+                "@typescript-eslint/project-service": "8.59.0",
+                "@typescript-eslint/tsconfig-utils": "8.59.0",
+                "@typescript-eslint/types": "8.59.0",
+                "@typescript-eslint/visitor-keys": "8.59.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -3370,16 +2646,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.58.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
-            "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+            "version": "8.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
+            "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.58.2",
-                "@typescript-eslint/types": "8.58.2",
-                "@typescript-eslint/typescript-estree": "8.58.2"
+                "@typescript-eslint/scope-manager": "8.59.0",
+                "@typescript-eslint/types": "8.59.0",
+                "@typescript-eslint/typescript-estree": "8.59.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3394,13 +2670,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.58.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
-            "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+            "version": "8.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
+            "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/types": "8.59.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -3423,6 +2699,27 @@
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
+        },
+        "node_modules/@zxcvbn-ts/core": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@zxcvbn-ts/core/-/core-3.0.4.tgz",
+            "integrity": "sha512-aQeiT0F09FuJaAqNrxynlAwZ2mW/1MdXakKWNmGM1Qp/VaY6CnB/GfnMS2T8gB2231Esp1/maCWd8vTG4OuShw==",
+            "license": "MIT",
+            "dependencies": {
+                "fastest-levenshtein": "1.0.16"
+            }
+        },
+        "node_modules/@zxcvbn-ts/language-common": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@zxcvbn-ts/language-common/-/language-common-3.0.4.tgz",
+            "integrity": "sha512-viSNNnRYtc7ULXzxrQIVUNwHAPSXRtoIwy/Tq4XQQdIknBzw4vz36lQLF6mvhMlTIlpjoN/Z1GFu/fwiAlUSsw==",
+            "license": "MIT"
+        },
+        "node_modules/@zxcvbn-ts/language-en": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@zxcvbn-ts/language-en/-/language-en-3.0.2.tgz",
+            "integrity": "sha512-Zp+zL+I6Un2Bj0tRXNs6VUBq3Djt+hwTwUz4dkt2qgsQz47U0/XthZ4ULrT/RxjwJRl5LwiaKOOZeOtmixHnjg==",
+            "license": "MIT"
         },
         "node_modules/acorn": {
             "version": "8.16.0",
@@ -4142,9 +3439,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.340",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
-            "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
+            "version": "1.5.341",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.341.tgz",
+            "integrity": "sha512-1sZTssferjgDgaqRTc0ieP+ozzpOy7LQTPTtEW3yQFn4+ORdIAZWV5BthXPyHF7YqLvFJCUPhNhdAJQYlYUgiw==",
             "dev": true,
             "license": "ISC"
         },
@@ -4586,6 +3883,15 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/fastest-levenshtein": {
+            "version": "1.0.16",
+            "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+            "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4.9.1"
+            }
         },
         "node_modules/fdir": {
             "version": "6.5.0",
@@ -5616,216 +4922,6 @@
                 "lightningcss-linux-x64-musl": "1.32.0",
                 "lightningcss-win32-arm64-msvc": "1.32.0",
                 "lightningcss-win32-x64-msvc": "1.32.0"
-            }
-        },
-        "node_modules/lightningcss-android-arm64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-darwin-arm64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-darwin-x64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-freebsd-x64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-arm-gnueabihf": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-arm64-gnu": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-arm64-musl": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-x64-gnu": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-x64-musl": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-win32-arm64-msvc": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
             }
         },
         "node_modules/lightningcss-win32-x64-msvc": {
@@ -7226,16 +6322,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.58.2",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
-            "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
+            "version": "8.59.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.0.tgz",
+            "integrity": "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.58.2",
-                "@typescript-eslint/parser": "8.58.2",
-                "@typescript-eslint/typescript-estree": "8.58.2",
-                "@typescript-eslint/utils": "8.58.2"
+                "@typescript-eslint/eslint-plugin": "8.59.0",
+                "@typescript-eslint/parser": "8.59.0",
+                "@typescript-eslint/typescript-estree": "8.59.0",
+                "@typescript-eslint/utils": "8.59.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7469,12 +6565,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/zxcvbn": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/zxcvbn/-/zxcvbn-4.4.2.tgz",
-            "integrity": "sha512-Bq0B+ixT/DMyG8kgX2xWcI5jUvCwqrMxSFam7m0lAf78nf04hv6lNCsyLYdyYTrCVMqNDY/206K7eExYCeSyUQ==",
-            "license": "MIT"
         }
     }
 }

--- a/src/Unosquare.PassCore.Web/ClientApp/package.json
+++ b/src/Unosquare.PassCore.Web/ClientApp/package.json
@@ -25,9 +25,8 @@
     "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@mui/icons-material": "^6.5.0",
-        "@mui/material": "^6.5.0",
-        "package.json": "^0.0.0",
+        "@mui/icons-material": "^9.0.0",
+        "@mui/material": "^9.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "zxcvbn": "^4.4.2"

--- a/src/Unosquare.PassCore.Web/ClientApp/package.json
+++ b/src/Unosquare.PassCore.Web/ClientApp/package.json
@@ -27,9 +27,11 @@
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
+        "@zxcvbn-ts/core": "^3.0.4",
+        "@zxcvbn-ts/language-common": "^3.0.4",
+        "@zxcvbn-ts/language-en": "^3.0.2",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0",
-        "zxcvbn": "^4.4.2"
+        "react-dom": "^19.0.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.39.4",

--- a/src/Unosquare.PassCore.Web/ClientApp/tsconfig.json
+++ b/src/Unosquare.PassCore.Web/ClientApp/tsconfig.json
@@ -4,7 +4,7 @@
         "noImplicitAny": true,
         "module": "esnext",
         "target": "es5",
-        "jsx": "react",
+        "jsx": "react-jsx",
         "lib": ["esnext", "dom"],
         "moduleResolution": "node",
         "strictNullChecks": false,
@@ -12,7 +12,9 @@
         "forceConsistentCasingInFileNames": true,
         "noEmit": true,
         "noUnusedLocals": true,
-        "typeRoots": ["./node_modules/@types"]
+        "typeRoots": ["./node_modules/@types"],
+        "skipLibCheck": true,
+        "esModuleInterop": true
     },
     "include": ["./**/*"],
     "exclude": ["node_modules", "build", "scripts", "acceptance-tests", "webpack"],

--- a/src/Unosquare.PassCore.Web/ClientApp/vendor.ts
+++ b/src/Unosquare.PassCore.Web/ClientApp/vendor.ts
@@ -1,3 +1,2 @@
 import('react');
 import('react-dom');
-import('zxcvbn');

--- a/src/Unosquare.PassCore.Web/Unosquare.PassCore.Web.csproj
+++ b/src/Unosquare.PassCore.Web/Unosquare.PassCore.Web.csproj
@@ -49,17 +49,24 @@
 		<DefineConstants>PASSCORE_LDAP_PROVIDER</DefineConstants>
 	</PropertyGroup>
 
-	<Target Name="NpmInstall" BeforeTargets="Build" Condition="!Exists('ClientApp/node_modules')">
-		<Message Importance="high" Text="Performing first-run npm install..." />
+	<Target Name="NpmInstall" BeforeTargets="Build">
+		<Message Importance="high" Text="Performing first-run npm clean install..." />
 		<!-- Fail fast if Node.js is not available -->
 		<Exec Command="node --version" ContinueOnError="true">
 			<Output TaskParameter="ExitCode" PropertyName="NodeExitCode" />
 		</Exec>
 		<Error Condition="'$(NodeExitCode)' != '0'" Text="Node.js is required to build and run this project. Please install Node.js from https://nodejs.org/ and restart your shell or IDE." />
+		<Exec Command="npm --version" ContinueOnError="true">
+			<Output TaskParameter="ExitCode" PropertyName="NpmVersionExitCode" />
+		</Exec>
+		<Error Condition="'$(NpmVersionExitCode)' != '0'" Text="npm is required but was not found. Ensure Node.js is installed correctly." />
 		<!-- Install frontend dependencies: not allowed to continue if install fails -->
-		<Exec Command="npm install" WorkingDirectory="ClientApp" />
+		<Exec Command="npm ci" WorkingDirectory="ClientApp">
+			<Output TaskParameter="ExitCode" PropertyName="NpmExitCode" />
+		</Exec>
+		<Error Condition="'$(NpmExitCode)' != '0'" Text="Installation failed! npm ci encountered an error (exit code $(NpmExitCode))." />
 		<!-- Security audit: allowed to fail without breaking the build -->
-		<Exec Command="npm audit --fix" WorkingDirectory="ClientApp" ContinueOnError="true" />
+		<Exec Command="npm audit" WorkingDirectory="ClientApp" ContinueOnError="true" />
 		<!-- Optional version metadata generation -->
 		<Exec Command="node version-script.mjs" WorkingDirectory="ClientApp" ContinueOnError="true" />
 	</Target>


### PR DESCRIPTION
This PR migrates the frontend to MUI v9 and modernizes the codebase to follow React 19 idioms.

Key changes:
- Corrected all deep MUI imports (e.g., @mui/material/AppBar/AppBar -> @mui/material/AppBar).
- Moved shorthand system props on Box (display, justifyContent, etc.) into the sx prop as required by MUI v9.
- Replaced the deprecated 'align' prop on Typography with 'sx={{ textAlign: "..." }}'.
- Updated MUI packages and cleaned up package.json.
- Refactored all components to use named function declarations instead of React.FC arrow functions.
- Replaced useContext with the React 19 use hook.
- Configured the project to use the automatic JSX runtime, removing the need for 'import React' in every file.
- Enabled 'skipLibCheck' and 'esModuleInterop' in tsconfig.json to resolve type issues with MUI v9.

---
*PR created automatically by Jules for task [7601402473392190576](https://jules.google.com/task/7601402473392190576) started by @ECRLib*