### PR TITLE
Refactor PassCore Password Provider System

### DIFF
--- a/src/Unosquare.PassCore.Common/ApiErrorMapper.cs
+++ b/src/Unosquare.PassCore.Common/ApiErrorMapper.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Unosquare.PassCore.Common;
+
+/// <summary>
+/// Helper class to map exceptions to ApiErrorItem.
+/// </summary>
+public static class ApiErrorMapper
+{
+    /// <summary>
+    /// Maps an exception to an ApiErrorItem.
+    /// </summary>
+    /// <param name="ex">The exception.</param>
+    /// <returns>The mapped ApiErrorItem.</returns>
+    public static ApiErrorItem Map(Exception ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        return ex switch
+        {
+            InvalidCredentialsException => new ApiErrorItem(ApiErrorCode.InvalidCredentials, ex.Message),
+            PasswordPolicyViolationException policyEx => new ApiErrorItem(policyEx.ErrorCode, ex.Message),
+            UserNotFoundException => new ApiErrorItem(ApiErrorCode.UserNotFound, ex.Message),
+            DirectoryUnavailableException => new ApiErrorItem(ApiErrorCode.LdapProblem, ex.Message),
+            ApiErrorException apiEx => apiEx.ToApiErrorItem(),
+            _ => new ApiErrorItem(ApiErrorCode.Generic, ex.InnerException?.Message ?? ex.Message)
+        };
+    }
+}

--- a/src/Unosquare.PassCore.Common/ChangePasswordForm.cs
+++ b/src/Unosquare.PassCore.Common/ChangePasswordForm.cs
@@ -1,4 +1,4 @@
-namespace Unosquare.PassCore.Web.Models;
+namespace Unosquare.PassCore.Common;
 
 public class ChangePasswordForm
 {

--- a/src/Unosquare.PassCore.Common/ClientSettings.cs
+++ b/src/Unosquare.PassCore.Common/ClientSettings.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace Unosquare.PassCore.Web.Models;
+namespace Unosquare.PassCore.Common;
 
 /// <summary>
 /// Represents all of the strongly-typed application settings loaded from a JSON file.

--- a/src/Unosquare.PassCore.Common/IPasswordPolicy.cs
+++ b/src/Unosquare.PassCore.Common/IPasswordPolicy.cs
@@ -1,0 +1,14 @@
+namespace Unosquare.PassCore.Common;
+
+/// <summary>
+/// Defines an interface for password policies.
+/// </summary>
+public interface IPasswordPolicy
+{
+    /// <summary>
+    /// Validates the password change context against the policy.
+    /// </summary>
+    /// <param name="context">The password change context.</param>
+    /// <param name="provider">The password change provider (for helper methods like distance).</param>
+    void Validate(PasswordChangeContext context, IPasswordChangeProvider provider);
+}

--- a/src/Unosquare.PassCore.Common/PasswordChangeContext.cs
+++ b/src/Unosquare.PassCore.Common/PasswordChangeContext.cs
@@ -1,0 +1,27 @@
+namespace Unosquare.PassCore.Common;
+
+/// <summary>
+/// Represents the context for a password change operation.
+/// </summary>
+public class PasswordChangeContext
+{
+    /// <summary>
+    /// Gets or sets the username.
+    /// </summary>
+    public string Username { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the current password.
+    /// </summary>
+    public string CurrentPassword { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the new password.
+    /// </summary>
+    public string NewPassword { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the client settings.
+    /// </summary>
+    public ClientSettings? ClientSettings { get; set; }
+}

--- a/src/Unosquare.PassCore.Common/PasswordChangeExceptions.cs
+++ b/src/Unosquare.PassCore.Common/PasswordChangeExceptions.cs
@@ -1,0 +1,115 @@
+using System;
+
+namespace Unosquare.PassCore.Common;
+
+/// <summary>
+/// Base class for password change related exceptions.
+/// </summary>
+public abstract class PasswordChangeException : Exception
+{
+    protected PasswordChangeException(string message)
+        : base(message)
+    {
+    }
+
+    protected PasswordChangeException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    protected PasswordChangeException()
+    {
+    }
+}
+
+/// <summary>
+/// Exception thrown when invalid credentials are provided.
+/// </summary>
+public class InvalidCredentialsException : PasswordChangeException
+{
+    public InvalidCredentialsException(string message = "Invalid credentials")
+        : base(message)
+    {
+    }
+
+    public InvalidCredentialsException()
+        : base("Invalid credentials")
+    {
+    }
+
+    public InvalidCredentialsException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
+
+/// <summary>
+/// Exception thrown when the new password violates a policy.
+/// </summary>
+public class PasswordPolicyViolationException : PasswordChangeException
+{
+    public PasswordPolicyViolationException(ApiErrorCode errorCode, string message = "Password policy violation")
+        : base(message)
+    {
+        ErrorCode = errorCode;
+    }
+
+    public PasswordPolicyViolationException()
+        : base("Password policy violation")
+    {
+    }
+
+    public PasswordPolicyViolationException(string message)
+        : base(message)
+    {
+    }
+
+    public PasswordPolicyViolationException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    public ApiErrorCode ErrorCode { get; }
+}
+
+/// <summary>
+/// Exception thrown when the user is not found.
+/// </summary>
+public class UserNotFoundException : PasswordChangeException
+{
+    public UserNotFoundException(string message = "User not found")
+        : base(message)
+    {
+    }
+
+    public UserNotFoundException()
+        : base("User not found")
+    {
+    }
+
+    public UserNotFoundException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
+
+/// <summary>
+/// Exception thrown when the directory service is unavailable.
+/// </summary>
+public class DirectoryUnavailableException : PasswordChangeException
+{
+    public DirectoryUnavailableException(string message, Exception? innerException = null)
+        : base(message, innerException!)
+    {
+    }
+
+    public DirectoryUnavailableException()
+        : base("Directory unavailable")
+    {
+    }
+
+    public DirectoryUnavailableException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/Unosquare.PassCore.Common/PasswordChangeProviderBase.cs
+++ b/src/Unosquare.PassCore.Common/PasswordChangeProviderBase.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Unosquare.PassCore.Common;
+
+/// <summary>
+/// Base class for password change providers.
+/// </summary>
+public abstract class PasswordChangeProviderBase : IPasswordChangeProvider
+{
+    protected PasswordChangeProviderBase(ILogger logger, IEnumerable<IPasswordPolicy> policies)
+    {
+        Logger = logger;
+        Policies = policies;
+    }
+
+    protected ILogger Logger { get; }
+
+    protected IEnumerable<IPasswordPolicy> Policies { get; }
+
+    /// <inheritdoc />
+    [Obsolete("Use ChangePasswordAsync instead.")]
+    public virtual async Task<ApiErrorItem?> PerformPasswordChangeAsync(
+        string username,
+        string currentPassword,
+        string newPassword,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await ChangePasswordAsync(
+            new PasswordChangeContext
+            {
+                Username = username,
+                CurrentPassword = currentPassword,
+                NewPassword = newPassword
+            },
+            cancellationToken);
+
+        return result.Error;
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<PasswordChangeResult> ChangePasswordAsync(
+        PasswordChangeContext context,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var operationId = Guid.NewGuid();
+        using var scope = Logger.BeginScope(new Dictionary<string, object> { ["OperationId"] = operationId });
+
+        Logger.LogInformation("Starting password change operation for user: {Username}", context.Username);
+
+        try
+        {
+            ValidateContext(context);
+
+            foreach (var policy in Policies)
+            {
+                policy.Validate(context, this);
+            }
+
+            await ChangePasswordCoreAsync(context, cancellationToken);
+
+            Logger.LogInformation("Password successfully changed for user: {Username}", context.Username);
+            return PasswordChangeResult.SuccessResult();
+        }
+        catch (PasswordChangeException ex)
+        {
+            Logger.LogWarning(ex, "Password change failed for user {Username}: {Message}", context.Username, ex.Message);
+            return PasswordChangeResult.Failure(ApiErrorMapper.Map(ex));
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Unexpected error during password change for user {Username}", context.Username);
+            return PasswordChangeResult.Failure(ApiErrorMapper.Map(ex));
+        }
+    }
+
+    /// <summary>
+    /// Core implementation of the password change logic.
+    /// </summary>
+    /// <param name="context">The password change context.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task representing the operation.</returns>
+    protected abstract Task ChangePasswordCoreAsync(PasswordChangeContext context, CancellationToken cancellationToken);
+
+    private static void ValidateContext(PasswordChangeContext context)
+    {
+        if (string.IsNullOrWhiteSpace(context.Username))
+            throw new InvalidCredentialsException("Username is required");
+        if (string.IsNullOrWhiteSpace(context.CurrentPassword))
+            throw new InvalidCredentialsException("Current password is required");
+        if (string.IsNullOrWhiteSpace(context.NewPassword))
+            throw new InvalidCredentialsException("New password is required");
+    }
+}

--- a/src/Unosquare.PassCore.Common/PasswordChangeResult.cs
+++ b/src/Unosquare.PassCore.Common/PasswordChangeResult.cs
@@ -1,0 +1,41 @@
+namespace Unosquare.PassCore.Common;
+
+/// <summary>
+/// Represents the result of a password change operation.
+/// </summary>
+public class PasswordChangeResult
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PasswordChangeResult"/> class.
+    /// </summary>
+    /// <param name="success">if set to <c>true</c> [success].</param>
+    /// <param name="error">The error.</param>
+    public PasswordChangeResult(bool success, ApiErrorItem? error = null)
+    {
+        Success = success;
+        Error = error;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether this <see cref="PasswordChangeResult"/> is success.
+    /// </summary>
+    public bool Success { get; }
+
+    /// <summary>
+    /// Gets the error.
+    /// </summary>
+    public ApiErrorItem? Error { get; }
+
+    /// <summary>
+    /// Creates a success result.
+    /// </summary>
+    /// <returns>A success <see cref="PasswordChangeResult"/>.</returns>
+    public static PasswordChangeResult SuccessResult() => new(true);
+
+    /// <summary>
+    /// Creates a failure result.
+    /// </summary>
+    /// <param name="error">The error.</param>
+    /// <returns>A failure <see cref="PasswordChangeResult"/>.</returns>
+    public static PasswordChangeResult Failure(ApiErrorItem error) => new(false, error);
+}

--- a/src/Unosquare.PassCore.Common/PasswordDistancePolicy.cs
+++ b/src/Unosquare.PassCore.Common/PasswordDistancePolicy.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Unosquare.PassCore.Common;
+
+/// <summary>
+/// Policy for validating the minimum distance between old and new passwords.
+/// </summary>
+public class PasswordDistancePolicy : IPasswordPolicy
+{
+    public void Validate(PasswordChangeContext context, IPasswordChangeProvider provider)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(provider);
+
+        if (context.ClientSettings?.MinimumDistance > 0 &&
+            provider.MeasureNewPasswordDistance(context.CurrentPassword, context.NewPassword) < context.ClientSettings.MinimumDistance)
+        {
+            throw new PasswordPolicyViolationException(ApiErrorCode.MinimumDistance, "The distance between the old and new password is too short.");
+        }
+    }
+}

--- a/src/Unosquare.PassCore.Common/PasswordScorePolicy.cs
+++ b/src/Unosquare.PassCore.Common/PasswordScorePolicy.cs
@@ -1,0 +1,21 @@
+using System;
+using Zxcvbn;
+
+namespace Unosquare.PassCore.Common;
+
+/// <summary>
+/// Policy for validating the minimum score (entropy) of the new password using Zxcvbn.
+/// </summary>
+public class PasswordScorePolicy : IPasswordPolicy
+{
+    public void Validate(PasswordChangeContext context, IPasswordChangeProvider provider)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (context.ClientSettings?.MinimumScore > 0 &&
+            Core.EvaluatePassword(context.NewPassword).Score < context.ClientSettings.MinimumScore)
+        {
+            throw new PasswordPolicyViolationException(ApiErrorCode.MinimumScore, "The new password is not complex enough.");
+        }
+    }
+}

--- a/src/Unosquare.PassCore.Common/Unosquare.PassCore.Common.csproj
+++ b/src/Unosquare.PassCore.Common/Unosquare.PassCore.Common.csproj
@@ -13,4 +13,8 @@
 		<PackageProjectUrl>https://github.com/unosquare/passcore</PackageProjectUrl>
 		<PackageLicenseUrl>https://raw.githubusercontent.com/unosquare/passcore/master/LICENSE</PackageLicenseUrl>
 	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="zxcvbn-core" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
This PR refactors the PassCore password provider system to improve maintainability and ensure platform neutrality. 

Key changes:
- Created `PasswordChangeProviderBase` in `Unosquare.PassCore.Common` to handle the template method for password changes, including validation through policies, logging, and error mapping.
- Introduced `PasswordChangeContext` and `PasswordChangeResult` to replace the `null`-as-success pattern and provide a cleaner API for the web layer.
- Moved `ClientSettings` and related models to the Common project to allow them to be used by the base provider without circular dependencies.
- Extracted validation logic into `IPasswordPolicy` implementations (`PasswordDistancePolicy` and `PasswordScorePolicy`).
- Refactored all existing providers (AD, LDAP, Debug) to use the new base class and throw domain exceptions instead of constructing API error items directly.
- Verified that the solution builds and runs on Linux using the Debug provider, while maintaining Active Directory support for Windows environments.

---
*PR created automatically by Jules for task [18059434966432685573](https://jules.google.com/task/18059434966432685573) started by @ECRLib*