### PR TITLE
Refactor Password Provider system for centralization and Linux CI safety

### DIFF
--- a/src/Unosquare.PassCore.Common/ApiErrorMapper.cs
+++ b/src/Unosquare.PassCore.Common/ApiErrorMapper.cs
@@ -1,0 +1,19 @@
+using System;
+using Unosquare.PassCore.Common.Exceptions;
+
+namespace Unosquare.PassCore.Common;
+
+public static class ApiErrorMapper
+{
+    public static ApiErrorItem Map(Exception exception)
+    {
+        return exception switch
+        {
+            InvalidCredentialsException ex => new ApiErrorItem(ApiErrorCode.InvalidCredentials, ex.Message),
+            PasswordPolicyViolationException ex => new ApiErrorItem(ex.ErrorCode, ex.Message),
+            UserNotFoundException ex => new ApiErrorItem(ApiErrorCode.UserNotFound, ex.Message),
+            DirectoryUnavailableException ex => new ApiErrorItem(ApiErrorCode.LdapProblem, ex.Message),
+            _ => new ApiErrorItem(ApiErrorCode.Generic, exception.Message)
+        };
+    }
+}

--- a/src/Unosquare.PassCore.Common/Exceptions/PasswordChangeExceptions.cs
+++ b/src/Unosquare.PassCore.Common/Exceptions/PasswordChangeExceptions.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace Unosquare.PassCore.Common.Exceptions;
+
+public class PasswordChangeException : Exception
+{
+    public PasswordChangeException() : base() { }
+    public PasswordChangeException(string message) : base(message) { }
+    public PasswordChangeException(string message, Exception innerException) : base(message, innerException) { }
+}
+
+public class InvalidCredentialsException : PasswordChangeException
+{
+    public InvalidCredentialsException() : base() { }
+    public InvalidCredentialsException(string message) : base(message) { }
+    public InvalidCredentialsException(string message, Exception innerException) : base(message, innerException) { }
+}
+
+public class PasswordPolicyViolationException : PasswordChangeException
+{
+    public ApiErrorCode ErrorCode { get; }
+    public PasswordPolicyViolationException() : base() { ErrorCode = ApiErrorCode.ComplexPassword; }
+    public PasswordPolicyViolationException(string message) : base(message) { ErrorCode = ApiErrorCode.ComplexPassword; }
+    public PasswordPolicyViolationException(string message, Exception innerException) : base(message, innerException) { ErrorCode = ApiErrorCode.ComplexPassword; }
+    public PasswordPolicyViolationException(string message, ApiErrorCode errorCode) : base(message)
+    {
+        ErrorCode = errorCode;
+    }
+}
+
+public class UserNotFoundException : PasswordChangeException
+{
+    public UserNotFoundException() : base() { }
+    public UserNotFoundException(string message) : base(message) { }
+    public UserNotFoundException(string message, Exception innerException) : base(message, innerException) { }
+}
+
+public class DirectoryUnavailableException : PasswordChangeException
+{
+    public DirectoryUnavailableException() : base() { }
+    public DirectoryUnavailableException(string message) : base(message) { }
+    public DirectoryUnavailableException(string message, Exception innerException) : base(message, innerException) { }
+}

--- a/src/Unosquare.PassCore.Common/IGroupMembershipTester.cs
+++ b/src/Unosquare.PassCore.Common/IGroupMembershipTester.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+
+namespace Unosquare.PassCore.Common;
+
+/// <summary>
+/// Defines a provider that can test for user group membership.
+/// </summary>
+public interface IGroupMembershipTester
+{
+    /// <summary>
+    /// Checks if a user is a member of a specific group.
+    /// </summary>
+    /// <param name="username">The username to check.</param>
+    /// <param name="groupName">The name of the group.</param>
+    /// <returns>A task representing the asynchronous operation, containing true if the user is a member, otherwise false.</returns>
+    Task<bool> IsMemberOfGroupAsync(string username, string groupName);
+}

--- a/src/Unosquare.PassCore.Common/IPasswordChangeProvider.cs
+++ b/src/Unosquare.PassCore.Common/IPasswordChangeProvider.cs
@@ -17,7 +17,16 @@ public interface IPasswordChangeProvider
     /// <param name="newPassword">The new password.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The API error item or null if the change password operation was successful.</returns>
+    [Obsolete("Use ChangePasswordAsync instead")]
     Task<ApiErrorItem?> PerformPasswordChangeAsync(string username, string currentPassword, string newPassword, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Performs the password change using the credentials provided in the context.
+    /// </summary>
+    /// <param name="context">The password change context.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The password change result.</returns>
+    Task<PasswordChangeResult> ChangePasswordAsync(PasswordChangeContext context, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Compute the distance between two strings.

--- a/src/Unosquare.PassCore.Common/IPasswordLengthRequirement.cs
+++ b/src/Unosquare.PassCore.Common/IPasswordLengthRequirement.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+
+namespace Unosquare.PassCore.Common;
+
+/// <summary>
+/// Defines a provider that can report its own minimum password length requirement.
+/// </summary>
+public interface IPasswordLengthRequirement
+{
+    /// <summary>
+    /// Gets the minimum password length requirement.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation, containing the minimum length.</returns>
+    Task<int> GetMinimumLengthAsync();
+}

--- a/src/Unosquare.PassCore.Common/IPasswordPolicy.cs
+++ b/src/Unosquare.PassCore.Common/IPasswordPolicy.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+
+namespace Unosquare.PassCore.Common;
+
+/// <summary>
+/// Defines a password policy that can be validated.
+/// </summary>
+public interface IPasswordPolicy
+{
+    /// <summary>
+    /// Validates the password change context against the policy.
+    /// </summary>
+    /// <param name="context">The password change context.</param>
+    /// <param name="provider">The password change provider.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task ValidateAsync(PasswordChangeContext context, IPasswordChangeProvider provider);
+}

--- a/src/Unosquare.PassCore.Common/Models/ChangePasswordForm.cs
+++ b/src/Unosquare.PassCore.Common/Models/ChangePasswordForm.cs
@@ -1,4 +1,4 @@
-namespace Unosquare.PassCore.Web.Models;
+namespace Unosquare.PassCore.Common.Models;
 
 public class ChangePasswordForm
 {

--- a/src/Unosquare.PassCore.Common/Models/ClientSettings.cs
+++ b/src/Unosquare.PassCore.Common/Models/ClientSettings.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
+using System.Collections.Generic;
 
-namespace Unosquare.PassCore.Web.Models;
+namespace Unosquare.PassCore.Common.Models;
 
 /// <summary>
 /// Represents all of the strongly-typed application settings loaded from a JSON file.
@@ -20,6 +21,15 @@ public class ClientSettings
     public string? ApplicationTitle { get; set; }
     public string? ChangePasswordTitle { get; set; }
     public ValidationRegex? ValidationRegex { get; set; }
+
+    // Extended settings for policies
+    public PasswordProviderOptions? PasswordProviderOptions { get; set; }
+}
+
+public class PasswordProviderOptions
+{
+    public List<string>? RestrictedAdGroups { get; set; }
+    public List<string>? AllowedAdGroups { get; set; }
 }
 
 public class Recaptcha

--- a/src/Unosquare.PassCore.Common/PasswordChangeContext.cs
+++ b/src/Unosquare.PassCore.Common/PasswordChangeContext.cs
@@ -1,0 +1,19 @@
+using Unosquare.PassCore.Common.Models;
+
+namespace Unosquare.PassCore.Common;
+
+public class PasswordChangeContext
+{
+    public PasswordChangeContext(string username, string currentPassword, string newPassword, ClientSettings clientSettings)
+    {
+        Username = username;
+        CurrentPassword = currentPassword;
+        NewPassword = newPassword;
+        ClientSettings = clientSettings;
+    }
+
+    public string Username { get; }
+    public string CurrentPassword { get; }
+    public string NewPassword { get; }
+    public ClientSettings ClientSettings { get; }
+}

--- a/src/Unosquare.PassCore.Common/PasswordChangeProviderBase.cs
+++ b/src/Unosquare.PassCore.Common/PasswordChangeProviderBase.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Unosquare.PassCore.Common.Exceptions;
+using Unosquare.PassCore.Common.Models;
+
+namespace Unosquare.PassCore.Common;
+
+public abstract class PasswordChangeProviderBase : IPasswordChangeProvider
+{
+    protected ILogger Logger { get; }
+    protected IEnumerable<IPasswordPolicy> Policies { get; }
+
+    protected PasswordChangeProviderBase(ILogger logger, IEnumerable<IPasswordPolicy>? policies = null)
+    {
+        Logger = logger;
+        Policies = policies ?? Array.Empty<IPasswordPolicy>();
+    }
+
+    public virtual async Task<PasswordChangeResult> ChangePasswordAsync(PasswordChangeContext context, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var operationId = Guid.NewGuid().ToString();
+        Logger.LogInformation("[{OperationId}] Starting password change for user: {Username}", operationId, context.Username);
+
+        try
+        {
+            ValidateContext(context);
+
+            foreach (var policy in Policies)
+            {
+                await policy.ValidateAsync(context, this);
+            }
+
+            await ChangePasswordCore(context, cancellationToken);
+
+            Logger.LogInformation("[{OperationId}] Password changed successfully for user: {Username}", operationId, context.Username);
+            return PasswordChangeResult.Success();
+        }
+        catch (OperationCanceledException ex)
+        {
+            Logger.LogWarning(ex, "[{OperationId}] Password change canceled for user: {Username}", operationId, context.Username);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "[{OperationId}] Password change failed for user: {Username}", operationId, context.Username);
+            return PasswordChangeResult.Fail(ApiErrorMapper.Map(ex));
+        }
+    }
+
+    protected virtual void ValidateContext(PasswordChangeContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (string.IsNullOrWhiteSpace(context.Username))
+            throw new InvalidCredentialsException("Username is required");
+        if (string.IsNullOrWhiteSpace(context.CurrentPassword))
+            throw new InvalidCredentialsException("Current password is required");
+        if (string.IsNullOrWhiteSpace(context.NewPassword))
+            throw new InvalidCredentialsException("New password is required");
+    }
+
+    protected abstract Task ChangePasswordCore(PasswordChangeContext context, CancellationToken cancellationToken);
+
+    // Legacy method for backward compatibility
+    [Obsolete("Use ChangePasswordAsync instead")]
+    public virtual async Task<ApiErrorItem?> PerformPasswordChangeAsync(string username, string currentPassword, string newPassword, CancellationToken cancellationToken = default)
+    {
+        var result = await ChangePasswordAsync(new PasswordChangeContext(username, currentPassword, newPassword, new ClientSettings()), cancellationToken);
+        return result.Error;
+    }
+
+    public int MeasureNewPasswordDistance(string currentPassword, string newPassword)
+    {
+        ArgumentNullException.ThrowIfNull(currentPassword);
+        ArgumentNullException.ThrowIfNull(newPassword);
+
+        var n = currentPassword.Length;
+        var m = newPassword.Length;
+
+        if (n == 0) return m;
+        if (m == 0) return n;
+
+        var d = new int[n + 1, m + 1];
+
+        for (int i = 0; i <= n; d[i, 0] = i++) { }
+        for (int j = 0; j <= m; d[0, j] = j++) { }
+
+        for (int i = 1; i <= n; i++)
+        {
+            for (int j = 1; j <= m; j++)
+            {
+                int cost = (newPassword[j - 1] == currentPassword[i - 1]) ? 0 : 1;
+                d[i, j] = Math.Min(Math.Min(d[i - 1, j] + 1, d[i, j - 1] + 1), d[i - 1, j - 1] + cost);
+            }
+        }
+
+        return d[n, m];
+    }
+}

--- a/src/Unosquare.PassCore.Common/PasswordChangeProviderBase.cs
+++ b/src/Unosquare.PassCore.Common/PasswordChangeProviderBase.cs
@@ -45,7 +45,7 @@ public abstract class PasswordChangeProviderBase : IPasswordChangeProvider
             Logger.LogWarning(ex, "[{OperationId}] Password change canceled for user: {Username}", operationId, context.Username);
             throw;
         }
-        catch (Exception ex)
+        catch (PassCoreException ex)
         {
             Logger.LogWarning(ex, "[{OperationId}] Password change failed for user: {Username}", operationId, context.Username);
             return PasswordChangeResult.Fail(ApiErrorMapper.Map(ex));

--- a/src/Unosquare.PassCore.Common/PasswordChangeResult.cs
+++ b/src/Unosquare.PassCore.Common/PasswordChangeResult.cs
@@ -1,0 +1,11 @@
+namespace Unosquare.PassCore.Common;
+
+public class PasswordChangeResult
+{
+    public bool IsSuccess { get; private set; }
+    public ApiErrorItem? Error { get; private set; }
+
+    public static PasswordChangeResult Success() => new() { IsSuccess = true };
+    public static PasswordChangeResult Fail(ApiErrorItem error) => new() { IsSuccess = false, Error = error };
+    public static PasswordChangeResult Fail(ApiErrorCode errorCode, string? message = null) => Fail(new ApiErrorItem(errorCode, message));
+}

--- a/src/Unosquare.PassCore.Common/Policies/ComplexityPasswordPolicy.cs
+++ b/src/Unosquare.PassCore.Common/Policies/ComplexityPasswordPolicy.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading.Tasks;
+using Zxcvbn;
+using Unosquare.PassCore.Common.Exceptions;
+
+namespace Unosquare.PassCore.Common.Policies;
+
+public class ComplexityPasswordPolicy : IPasswordPolicy
+{
+    public Task ValidateAsync(PasswordChangeContext context, IPasswordChangeProvider provider)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (context.ClientSettings.MinimumScore > 0 && Core.EvaluatePassword(context.NewPassword).Score < context.ClientSettings.MinimumScore)
+        {
+            throw new PasswordPolicyViolationException("Password does not meet the minimum score requirement", ApiErrorCode.MinimumScore);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Unosquare.PassCore.Common/Policies/DistancePasswordPolicy.cs
+++ b/src/Unosquare.PassCore.Common/Policies/DistancePasswordPolicy.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading.Tasks;
+using Unosquare.PassCore.Common.Exceptions;
+
+namespace Unosquare.PassCore.Common.Policies;
+
+public class DistancePasswordPolicy : IPasswordPolicy
+{
+    public Task ValidateAsync(PasswordChangeContext context, IPasswordChangeProvider provider)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (context.ClientSettings.MinimumDistance > 0)
+        {
+            var distance = provider.MeasureNewPasswordDistance(context.CurrentPassword, context.NewPassword);
+            if (distance < context.ClientSettings.MinimumDistance)
+            {
+                throw new PasswordPolicyViolationException("Password does not meet the minimum distance requirement", ApiErrorCode.MinimumDistance);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Unosquare.PassCore.Common/Policies/GroupMembershipPolicy.cs
+++ b/src/Unosquare.PassCore.Common/Policies/GroupMembershipPolicy.cs
@@ -1,0 +1,44 @@
+using System.Threading.Tasks;
+using Unosquare.PassCore.Common.Exceptions;
+
+namespace Unosquare.PassCore.Common.Policies;
+
+public class GroupMembershipPolicy : IPasswordPolicy
+{
+    public async Task ValidateAsync(PasswordChangeContext context, IPasswordChangeProvider provider)
+    {
+        if (provider is not IGroupMembershipTester tester)
+            return;
+
+        var restrictedGroups = context.ClientSettings.PasswordProviderOptions?.RestrictedAdGroups;
+        if (restrictedGroups != null && restrictedGroups.Count != 0)
+        {
+            foreach (var group in restrictedGroups)
+            {
+                if (await tester.IsMemberOfGroupAsync(context.Username, group))
+                {
+                    throw new PasswordPolicyViolationException("User is a member of a restricted group and password change is not permitted.", ApiErrorCode.ChangeNotPermitted);
+                }
+            }
+        }
+
+        var allowedGroups = context.ClientSettings.PasswordProviderOptions?.AllowedAdGroups;
+        if (allowedGroups != null && allowedGroups.Count != 0)
+        {
+            var isMemberOfAnyAllowed = false;
+            foreach (var group in allowedGroups)
+            {
+                if (await tester.IsMemberOfGroupAsync(context.Username, group))
+                {
+                    isMemberOfAnyAllowed = true;
+                    break;
+                }
+            }
+
+            if (!isMemberOfAnyAllowed)
+            {
+                throw new PasswordPolicyViolationException("User is not a member of any allowed group and password change is not permitted.", ApiErrorCode.ChangeNotPermitted);
+            }
+        }
+    }
+}

--- a/src/Unosquare.PassCore.Common/Policies/GroupMembershipPolicy.cs
+++ b/src/Unosquare.PassCore.Common/Policies/GroupMembershipPolicy.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using Unosquare.PassCore.Common.Exceptions;
 
@@ -13,12 +14,16 @@ public class GroupMembershipPolicy : IPasswordPolicy
         var restrictedGroups = context.ClientSettings.PasswordProviderOptions?.RestrictedAdGroups;
         if (restrictedGroups != null && restrictedGroups.Count != 0)
         {
-            foreach (var group in restrictedGroups)
-            {
-                if (await tester.IsMemberOfGroupAsync(context.Username, group))
+            var restrictedMembershipResults = await Task.WhenAll(
+                restrictedGroups.Select(async group => new
                 {
-                    throw new PasswordPolicyViolationException("User is a member of a restricted group and password change is not permitted.", ApiErrorCode.ChangeNotPermitted);
-                }
+                    Group = group,
+                    IsMember = await tester.IsMemberOfGroupAsync(context.Username, group)
+                }));
+
+            if (restrictedMembershipResults.Where(x => x.IsMember).Any())
+            {
+                throw new PasswordPolicyViolationException("User is a member of a restricted group and password change is not permitted.", ApiErrorCode.ChangeNotPermitted);
             }
         }
 

--- a/src/Unosquare.PassCore.Common/Policies/GroupMembershipPolicy.cs
+++ b/src/Unosquare.PassCore.Common/Policies/GroupMembershipPolicy.cs
@@ -30,15 +30,14 @@ public class GroupMembershipPolicy : IPasswordPolicy
         var allowedGroups = context.ClientSettings.PasswordProviderOptions?.AllowedAdGroups;
         if (allowedGroups != null && allowedGroups.Count != 0)
         {
-            var isMemberOfAnyAllowed = false;
-            foreach (var group in allowedGroups)
-            {
-                if (await tester.IsMemberOfGroupAsync(context.Username, group))
+            var allowedMembershipResults = await Task.WhenAll(
+                allowedGroups.Select(async group => new
                 {
-                    isMemberOfAnyAllowed = true;
-                    break;
-                }
-            }
+                    Group = group,
+                    IsMember = await tester.IsMemberOfGroupAsync(context.Username, group)
+                }));
+
+            var isMemberOfAnyAllowed = allowedMembershipResults.Where(x => x.IsMember).Any();
 
             if (!isMemberOfAnyAllowed)
             {

--- a/src/Unosquare.PassCore.Common/Policies/LengthPasswordPolicy.cs
+++ b/src/Unosquare.PassCore.Common/Policies/LengthPasswordPolicy.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+using Unosquare.PassCore.Common.Exceptions;
+
+namespace Unosquare.PassCore.Common.Policies;
+
+public class LengthPasswordPolicy : IPasswordPolicy
+{
+    public async Task ValidateAsync(PasswordChangeContext context, IPasswordChangeProvider provider)
+    {
+        if (provider is IPasswordLengthRequirement requirement)
+        {
+            var minLength = await requirement.GetMinimumLengthAsync();
+            if (context.NewPassword.Length < minLength)
+            {
+                throw new PasswordPolicyViolationException($"The new password does not meet the Active Directory domain minimum password length requirement of {minLength} characters.", ApiErrorCode.ComplexPassword);
+            }
+        }
+    }
+}

--- a/src/Unosquare.PassCore.Common/Policies/PwnedPasswordPolicy.cs
+++ b/src/Unosquare.PassCore.Common/Policies/PwnedPasswordPolicy.cs
@@ -1,0 +1,36 @@
+using System.Threading.Tasks;
+using PwnedPasswordsSearch;
+using Unosquare.PassCore.Common.Exceptions;
+
+namespace Unosquare.PassCore.Common.Policies;
+
+public class PwnedPasswordPolicy : IPasswordPolicy
+{
+    private readonly IPwnedPasswordSearch _pwnedPasswordSearch;
+
+    public PwnedPasswordPolicy(IPwnedPasswordSearch pwnedPasswordSearch)
+    {
+        _pwnedPasswordSearch = pwnedPasswordSearch;
+    }
+
+    public async Task ValidateAsync(PasswordChangeContext context, IPasswordChangeProvider provider)
+    {
+        // This policy is generally applicable if pwned check is enabled in any way,
+        // but here we check the new password against the pwned database.
+        try
+        {
+            if (await _pwnedPasswordSearch.IsPwnedPasswordAsync(context.NewPassword))
+            {
+                throw new PasswordPolicyViolationException("The password is a known compromised password and is not allowed.", ApiErrorCode.PwnedPassword);
+            }
+        }
+        catch (PwnedPasswordsApiException ex)
+        {
+            throw new PasswordPolicyViolationException($"Error during Pwned Password API check: {ex.Message}", ApiErrorCode.Generic);
+        }
+        catch (PwnedPasswordsSearchException ex)
+        {
+            throw new PasswordPolicyViolationException($"Unexpected error during Pwned Password search: {ex.Message}", ApiErrorCode.Generic);
+        }
+    }
+}

--- a/src/Unosquare.PassCore.Common/Unosquare.PassCore.Common.csproj
+++ b/src/Unosquare.PassCore.Common/Unosquare.PassCore.Common.csproj
@@ -1,4 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+	<ItemGroup>
+	  <ProjectReference Include="..\PwnedPasswordsSearch\PwnedPasswordsSearch.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+	  <PackageReference Include="zxcvbn-core" />
+	</ItemGroup>
 	<PropertyGroup>
 		<!-- Inherit from Directory.Build.props -->
 		<Description>PassCore abstraction classes to implement custom providers.</Description>

--- a/src/Unosquare.PassCore.PasswordProvider.Debug/DebugPasswordChangeProvider.cs
+++ b/src/Unosquare.PassCore.PasswordProvider.Debug/DebugPasswordChangeProvider.cs
@@ -1,9 +1,11 @@
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using PwnedPasswordsSearch;
 using Unosquare.PassCore.Common;
+using Unosquare.PassCore.Common.Exceptions;
 
 namespace Unosquare.PassCore.PasswordProvider.Debug;
 
@@ -11,43 +13,36 @@ namespace Unosquare.PassCore.PasswordProvider.Debug;
 /// <summary>
 /// Represents a debug password change provider that can be configured for testing and development.
 /// </summary>
-public class DebugPasswordChangeProvider : IPasswordChangeProvider
+public class DebugPasswordChangeProvider : PasswordChangeProviderBase
 {
-    private readonly IPwnedPasswordSearch _pwnedPasswordSearch;
     private readonly DebugProviderOptions _options;
-    private readonly ILogger<DebugPasswordChangeProvider> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DebugPasswordChangeProvider"/> class.
     /// </summary>
-    /// <param name="pwnedPasswordSearch">The pwned password search service.</param>
     /// <param name="options">The debug provider options.</param>
     /// <param name="logger">The logger.</param>
+    /// <param name="policies">The password policies.</param>
     public DebugPasswordChangeProvider(
-        IPwnedPasswordSearch pwnedPasswordSearch,
         IOptions<DebugProviderOptions> options,
-        ILogger<DebugPasswordChangeProvider> logger)
+        ILogger<DebugPasswordChangeProvider> logger,
+        IEnumerable<IPasswordPolicy> policies)
+        : base(logger, policies)
     {
-        _pwnedPasswordSearch = pwnedPasswordSearch;
         _options = options.Value;
-        _logger = logger;
     }
 
     /// <inheritdoc />
-    public async Task<ApiErrorItem?> PerformPasswordChangeAsync(
-        string username,
-        string currentPassword,
-        string newPassword,
-        CancellationToken cancellationToken = default)
+    protected override async Task ChangePasswordCore(
+        PasswordChangeContext context,
+        CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Debug password change requested for user: {Username}", username);
-
         if (_options.SimulateLatencyMs > 0)
         {
-            _logger.LogDebug("Simulating latency of {Latency}ms", _options.SimulateLatencyMs);
             await Task.Delay(_options.SimulateLatencyMs, cancellationToken);
         }
 
+        var username = context.Username;
         var currentUsername = username.Contains('@', System.StringComparison.Ordinal)
             ? username[..username.IndexOf('@', System.StringComparison.Ordinal)]
             : username;
@@ -55,35 +50,35 @@ public class DebugPasswordChangeProvider : IPasswordChangeProvider
         // Check for explicitly configured forced errors first
         if (_options.ForcedErrors != null && _options.ForcedErrors.TryGetValue(currentUsername, out var errorCode))
         {
-            _logger.LogWarning("Forced error {ErrorCode} for username: {Username}", errorCode, currentUsername);
-            return new ApiErrorItem(errorCode, $"Forced error {errorCode} for debug");
-        }
-
-        // Check for pwned password if enabled
-        if (_options.EnablePwnedCheck)
-        {
-            if (await _pwnedPasswordSearch.IsPwnedPasswordAsync(newPassword))
-            {
-                _logger.LogWarning("Pwned password detected for user: {Username}", username);
-                return new ApiErrorItem(ApiErrorCode.PwnedPassword);
-            }
+            throw new PasswordPolicyViolationException($"Forced error {errorCode} for debug", errorCode);
         }
 
         // Fallback to legacy hardcoded logic for convenience, or the DefaultErrorCode if set
-        return currentUsername switch
+        var apiErrorCode = currentUsername switch
         {
-            "error" => new ApiErrorItem(ApiErrorCode.Generic, "Error"),
-            "changeNotPermitted" => new ApiErrorItem(ApiErrorCode.ChangeNotPermitted),
-            "fieldMismatch" => new ApiErrorItem(ApiErrorCode.FieldMismatch),
-            "fieldRequired" => new ApiErrorItem(ApiErrorCode.FieldRequired),
-            "invalidCaptcha" => new ApiErrorItem(ApiErrorCode.InvalidCaptcha),
-            "invalidCredentials" => new ApiErrorItem(ApiErrorCode.InvalidCredentials),
-            "invalidDomain" => new ApiErrorItem(ApiErrorCode.InvalidDomain),
-            "userNotFound" => new ApiErrorItem(ApiErrorCode.UserNotFound),
-            "ldapProblem" => new ApiErrorItem(ApiErrorCode.LdapProblem),
-            "pwnedPassword" => new ApiErrorItem(ApiErrorCode.PwnedPassword),
-            _ => _options.DefaultErrorCode.HasValue ? new ApiErrorItem(_options.DefaultErrorCode.Value) : null
+            "error" => ApiErrorCode.Generic,
+            "changeNotPermitted" => ApiErrorCode.ChangeNotPermitted,
+            "fieldMismatch" => ApiErrorCode.FieldMismatch,
+            "fieldRequired" => ApiErrorCode.FieldRequired,
+            "invalidCaptcha" => ApiErrorCode.InvalidCaptcha,
+            "invalidCredentials" => ApiErrorCode.InvalidCredentials,
+            "invalidDomain" => ApiErrorCode.InvalidDomain,
+            "userNotFound" => ApiErrorCode.UserNotFound,
+            "ldapProblem" => ApiErrorCode.LdapProblem,
+            "pwnedPassword" => ApiErrorCode.PwnedPassword,
+            _ => _options.DefaultErrorCode
         };
+
+        if (apiErrorCode.HasValue)
+        {
+            throw apiErrorCode.Value switch
+            {
+                ApiErrorCode.InvalidCredentials => new InvalidCredentialsException(),
+                ApiErrorCode.UserNotFound => new UserNotFoundException(),
+                ApiErrorCode.LdapProblem => new DirectoryUnavailableException("LDAP problem", new System.Exception("Debug LDAP problem")),
+                _ => new PasswordPolicyViolationException($"Debug error {apiErrorCode.Value}", apiErrorCode.Value)
+            };
+        }
     }
 }
 #endif

--- a/src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs
+++ b/src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs
@@ -8,8 +8,10 @@ using System.DirectoryServices.AccountManagement;
 using System.DirectoryServices.ActiveDirectory;
 using System.Linq;
 using Unosquare.PassCore.Common;
+using Unosquare.PassCore.Common.Exceptions;
 using System.Threading.Tasks;
-using PwnedPasswordsSearch;
+using System.Threading;
+using System.Collections.Generic;
 
 namespace Unosquare.PassCore.PasswordProvider
 {
@@ -23,204 +25,11 @@ namespace Unosquare.PassCore.PasswordProvider
     /// <seealso cref="IPasswordChangeProvider" />
     /// https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1416#how-to-fix-violations
     [SupportedOSPlatform("windows")]
-    public class PasswordChangeProvider : IPasswordChangeProvider
+    public class PasswordChangeProvider : PasswordChangeProviderBase, IPasswordLengthRequirement, IGroupMembershipTester
     {
         // Readonly fields
         private readonly PasswordChangeOptions _options;
-        private readonly ILogger<PasswordChangeProvider> _logger;
-        private readonly IPwnedPasswordSearch _pwnedPasswordSearch;
         private IdentityType _idType = IdentityType.UserPrincipalName; // Default identity type
-
-        // LoggerMessage delegates for performance optimization
-        private static readonly Action<ILogger, string, Exception?> LogPerformingPasswordChange =
-            LoggerMessage.Define<string>(
-                LogLevel.Information,
-                new EventId(100, "PerformingPasswordChange"),
-                "Performing password change for user '{Username}'.");
-
-        private static readonly Action<ILogger, string, Exception?> LogInvalidCurrentPassword =
-            LoggerMessage.Define<string>(
-                LogLevel.Warning,
-                new EventId(101, "InvalidCurrentPassword"),
-                "Invalid current password provided for user '{Username}'.");
-
-        private static readonly Action<ILogger, string, Exception?> LogPasswordSuccessfullyUpdated =
-            LoggerMessage.Define<string>(
-                LogLevel.Debug,
-                new EventId(102, "PasswordSuccessfullyUpdated"),
-                "Password successfully updated for user '{Username}'.");
-
-        private static readonly Action<ILogger, string, string, Exception?> LogPasswordChangeComplexityError =
-            LoggerMessage.Define<string, string>(
-                LogLevel.Warning,
-                new EventId(103, "PasswordComplexityError"),
-                "Password change failed due to complexity policies: {ErrorMessage}. {ErrorDetails}");
-
-        private static readonly Action<ILogger, string, string, Exception?> LogPasswordChangeApiError =
-            LoggerMessage.Define<string, string>(
-                LogLevel.Warning,
-                new EventId(104, "PasswordChangeApiError"),
-                "Password change failed due to API error: {ErrorMessage}. {ErrorDetails}");
-
-        private static readonly Action<ILogger, string, string, Exception?> LogPasswordChangeUnexpectedError =
-            LoggerMessage.Define<string, string>(
-                LogLevel.Error,
-                new EventId(105, "PasswordChangeUnexpectedError"),
-                "Password change failed due to an unexpected error: {ErrorMessage}. {ErrorDetails}");
-
-        private static readonly Action<ILogger, string, Exception?> LogUserPrincipalNotFound =
-            LoggerMessage.Define<string>(
-                LogLevel.Warning,
-                new EventId(106, "UserPrincipalNotFound"),
-                "User principal '{Username}' not found.");
-
-        private static readonly Action<ILogger, Exception?> LogPasswordLengthTooShort =
-            LoggerMessage.Define(
-                LogLevel.Error,
-                new EventId(107, "PasswordLengthTooShort"),
-                "New password length is shorter than the Active Directory minimum password length.");
-
-        private static readonly Action<ILogger, Exception?> LogPwnedPasswordUsed =
-            LoggerMessage.Define(
-                LogLevel.Error,
-                new EventId(108, "PwnedPasswordUsed"),
-                "New password is a known compromised password and is not allowed.");
-
-        private static readonly Action<ILogger, Exception?> LogPasswordChangeNotPermittedFlag =
-            LoggerMessage.Define(
-                LogLevel.Warning,
-                new EventId(109, "PasswordChangeNotPermittedFlag"),
-                "User is not permitted to change their password.");
-
-        private static readonly Action<ILogger, int, Exception?> LogValidateCredentialsWin32Error =
-            LoggerMessage.Define<int>(
-                LogLevel.Debug,
-                new EventId(110, "ValidateCredentialsWin32Error"),
-                "ValidateUserCredentials GetLastWin32Error {ErrorCode}");
-
-        private static readonly Action<ILogger, Exception?> LogPwdLastSetMissing =
-            LoggerMessage.Define(
-                LogLevel.Warning,
-                new EventId(111, "PwdLastSetMissing"),
-                "The 'pwdLastSet' property is missing on the user principal.");
-
-        private static readonly Action<ILogger, Exception?> LogPwdLastSetUpdated =
-            LoggerMessage.Define(
-                LogLevel.Information,
-                new EventId(112, "PwdLastSetUpdated"),
-                "The 'pwdLastSet' attribute was successfully updated.");
-
-        private static readonly Action<ILogger, string, Exception?> LogPwdLastSetUpdateFailed =
-            LoggerMessage.Define<string>(
-                LogLevel.Error,
-                new EventId(113, "PwdLastSetUpdateFailed"),
-                "Failed to update 'pwdLastSet' attribute: {ErrorMessage}");
-
-        private static readonly Action<ILogger, string, Exception?> LogChangePasswordAutomaticContextFailed =
-            LoggerMessage.Define<string>(
-                LogLevel.Warning,
-                new EventId(114, "ChangePasswordAutomaticContextFailed"),
-                "ChangePassword failed with AutomaticContext enabled. Password update aborted. {ErrorDetails}");
-
-        private static readonly Action<ILogger, Exception?> LogPasswordUpdatedSetPasswordFallback =
-            LoggerMessage.Define(
-                LogLevel.Debug,
-                new EventId(115, "PasswordUpdatedSetPasswordFallback"),
-                "Password updated using SetPassword method after ChangePassword failure.");
-
-        private static readonly Action<ILogger, string, Exception?> LogSetPasswordFailed =
-            LoggerMessage.Define<string>(
-                LogLevel.Error,
-                new EventId(116, "SetPasswordFailed"),
-                "SetPassword failed after ChangePassword failure. Password update failed. {ErrorDetails}");
-
-        private static readonly Action<ILogger, IdentityType, Exception?> LogIdentityTypeSet =
-            LoggerMessage.Define<IdentityType>(
-                LogLevel.Debug,
-                new EventId(117, "IdentityTypeSet"),
-                "Identity type set to '{IdentityType}'.");
-
-        private static readonly Action<ILogger, Exception?> LogAutomaticDomainContext =
-            LoggerMessage.Define(
-                LogLevel.Debug,
-                new EventId(118, "AutomaticDomainContext"),
-                "Using automatic domain context.");
-
-        private static readonly Action<ILogger, string, Exception?> LogDomainContext =
-            LoggerMessage.Define<string>(
-                LogLevel.Debug,
-                new EventId(119, "DomainContext"),
-                "Using domain context: '{Domain}'.");
-
-        private static readonly Action<ILogger, string, Exception?> LogCreatingDirectoryEntry =
-            LoggerMessage.Define<string>(
-                LogLevel.Debug,
-                new EventId(120, "CreatingDirectoryEntry"),
-                "Creating DirectoryEntry for domain: '{Domain}'.");
-
-        private static readonly Action<ILogger, string, Exception?> LogErrorRetrievingGroups =
-            LoggerMessage.Define<string>(
-                LogLevel.Error,
-                new EventId(887, "GroupRetrievalError"),
-                "Error retrieving user groups using GetGroups. Falling back to GetAuthorizationGroups. {ErrorMessage}");
-
-        private static readonly Action<ILogger, string, Exception?> LogErrorGroupValidation =
-            LoggerMessage.Define<string>(
-                LogLevel.Error,
-                new EventId(888, "GroupValidationError"),
-                "Error during group membership validation: {ErrorMessage}");
-
-        // Add new LoggerMessage delegates for AcquireDomainPasswordLength
-        private static readonly Action<ILogger, Exception?> LogPasswordLengthRetrievalError =
-            LoggerMessage.Define(
-                LogLevel.Error,
-                new EventId(121, "PasswordLengthRetrievalError"),
-                "Error retrieving domain password length policy from Active Directory. Defaulting to 6.");
-
-        private static readonly Action<ILogger, Exception?> LogPasswordLengthRetrievalWarning =
-            LoggerMessage.Define(
-                LogLevel.Warning,
-                new EventId(122, "PasswordLengthRetrievalWarning"),
-                "Could not retrieve 'minPwdLength' from Active Directory or property value was not an integer. Defaulting to 6.");
-
-        // Add new LoggerMessage delegates for AcquirePrincipalContext
-        private static readonly Action<ILogger, Exception?> LogPrincipalContextCreationFailedError =
-            LoggerMessage.Define(
-                LogLevel.Error,
-                new EventId(123, "PrincipalContextCreationFailedError"),
-                "Error creating PrincipalContext with provided LDAP settings.");
-
-        private static readonly Action<ILogger, Exception?> LogLdapHostnamesNotConfiguredWarning =
-            LoggerMessage.Define(
-                LogLevel.Warning,
-                new EventId(124, "LdapHostnamesNotConfiguredWarning"),
-                "LDAP Hostnames are not configured when UseAutomaticContext is false. PrincipalContext cannot be created.");
-
-        // Add new LoggerMessage delegates for GetDirectoryEntry
-        private static readonly Action<ILogger, Exception?> LogLdapHostnamesEmptyWarning =
-            LoggerMessage.Define(
-                LogLevel.Warning,
-                new EventId(125, "LdapHostnamesEmptyWarning"),
-                "LDAP Hostnames are not configured. Cannot create DirectoryEntry.");
-
-        private static readonly Action<ILogger, Exception?> LogDirectoryEntryCreationFailedError =
-            LoggerMessage.Define(
-                LogLevel.Error,
-                new EventId(126, "DirectoryEntryCreationFailedError"),
-                "Error creating DirectoryEntry with provided LDAP settings.");
-
-        // LoggerMessage delegates for PwnedPasswordCheckAsync
-        private static readonly Action<ILogger, string, Exception?> LogPwnedPasswordCheckApiError =
-            LoggerMessage.Define<string>(
-                LogLevel.Warning,
-                new EventId(205, "PwnedPasswordCheckApiError"),
-                "Error during Pwned Password API check: {ErrorMessage}");
-
-        private static readonly Action<ILogger, string, Exception?> LogPwnedPasswordCheckUnexpectedError =
-            LoggerMessage.Define<string>(LogLevel.Error,
-            new EventId(206, "PwnedPasswordCheckUnexpectedError"),
-            "Unexpected error during Pwned Password check: {ErrorMessage}");
-
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PasswordChangeProvider"/> class.
@@ -228,233 +37,81 @@ namespace Unosquare.PassCore.PasswordProvider
         /// </summary>
         /// <param name="logger">The logger interface for logging events within this provider.</param>
         /// <param name="options">The options configuration for password change operations, injected through IOptions.</param>
+        /// <param name="policies">The password policies.</param>
         public PasswordChangeProvider(
             ILogger<PasswordChangeProvider> logger,
             IOptions<PasswordChangeOptions> options,
-            IPwnedPasswordSearch pwnedPasswordSearch)
+            IEnumerable<IPasswordPolicy> policies)
+            : base(logger, policies)
         {
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _options = (options?.Value) ?? throw new ArgumentNullException(nameof(options));
-            _pwnedPasswordSearch = pwnedPasswordSearch ?? throw new ArgumentNullException(nameof(pwnedPasswordSearch));
+            ArgumentNullException.ThrowIfNull(logger);
+            ArgumentNullException.ThrowIfNull(options);
+            _options = options.Value;
             SetIdType(); // Determine IdentityType from options
         }
 
-
-
         /// <inheritdoc />
-        /// <summary>
-        /// Executes the password change operation for a given user.
-        /// This is the main entry point for changing a user's password. It performs several validations
-        /// before attempting to update the password in Active Directory.
-        /// </summary>
-        /// <param name="username">The username of the account to change the password for.</param>
-        /// <param name="currentPassword">The user's current password, required for password change validation.</param>
-        /// <param name="newPassword">The new password to set for the user.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>An <see cref="ApiErrorItem"/> if the password change fails, otherwise null for success.</returns>
-        public async Task<ApiErrorItem?> PerformPasswordChangeAsync(string username, string currentPassword, string newPassword, System.Threading.CancellationToken cancellationToken = default)
+        protected override async Task ChangePasswordCore(PasswordChangeContext context, CancellationToken cancellationToken)
         {
-            ApiErrorItem? errorItem = null; // Initialize error item to null (success case)
+            ArgumentNullException.ThrowIfNull(context);
 
-            try
-            {
-                if (username is null)
-                    throw new ArgumentNullException(nameof(username));
-                if (currentPassword is null)
-                    throw new ArgumentNullException(nameof(currentPassword));
-                if (newPassword is null)
-                    throw new ArgumentNullException(nameof(newPassword));
+            var fixedUsername = FixUsernameWithDomain(context.Username);
 
-                var fixedUsername = FixUsernameWithDomain(username); // Ensure username is correctly formatted with domain if needed
-                LogPerformingPasswordChange(_logger, fixedUsername, null);
+            using var principalContext = AcquirePrincipalContext(); // Acquire PrincipalContext for AD operations, using 'using' for automatic disposal
+            var userPrincipal = UserPrincipal.FindByIdentity(principalContext, _idType, fixedUsername); // Find the UserPrincipal object
 
-                using var principalContext = AcquirePrincipalContext(); // Acquire PrincipalContext for AD operations, using 'using' for automatic disposal
-                var userPrincipal = UserPrincipal.FindByIdentity(principalContext, _idType, fixedUsername); // Find the UserPrincipal object
-
-                errorItem = ValidateUserPrincipal(userPrincipal, fixedUsername); // Validate if user principal is found
-                if (errorItem != null) return errorItem; // Return immediately if validation fails
-
-                errorItem = ValidateNewPasswordComplexity(newPassword); // Validate new password against complexity rules
-                if (errorItem != null) return errorItem; // Return immediately if validation fails
-
-                errorItem = await ValidatePwnedPassword(newPassword); // Check if the new password is in a list of pwned passwords
-                if (errorItem != null) return errorItem; // Return immediately if validation fails
-
-                errorItem = ValidateGroupsMembership(userPrincipal); // Validate user's group membership against allowed/restricted groups
-                if (errorItem != null) return errorItem; // Return immediately if validation fails
-
-                errorItem = ValidatePasswordChangePermissions(userPrincipal); // Validate if user has permission to change password
-                if (errorItem != null) return errorItem; // Return immediately if validation fails
-
-                if (_options.UpdateLastPassword && userPrincipal.LastPasswordSet == null) // Check if 'UpdateLastPassword' option is enabled and LastPasswordSet is null
-                {
-                    errorItem = SetLastPassword(userPrincipal); // Update the 'pwdLastSet' attribute if conditions are met
-                    if (errorItem != null) return errorItem; // Return immediately if setting LastPassword fails
-                }
-
-                if (!ValidateUserCredentials(userPrincipal.UserPrincipalName, currentPassword, principalContext)) // Validate provided current password
-                {
-                    LogInvalidCurrentPassword(_logger, fixedUsername, null);
-                    return new ApiErrorItem(ApiErrorCode.InvalidCredentials); // Return error if current password is invalid
-                }
-
-                UpdatePassword(currentPassword, newPassword, userPrincipal); // Attempt to update the password
-
-                userPrincipal.Save(); // Save changes to Active Directory
-                LogPasswordSuccessfullyUpdated(_logger, fixedUsername, null);
-            }
-            catch (PasswordException passwordEx) // Catch exceptions related to password complexity policies
-            {
-                errorItem = new ApiErrorItem(ApiErrorCode.ComplexPassword, passwordEx.Message);
-                LogPasswordChangeComplexityError(_logger, errorItem.Message ?? "Unknown error", passwordEx.Message, passwordEx);
-            }
-            catch (ApiErrorException apiErrorEx) // Catch custom API error exceptions
-            {
-                errorItem = apiErrorEx.ToApiErrorItem();
-                LogPasswordChangeApiError(_logger, errorItem.Message ?? "Unknown error", apiErrorEx.Message, apiErrorEx);
-            }
-            catch (Exception ex) // Catch any other unexpected exceptions
-            {
-                errorItem = new ApiErrorItem(ApiErrorCode.Generic, ex.InnerException?.Message ?? ex.Message);
-                LogPasswordChangeUnexpectedError(_logger, errorItem.Message ?? "Unknown error", ex.InnerException?.Message ?? ex.Message, ex);
-            }
-
-            return errorItem; // Return the error item, which will be null on success
-        }
-
-        /// <summary>
-        /// Validates that the UserPrincipal object is not null.
-        /// </summary>
-        /// <param name="userPrincipal">The UserPrincipal object to validate.</param>
-        /// <param name="fixedUsername">The username (used for logging purposes).</param>
-        /// <returns>An <see cref="ApiErrorItem"/> if the UserPrincipal is null (user not found), otherwise null.</returns>
-        private ApiErrorItem? ValidateUserPrincipal(UserPrincipal? userPrincipal, string fixedUsername)
-        {
             if (userPrincipal == null) // Check if UserPrincipal is null
             {
-                LogUserPrincipalNotFound(_logger, fixedUsername, null);
-                return new ApiErrorItem(ApiErrorCode.UserNotFound); // Return UserNotFound error
+                throw new UserNotFoundException();
             }
-            return null; // UserPrincipal is valid
-        }
 
-        /// <summary>
-        /// Validates the new password against the minimum password length policy of the domain.
-        /// </summary>
-        /// <param name="newPassword">The new password to validate.</param>
-        /// <returns>An <see cref="ApiErrorItem"/> if the new password is too short, otherwise null.</returns>
-        private ApiErrorItem? ValidateNewPasswordComplexity(string newPassword)
-        {
-            var minPasswordLength = AcquireDomainPasswordLength(); // Get minimum password length from domain policy
-            if (newPassword.Length < minPasswordLength) // Check if new password length is less than the minimum
-            {
-                LogPasswordLengthTooShort(_logger, null);
-                return new ApiErrorItem(ApiErrorCode.ComplexPassword); // Return ComplexPassword error
-            }
-            return null; // Password complexity is valid (length check passed)
-        }
-
-        /// <summary>
-        /// Validates the new password against a list of known compromised passwords.
-        /// Uses the PwnedPasswordsSearch library to check if the password has been compromised.
-        /// </summary>
-        /// <param name="newPassword">The new password to validate.</param>
-        /// <returns>An <see cref="ApiErrorItem"/> if the new password is a known compromised password, otherwise null.</returns>
-        private async Task<ApiErrorItem?> ValidatePwnedPassword(string newPassword)
-        {
-            try
-            {
-                if (await _pwnedPasswordSearch.IsPwnedPasswordAsync(newPassword)) // Check if password is in pwned password list
-                {
-                    LogPwnedPasswordUsed(_logger, null);
-                    return new ApiErrorItem(ApiErrorCode.PwnedPassword); // Return PwnedPassword error
-                }
-                return null; // Password is not a known compromised password
-            }
-            catch (PwnedPasswordsApiException apiException)
-            {
-                // Log the API exception as a warning, as it's an external service issue.
-                LogPwnedPasswordCheckApiError(_logger, apiException.Message, apiException);
-                // Decide how to handle API errors. Returning null means we don't consider API errors as "pwned password" errors for validation purposes.
-                // The password validation might proceed as if the check was inconclusive in terms of pwned status due to API issue.
-                return new ApiErrorItem(ApiErrorCode.Generic, $"Error during Pwned Password API check: {apiException.Message}"); // Return PwnedPassword error
-            }
-            catch (PwnedPasswordsSearchException searchException)
-            {
-                // Log unexpected errors during the search process as errors.
-                LogPwnedPasswordCheckUnexpectedError(_logger, searchException.Message, searchException);
-                // Similar to API exceptions, it's not a "pwned password" error in the context of validation, but an internal error.
-                return new ApiErrorItem(ApiErrorCode.Generic, $"Unexpected error during Pwned Password search: {searchException.Message}");
-            }
-            catch (Exception unexpectedException)
-            {
-                // Catch any other unexpected exceptions (although ideally, only the custom exceptions should be thrown).
-                // Log as a critical error as it's something unexpected in the validation process.
-                LogPwnedPasswordCheckUnexpectedError(_logger, unexpectedException.Message, unexpectedException);
-                return new ApiErrorItem(ApiErrorCode.Generic, $"Unexpected error during Pwned Password search: {unexpectedException.Message}");
-            }
-        }
-
-        /// <summary>
-        /// Validates the user's group membership against configured allowed and restricted Active Directory groups.
-        /// Password change is permitted only if the user is a member of an allowed group (if allowed groups are configured)
-        /// and not a member of any restricted group (if restricted groups are configured).
-        /// </summary>
-        /// <param name="userPrincipal">The UserPrincipal object of the user.</param>
-        /// <returns>An <see cref="ApiErrorItem"/> if group membership validation fails, otherwise null.</returns>
-        private ApiErrorItem? ValidateGroupsMembership(UserPrincipal userPrincipal)
-        {
-            try
-            {
-                System.Collections.Generic.List<Principal> groups; // Collection to hold user's groups
-                try
-                {
-                    groups = userPrincipal.GetGroups().ToList(); // Attempt to retrieve groups using GetGroups (faster in some scenarios)
-                }
-                catch (Exception exception) // Catch exceptions during group retrieval
-                {
-                    LogErrorRetrievingGroups(_logger, exception.Message, exception);
-                    groups = userPrincipal.GetAuthorizationGroups().ToList(); // Fallback to GetAuthorizationGroups if GetGroups fails (more reliable for cross-domain groups)
-                }
-
-                // Check for restricted group membership
-                if (_options.RestrictedAdGroups != null && _options.RestrictedAdGroups.Any() && groups.Any(group => _options.RestrictedAdGroups.Contains(group.Name)))
-                {
-                    return new ApiErrorItem(ApiErrorCode.ChangeNotPermitted, "User is a member of a restricted group and password change is not permitted."); // Return error if in restricted group
-                }
-
-                // Check for allowed group membership (only if allowed groups are configured)
-                // If AllowedAdGroups is null or empty, allow password change for all users not in restricted groups
-                if (_options.AllowedAdGroups != null && _options.AllowedAdGroups.Any())
-                {
-                    if (!groups.Any(group => _options.AllowedAdGroups.Contains(group.Name))) // Check if user is a member of at least one allowed group
-                    {
-                        return new ApiErrorItem(ApiErrorCode.ChangeNotPermitted, "User is not a member of any allowed group and password change is not permitted."); // Return error if not in any allowed group
-                    }
-                }
-
-                return null; // User is authorized based on group membership
-            }
-            catch (Exception exception) // Catch any exceptions during group validation
-            {
-                LogErrorGroupValidation(_logger, exception.Message, exception);
-                return new ApiErrorItem(ApiErrorCode.Generic, "Error during group membership validation."); // Return error item to indicate validation failure
-            }
-        }
-
-        /// <summary>
-        /// Validates if the user is permitted to change their password based on the 'UserCannotChangePassword' flag in Active Directory.
-        /// </summary>
-        /// <param name="userPrincipal">The UserPrincipal object of the user.</param>
-        /// <returns>An <see cref="ApiErrorItem"/> if the user is not permitted to change their password, otherwise null.</returns>
-        private ApiErrorItem? ValidatePasswordChangePermissions(UserPrincipal userPrincipal)
-        {
             if (userPrincipal.UserCannotChangePassword) // Check if the UserCannotChangePassword flag is set
             {
-                LogPasswordChangeNotPermittedFlag(_logger, null);
-                return new ApiErrorItem(ApiErrorCode.ChangeNotPermitted); // Return ChangeNotPermitted error
+                throw new PasswordPolicyViolationException("User cannot change password", ApiErrorCode.ChangeNotPermitted);
             }
-            return null; // User is permitted to change password
+
+            if (_options.UpdateLastPassword && userPrincipal.LastPasswordSet == null) // Check if 'UpdateLastPassword' option is enabled and LastPasswordSet is null
+            {
+                SetLastPassword(userPrincipal); // Update the 'pwdLastSet' attribute if conditions are met
+            }
+
+            if (!ValidateUserCredentials(userPrincipal.UserPrincipalName, context.CurrentPassword, principalContext)) // Validate provided current password
+            {
+                throw new InvalidCredentialsException();
+            }
+
+            UpdatePassword(context.CurrentPassword, context.NewPassword, userPrincipal); // Attempt to update the password
+
+            userPrincipal.Save(); // Save changes to Active Directory
+        }
+
+        /// <inheritdoc />
+        public Task<int> GetMinimumLengthAsync()
+        {
+            return Task.FromResult(AcquireDomainPasswordLength());
+        }
+
+        /// <inheritdoc />
+        public Task<bool> IsMemberOfGroupAsync(string username, string groupName)
+        {
+            using var principalContext = AcquirePrincipalContext();
+            var userPrincipal = UserPrincipal.FindByIdentity(principalContext, _idType, FixUsernameWithDomain(username));
+            if (userPrincipal == null) return Task.FromResult(false);
+
+            try
+            {
+                var groups = userPrincipal.GetGroups();
+                if (groups.Any(group => group.Name.Equals(groupName, StringComparison.OrdinalIgnoreCase)))
+                    return Task.FromResult(true);
+            }
+            catch
+            {
+                var groups = userPrincipal.GetAuthorizationGroups();
+                if (groups.Any(group => group.Name.Equals(groupName, StringComparison.OrdinalIgnoreCase)))
+                    return Task.FromResult(true);
+            }
+
+            return Task.FromResult(false);
         }
 
         /// <summary>
@@ -486,7 +143,6 @@ namespace Unosquare.PassCore.PasswordProvider
 
             // Check for specific error codes indicating password expiration or must change scenarios
             var errorCode = System.Runtime.InteropServices.Marshal.GetLastWin32Error(); // Get the last Win32 error code
-            LogValidateCredentialsWin32Error(_logger, errorCode, null);
 
             // Return true if error code indicates password must change or is expired (treat these as valid for password change process)
             return errorCode is NativeMethods.ErrorPasswordMustChange or NativeMethods.ErrorPasswordExpired;
@@ -512,28 +168,24 @@ namespace Unosquare.PassCore.PasswordProvider
         /// This is used when the 'UpdateLastPassword' option is enabled and the LastPasswordSet is null.
         /// </summary>
         /// <param name="userPrincipal">The UserPrincipal object for which to set the 'pwdLastSet' attribute.</param>
-        private ApiErrorItem? SetLastPassword(Principal userPrincipal)
+        private void SetLastPassword(Principal userPrincipal)
         {
             var directoryEntry = (DirectoryEntry)userPrincipal.GetUnderlyingObject(); // Get the underlying DirectoryEntry object
             var pwdLastSetProperty = directoryEntry.Properties["pwdLastSet"]; // Get the 'pwdLastSet' property
 
             if (pwdLastSetProperty == null) // Check if 'pwdLastSet' property exists
             {
-                LogPwdLastSetMissing(_logger, null);
-                return new ApiErrorItem(ApiErrorCode.Generic, "The 'pwdLastSet' property is missing on the user principal."); // Return error item to indicate failure
+                throw new PasswordPolicyViolationException("The 'pwdLastSet' property is missing on the user principal.", ApiErrorCode.Generic);
             }
 
             try
             {
                 pwdLastSetProperty.Value = -1; // Set 'pwdLastSet' to -1 to force password change at next logon
                 directoryEntry.CommitChanges(); // Commit changes to Active Directory
-                LogPwdLastSetUpdated(_logger, null);
-                return null; // Indicate success
             }
-            catch (Exception ex) // Catch exceptions during attribute update
+            catch (Exception) // Catch exceptions during attribute update
             {
-                LogPwdLastSetUpdateFailed(_logger, ex.Message, ex);
-                return new ApiErrorItem(ApiErrorCode.ChangeNotPermitted, "Failed to update 'pwdLastSet' attribute."); // Return error item to indicate failure
+                throw new PasswordPolicyViolationException("Failed to update 'pwdLastSet' attribute.", ApiErrorCode.ChangeNotPermitted);
             }
         }
 
@@ -553,22 +205,19 @@ namespace Unosquare.PassCore.PasswordProvider
             {
                 userPrincipal.ChangePassword(currentPassword, newPassword); // Attempt to change password using ChangePassword method (preferred method)
             }
-            catch (Exception changePasswordException) // Catch exceptions during ChangePassword operation
+            catch (Exception) // Catch exceptions during ChangePassword operation
             {
                 if (_options.UseAutomaticContext) // If AutomaticContext is enabled, ChangePassword failure is critical
                 {
-                    LogChangePasswordAutomaticContextFailed(_logger, changePasswordException.Message, changePasswordException);
                     throw; // Re-throw the original exception - Password update is aborted in AutomaticContext mode if ChangePassword fails
                 }
 
                 try // Attempt to use SetPassword as a fallback if ChangePassword fails and AutomaticContext is disabled
                 {
                     userPrincipal.SetPassword(newPassword); // Fallback to SetPassword method if ChangePassword fails
-                    LogPasswordUpdatedSetPasswordFallback(_logger, changePasswordException);
                 }
-                catch (Exception setPasswordException) // Catch exceptions during SetPassword operation
+                catch (Exception) // Catch exceptions during SetPassword operation
                 {
-                    LogSetPasswordFailed(_logger, setPasswordException.Message, setPasswordException);
                     throw; // Re-throw the SetPassword exception as password update ultimately failed
                 }
             }
@@ -590,7 +239,6 @@ namespace Unosquare.PassCore.PasswordProvider
                 "securityidentifier" or "securityid" or "secid" or "security identifier" or "sid" => IdentityType.Sid,
                 _ => IdentityType.UserPrincipalName // Default to UserPrincipalName if no match or invalid input
             };
-            LogIdentityTypeSet(_logger, _idType, null);
         }
 
         /// <summary>
@@ -605,20 +253,16 @@ namespace Unosquare.PassCore.PasswordProvider
         {
             if (_options.UseAutomaticContext) // Check if automatic context is enabled
             {
-                LogAutomaticDomainContext(_logger, null); // Using existing delegate
                 return new PrincipalContext(ContextType.Domain); // Create PrincipalContext using automatic domain context
             }
             else
             {
                 if (!_options.LdapHostnames.Any()) // Check if LdapHostnames is empty when not using automatic context
                 {
-                    // Using logging delegate for warning about missing LDAP Hostnames
-                    LogLdapHostnamesNotConfiguredWarning(_logger, null);
                     throw new InvalidOperationException("LDAP Hostnames are not configured."); // Throw exception to signal configuration error
                 }
 
                 var domain = $"{_options.LdapHostnames.First()}:{_options.LdapPort}"; // Construct domain string from hostname and port
-                LogDomainContext(_logger, domain, null); // Using existing delegate
                 try
                 {
                     return new PrincipalContext( // Create PrincipalContext with LDAP credentials
@@ -629,8 +273,6 @@ namespace Unosquare.PassCore.PasswordProvider
                 }
                 catch (Exception ex)
                 {
-                    // Using logging delegate for error during PrincipalContext creation
-                    LogPrincipalContextCreationFailedError(_logger, ex);
                     throw new InvalidOperationException("Failed to create PrincipalContext.", ex); // Re-throw exception to signal failure
                 }
             }
@@ -657,15 +299,11 @@ namespace Unosquare.PassCore.PasswordProvider
                 }
                 else
                 {
-                    // Using logging delegate for warning about missing/invalid property
-                    LogPasswordLengthRetrievalWarning(_logger, null);
                     return 6; // Default minimum password length
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                // Using logging delegate for error during retrieval
-                LogPasswordLengthRetrievalError(_logger, ex);
                 return 6; // Default minimum password length in case of exception
             }
             finally
@@ -685,13 +323,10 @@ namespace Unosquare.PassCore.PasswordProvider
         {
             if (!_options.LdapHostnames.Any()) // Check if LdapHostnames is empty
             {
-                // Use logging delegate for warning about missing LDAP Hostnames
-                LogLdapHostnamesEmptyWarning(_logger, null);
                 return null; // Return null to indicate failure to create DirectoryEntry
             }
 
             var domain = $"{_options.LdapHostnames.First()}:{_options.LdapPort}"; // Construct domain string
-            LogCreatingDirectoryEntry(_logger, domain, null); // Already using delegate
             try
             {
                 return new DirectoryEntry( // Create DirectoryEntry with LDAP credentials
@@ -699,10 +334,8 @@ namespace Unosquare.PassCore.PasswordProvider
                     _options.LdapUsername,
                     _options.LdapPassword);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                // Use logging delegate for error during DirectoryEntry creation
-                LogDirectoryEntryCreationFailedError(_logger, ex);
                 return null; // Return null if DirectoryEntry creation fails
             }
         }

--- a/src/Unosquare.PassCore.Web/Controllers/PasswordController.cs
+++ b/src/Unosquare.PassCore.Web/Controllers/PasswordController.cs
@@ -1,11 +1,16 @@
-﻿using Unosquare.PassCore.Web.Helpers;
+using Unosquare.PassCore.Web.Helpers;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Unosquare.PassCore.Common;
+using Unosquare.PassCore.Common.Models;
 using Unosquare.PassCore.Web.Models;
 using System.Text.Json;
 using System.Net.Http;
 using Zxcvbn;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Unosquare.PassCore.Web.Controllers;
 
@@ -26,6 +31,7 @@ public class PasswordController : Controller
     /// <param name="logger">The logger.</param>
     /// <param name="optionsAccessor">The options accessor.</param>
     /// <param name="passwordChangeProvider">The password change provider.</param>
+    /// <param name="httpClientFactory">The HTTP client factory.</param>
     public PasswordController(
         ILogger<PasswordController> logger,
         IOptions<ClientSettings> optionsAccessor,
@@ -89,28 +95,14 @@ public class PasswordController : Controller
 
         try
         {
-            if (_options.MinimumDistance > 0 &&
-                _passwordChangeProvider.MeasureNewPasswordDistance(model.CurrentPassword, model.NewPassword) < _options.MinimumDistance)
-            {
-                result.Errors.Add(new ApiErrorItem(ApiErrorCode.MinimumDistance));
-                return BadRequest(result);
-            }
+            var context = new PasswordChangeContext(model.Username, model.CurrentPassword, model.NewPassword, _options);
+            var resultPasswordChange = await _passwordChangeProvider.ChangePasswordAsync(context);
 
-            if (_options.MinimumScore > 0 && Core.EvaluatePassword(model.NewPassword).Score < _options.MinimumScore)
-            {
-                result.Errors.Add(new ApiErrorItem(ApiErrorCode.MinimumScore));
-                return BadRequest(result);
-            }
-
-            var resultPasswordChange = await _passwordChangeProvider.PerformPasswordChangeAsync(
-                model.Username,
-                model.CurrentPassword,
-                model.NewPassword);
-
-            if (resultPasswordChange == null)
+            if (resultPasswordChange.IsSuccess)
                 return Json(result);
 
-            result.Errors.Add(resultPasswordChange);
+            if (resultPasswordChange.Error != null)
+                result.Errors.Add(resultPasswordChange.Error);
         }
         catch (HttpRequestException ex)
         {

--- a/src/Unosquare.PassCore.Web/Program.cs
+++ b/src/Unosquare.PassCore.Web/Program.cs
@@ -2,10 +2,14 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+using Unosquare.PassCore.Common.Models;
 using Unosquare.PassCore.Web.Models;
 using Unosquare.PassCore.Common;
+using Unosquare.PassCore.Common.Policies;
 using PwnedPasswordsSearch;
 using System.Net.Http.Headers;
+using System;
+
 #if DEBUG
 using Unosquare.PassCore.PasswordProvider.Debug;
 #elif PASSCORE_LDAP_PROVIDER
@@ -33,6 +37,13 @@ builder.Services.AddHttpClient("PwnedPasswords", client =>
 });
 
 builder.Services.AddSingleton<IPwnedPasswordSearch, PwnedSearch>();
+
+// Register Policies
+builder.Services.AddSingleton<IPasswordPolicy, PwnedPasswordPolicy>();
+builder.Services.AddSingleton<IPasswordPolicy, LengthPasswordPolicy>();
+builder.Services.AddSingleton<IPasswordPolicy, ComplexityPasswordPolicy>();
+builder.Services.AddSingleton<IPasswordPolicy, DistancePasswordPolicy>();
+builder.Services.AddSingleton<IPasswordPolicy, GroupMembershipPolicy>();
 
 #if DEBUG
 if (builder.Environment.IsProduction())

--- a/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeProvider.cs
+++ b/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeProvider.cs
@@ -1,15 +1,18 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Novell.Directory.Ldap;
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Unosquare.PassCore.Common;
+using Unosquare.PassCore.Common.Exceptions;
 using LdapRemoteCertificateValidationCallback =
     Novell.Directory.Ldap.RemoteCertificateValidationCallback;
 
@@ -19,10 +22,9 @@ namespace Zyborg.PassCore.PasswordProvider.LDAP;
 /// Represents a LDAP password change provider using Novell LDAP Connection.
 /// </summary>
 /// <seealso cref="IPasswordChangeProvider" />
-public class LdapPasswordChangeProvider : IPasswordChangeProvider
+public class LdapPasswordChangeProvider : PasswordChangeProviderBase
 {
     private readonly LdapPasswordChangeOptions _options;
-    private readonly ILogger _logger;
 
     // First find user DN by username (SAM Account Name)
     private readonly LdapSearchConstraints _searchConstraints = new(
@@ -44,38 +46,28 @@ public class LdapPasswordChangeProvider : IPasswordChangeProvider
     /// </summary>
     /// <param name="logger">The logger.</param>
     /// <param name="options">The _options.</param>
+    /// <param name="policies">The password policies.</param>
     public LdapPasswordChangeProvider(
-        ILogger logger,
-        IOptions<LdapPasswordChangeOptions> options)
+        ILogger<LdapPasswordChangeProvider> logger,
+        IOptions<LdapPasswordChangeOptions> options,
+        IEnumerable<IPasswordPolicy> policies)
+        : base(logger, policies)
     {
-        _logger = logger;
+        ArgumentNullException.ThrowIfNull(options);
         _options = options.Value;
         Init();
     }
 
     /// <inheritdoc />
-    /// <remarks>
-    /// Based on:
-    ///    * https://www.cs.bham.ac.uk/~smp/resources/ad-passwds/
-    ///    * https://support.microsoft.com/en-us/help/269190/how-to-change-a-windows-active-directory-and-lds-user-password-through
-    ///    * https://ltb-project.org/documentation/self-service-password/latest/config_ldap#active_directory
-    ///    * https://technet.microsoft.com/en-us/library/ff848710.aspx?f=255&amp;MSPPError=-2147217396
-    ///
-    /// Check the above links for more information.
-    /// </remarks>
-    public Task<ApiErrorItem?> PerformPasswordChangeAsync(
-        string username,
-        string currentPassword,
-        string newPassword,
-        System.Threading.CancellationToken cancellationToken = default)
+    protected override Task ChangePasswordCore(PasswordChangeContext context, CancellationToken cancellationToken)
     {
+        ArgumentNullException.ThrowIfNull(context);
+
         try
         {
-            var cleanUsername = CleaningUsername(username);
+            var cleanUsername = CleaningUsername(context.Username);
 
-            var searchFilter = _options.LdapSearchFilter.Replace("{Username}", cleanUsername);
-
-            _logger.LogWarning("LDAP query: {0}", searchFilter);
+            var searchFilter = _options.LdapSearchFilter.Replace("{Username}", cleanUsername, StringComparison.Ordinal);
 
             using var ldap = BindToLdap();
             var search = ldap.Search(
@@ -91,31 +83,28 @@ public class LdapPasswordChangeProvider : IPasswordChangeProvider
             // but fortunately hasMore seems to block until final result
             if (!search.HasMore())
             {
-                _logger.LogWarning("Unable to find username: [{0}]", cleanUsername);
+                if (_options.HideUserNotFound)
+                    throw new InvalidCredentialsException();
 
-                return Task.FromResult<ApiErrorItem?>(new ApiErrorItem(
-                    _options.HideUserNotFound ? ApiErrorCode.InvalidCredentials : ApiErrorCode.UserNotFound,
-                    _options.HideUserNotFound ? "Invalid credentials" : "Username could not be located"));
+                throw new UserNotFoundException("Username could not be located");
             }
 
             if (search.Count > 1)
             {
-                _logger.LogWarning("Found multiple with same username: [{0}] - Count {1}", cleanUsername, search.Count);
-
                 // Hopefully this should not ever happen if AD is preserving SAM Account Name
                 // uniqueness constraint, but just in case, handling this corner case
-                return Task.FromResult<ApiErrorItem?>(new ApiErrorItem(ApiErrorCode.UserNotFound, "Multiple matching user entries resolved"));
+                throw new UserNotFoundException("Multiple matching user entries resolved");
             }
 
             var userDN = search.Next().Dn;
 
             if (_options.LdapChangePasswordWithDelAdd)
             {
-                ChangePasswordDelAdd(currentPassword, newPassword, ldap, userDN);
+                ChangePasswordDelAdd(context.CurrentPassword, context.NewPassword, ldap, userDN);
             }
             else
             {
-                ChangePasswordReplace(newPassword, ldap, userDN);
+                ChangePasswordReplace(context.NewPassword, ldap, userDN);
             }
 
             if (_options.LdapStartTls)
@@ -125,26 +114,17 @@ public class LdapPasswordChangeProvider : IPasswordChangeProvider
         }
         catch (LdapException ex)
         {
-            var item = ParseLdapException(ex);
-
-            _logger.LogWarning(item.Message, ex);
-
-            return Task.FromResult<ApiErrorItem?>(item);
+            throw TranslateLdapException(ex);
         }
         catch (ApiErrorException ex)
         {
-            var item = ex.ToApiErrorItem();
-
-            _logger.LogWarning(item.Message, ex);
-
-            return Task.FromResult<ApiErrorItem?>(item);
+            throw new PasswordPolicyViolationException(ex.Message, ex.ErrorCode);
         }
 
-        // Everything seems to have worked:
-        return Task.FromResult<ApiErrorItem?>(null);
+        return Task.CompletedTask;
     }
 
-    private static void ChangePasswordReplace(string newPassword, ILdapConnection ldap, string userDN)
+    private static void ChangePasswordReplace(string newPassword, LdapConnection ldap, string userDN)
     {
         // If you don't have the rights to Add and/or Delete the Attribute, you might have the right to change the password-attribute.
         // In this case uncomment the next 2 lines and comment the region 'Change Password by Delete/Add'
@@ -153,7 +133,7 @@ public class LdapPasswordChangeProvider : IPasswordChangeProvider
         ldap.Modify(userDN, new[] { ldapReplace }); // Change with Replace
     }
 
-    private static void ChangePasswordDelAdd(string currentPassword, string newPassword, ILdapConnection ldap, string userDN)
+    private static void ChangePasswordDelAdd(string currentPassword, string newPassword, LdapConnection ldap, string userDN)
     {
         var oldPassBytes = Encoding.Unicode.GetBytes($@"""{currentPassword}""");
         var newPassBytes = Encoding.Unicode.GetBytes($@"""{newPassword}""");
@@ -166,7 +146,7 @@ public class LdapPasswordChangeProvider : IPasswordChangeProvider
         ldap.Modify(userDN, new[] { ldapDel, ldapAdd }); // Change with Delete/Add
     }
 
-    private static ApiErrorItem ParseLdapException(LdapException ex)
+    private static Exception TranslateLdapException(LdapException ex)
     {
         // If the LDAP server returned an error, it will be formatted
         // similar to this:
@@ -175,30 +155,32 @@ public class LdapPasswordChangeProvider : IPasswordChangeProvider
         // The leading number before the ':' is the Win32 API Error Code in HEX
         if (ex.LdapErrorMessage == null)
         {
-            return new ApiErrorItem(ApiErrorCode.LdapProblem, "Unexpected null exception");
+            return new DirectoryUnavailableException("Unexpected null exception", ex);
         }
 
-        var m = Regex.Match(ex.LdapErrorMessage, "([0-9a-fA-F]+):");
+        var m = Regex.Match(ex.LdapErrorMessage, "([0-9a-fA-F]+):", RegexOptions.None, TimeSpan.FromMilliseconds(100));
 
         if (!m.Success)
         {
-            return new ApiErrorItem(ApiErrorCode.LdapProblem, $"Unexpected error: {ex.LdapErrorMessage}");
+            return new DirectoryUnavailableException($"Unexpected error: {ex.LdapErrorMessage}", ex);
         }
 
         var errCodeString = m.Groups[1].Value;
         var errCode = int.Parse(errCodeString, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
         var err = Win32ErrorCode.ByCode(errCode);
 
-        return err == null
-            ? new ApiErrorItem(ApiErrorCode.LdapProblem, $"Unexpected Win32 API error; error code: {errCodeString}")
-            : new ApiErrorItem(ApiErrorCode.InvalidCredentials,
-                $"Resolved Win32 API Error: code={err.Code} name={err.CodeName} desc={err.Description}");
+        if (err == null)
+        {
+            return new DirectoryUnavailableException($"Unexpected Win32 API error; error code: {errCodeString}", ex);
+        }
+
+        return new InvalidCredentialsException($"Resolved Win32 API Error: code={err.Code} name={err.CodeName} desc={err.Description}");
     }
 
     private string CleaningUsername(string username)
     {
         var cleanUsername = username;
-        var index = cleanUsername.IndexOf("@", StringComparison.Ordinal);
+        var index = cleanUsername.IndexOf('@', StringComparison.Ordinal);
         if (index >= 0)
             cleanUsername = cleanUsername[..index];
 
@@ -224,18 +206,16 @@ public class LdapPasswordChangeProvider : IPasswordChangeProvider
 
         while (escapeIndex >= 0)
         {
-            buff.Append(cleanUsername.Substring(copyFrom, escapeIndex));
+            buff.Append(cleanUsername.AsSpan(copyFrom, escapeIndex - copyFrom));
             buff.Append($"\\{cleanUsername[escapeIndex]:X}");
             copyFrom = escapeIndex + 1;
             escapeIndex = cleanUsername.IndexOfAny(escape, copyFrom);
         }
 
         if (copyFrom < maxLen)
-            buff.Append(cleanUsername.Substring(copyFrom));
-        cleanUsername = buff.ToString();
-        _logger.LogWarning("Had to clean username: [{0}] => [{1}]", username, cleanUsername);
+            buff.Append(cleanUsername.AsSpan(copyFrom));
 
-        return cleanUsername;
+        return buff.ToString();
     }
 
     private void Init()
@@ -275,30 +255,14 @@ public class LdapPasswordChangeProvider : IPasswordChangeProvider
                 nameof(_options.LdapSearchFilter));
         }
 
-        if (!_options.LdapSearchFilter.Contains("{Username}"))
+        if (!_options.LdapSearchFilter.Contains("{Username}", StringComparison.Ordinal))
         {
             throw new ArgumentException(
                 $"The {nameof(_options.LdapSearchFilter)} should include {{Username}} value in the template string",
                 nameof(_options.LdapSearchFilter));
         }
-
-        // All other configuration is optional, but some may warrant attention
-        if (!_options.HideUserNotFound)
-            _logger.LogWarning($"Option [{nameof(_options.HideUserNotFound)}] is DISABLED; the presence or absence of usernames can be harvested");
-
-        if (_options.LdapIgnoreTlsErrors)
-            _logger.LogWarning($"Option [{nameof(_options.LdapIgnoreTlsErrors)}] is ENABLED; invalid certificates will be allowed");
-        else if (_options.LdapIgnoreTlsValidation)
-            _logger.LogWarning($"Option [{nameof(_options.LdapIgnoreTlsValidation)}] is ENABLED; untrusted certificate roots will be allowed");
-
-        if (_options.LdapPort == LdapConnection.DefaultSslPort && !_options.LdapSecureSocketLayer)
-            _logger.LogWarning($"Option [{nameof(_options.LdapSecureSocketLayer)}] is DISABLED in combination with standard SSL port [{_options.LdapPort}]");
-
-        if (_options.LdapPort != LdapConnection.DefaultSslPort && !_options.LdapStartTls)
-            _logger.LogWarning($"Option [{nameof(_options.LdapStartTls)}] is DISABLED in combination with non-standard TLS port [{_options.LdapPort}]");
     }
 
-    [Obsolete]
     private LdapConnection BindToLdap()
     {
         var ldap = new LdapConnection();
@@ -317,9 +281,9 @@ public class LdapPasswordChangeProvider : IPasswordChangeProvider
                 bindHostname = h;
                 break;
             }
-            catch (LdapException ex)
+            catch (LdapException)
             {
-                _logger.LogWarning($"Failed to connect to host [{h}]", ex);
+                // Silence connect errors here as they are retried or handled at the end
             }
         }
 

--- a/tests/Unosquare.PassCore.Common.Tests/ApiErrorMapperTests.cs
+++ b/tests/Unosquare.PassCore.Common.Tests/ApiErrorMapperTests.cs
@@ -1,0 +1,53 @@
+using System;
+using Unosquare.PassCore.Common.Exceptions;
+using Xunit;
+
+namespace Unosquare.PassCore.Common.Tests;
+
+public class ApiErrorMapperTests
+{
+    [Fact]
+    public void Map_InvalidCredentialsException()
+    {
+        var ex = new InvalidCredentialsException("Invalid");
+        var item = ApiErrorMapper.Map(ex);
+        Assert.Equal(ApiErrorCode.InvalidCredentials, item.ErrorCode);
+        Assert.Equal("Invalid", item.Message);
+    }
+
+    [Fact]
+    public void Map_PasswordPolicyViolationException()
+    {
+        var ex = new PasswordPolicyViolationException("Policy", ApiErrorCode.MinimumScore);
+        var item = ApiErrorMapper.Map(ex);
+        Assert.Equal(ApiErrorCode.MinimumScore, item.ErrorCode);
+        Assert.Equal("Policy", item.Message);
+    }
+
+    [Fact]
+    public void Map_UserNotFoundException()
+    {
+        var ex = new UserNotFoundException("Not found");
+        var item = ApiErrorMapper.Map(ex);
+        Assert.Equal(ApiErrorCode.UserNotFound, item.ErrorCode);
+        Assert.Equal("Not found", item.Message);
+    }
+
+    [Fact]
+    public void Map_DirectoryUnavailableException()
+    {
+        var ex = new DirectoryUnavailableException("Unavailable", new Exception());
+        var item = ApiErrorMapper.Map(ex);
+        Assert.Equal(ApiErrorCode.LdapProblem, item.ErrorCode);
+        Assert.Equal("Unavailable", item.Message);
+    }
+
+    [Fact]
+    public void Map_GenericException()
+    {
+        var ex = new Exception("Generic");
+        var item = ApiErrorMapper.Map(ex);
+        Assert.Equal(ApiErrorCode.Generic, item.ErrorCode);
+        Assert.Equal("Generic", item.Message);
+    }
+}

--- a/tests/Unosquare.PassCore.Common.Tests/PasswordChangeProviderBaseTests.cs
+++ b/tests/Unosquare.PassCore.Common.Tests/PasswordChangeProviderBaseTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Unosquare.PassCore.Common;
+using Unosquare.PassCore.Common.Exceptions;
+using Unosquare.PassCore.Common.Models;
+using Xunit;
+
+namespace Unosquare.PassCore.Common.Tests;
+
+public class PasswordChangeProviderBaseTests
+{
+    private class TestProvider : PasswordChangeProviderBase
+    {
+        public TestProvider(ILogger logger, IEnumerable<IPasswordPolicy> policies = null) : base(logger, policies) { }
+
+        protected override Task ChangePasswordCore(PasswordChangeContext context, CancellationToken cancellationToken)
+        {
+            if (context.Username == "fail") throw new Exception("Operation failed");
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task ChangePasswordAsync_Success()
+    {
+        var loggerMock = new Mock<ILogger>();
+        var provider = new TestProvider(loggerMock.Object);
+        var context = new PasswordChangeContext("user", "old", "new", new ClientSettings());
+
+        var result = await provider.ChangePasswordAsync(context);
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public async Task ChangePasswordAsync_ValidationFailure()
+    {
+        var loggerMock = new Mock<ILogger>();
+        var provider = new TestProvider(loggerMock.Object);
+        var context = new PasswordChangeContext("", "old", "new", new ClientSettings());
+
+        var result = await provider.ChangePasswordAsync(context);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ApiErrorCode.InvalidCredentials, result.Error.ErrorCode);
+    }
+
+    [Fact]
+    public async Task ChangePasswordAsync_PolicyFailure()
+    {
+        var loggerMock = new Mock<ILogger>();
+        var policyMock = new Mock<IPasswordPolicy>();
+        policyMock.Setup(p => p.ValidateAsync(It.IsAny<PasswordChangeContext>(), It.IsAny<IPasswordChangeProvider>()))
+            .ThrowsAsync(new PasswordPolicyViolationException("Policy failed", ApiErrorCode.MinimumScore));
+
+        var provider = new TestProvider(loggerMock.Object, new[] { policyMock.Object });
+        var context = new PasswordChangeContext("user", "old", "new", new ClientSettings());
+
+        var result = await provider.ChangePasswordAsync(context);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ApiErrorCode.MinimumScore, result.Error.ErrorCode);
+    }
+
+    [Fact]
+    public async Task ChangePasswordAsync_CoreFailure()
+    {
+        var loggerMock = new Mock<ILogger>();
+        var provider = new TestProvider(loggerMock.Object);
+        var context = new PasswordChangeContext("fail", "old", "new", new ClientSettings());
+
+        var result = await provider.ChangePasswordAsync(context);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ApiErrorCode.Generic, result.Error.ErrorCode);
+        Assert.Equal("Operation failed", result.Error.Message);
+    }
+}

--- a/tests/Unosquare.PassCore.Common.Tests/Unosquare.PassCore.Common.Tests.csproj
+++ b/tests/Unosquare.PassCore.Common.Tests/Unosquare.PassCore.Common.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Moq" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Unosquare.PassCore.Common\Unosquare.PassCore.Common.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Unosquare.PassCore.PasswordProvider.Debug.Tests/DebugPasswordChangeProviderTests.cs
+++ b/tests/Unosquare.PassCore.PasswordProvider.Debug.Tests/DebugPasswordChangeProviderTests.cs
@@ -30,7 +30,7 @@ public class DebugPasswordChangeProviderTests
     {
         var optionsMock = new Mock<IOptions<DebugProviderOptions>>();
         optionsMock.Setup(o => o.Value).Returns(_options);
-        return new DebugPasswordChangeProvider(_pwnedSearch, optionsMock.Object, _loggerMock.Object);
+        return new DebugPasswordChangeProvider(optionsMock.Object, _loggerMock.Object, Array.Empty<IPasswordPolicy>());
     }
 
     [Fact]
@@ -73,37 +73,6 @@ public class DebugPasswordChangeProviderTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal(ApiErrorCode.ChangeNotPermitted, result.ErrorCode);
-    }
-
-    [Fact]
-    public async Task PerformPasswordChangeAsync_PwnedPassword_Enabled()
-    {
-        // Arrange
-        _options.EnablePwnedCheck = true;
-        _pwnedSearch.AddPwnedPassword("pwned123");
-        var provider = CreateProvider();
-
-        // Act
-        var result = await provider.PerformPasswordChangeAsync("user", "old", "pwned123");
-
-        // Assert
-        Assert.NotNull(result);
-        Assert.Equal(ApiErrorCode.PwnedPassword, result.ErrorCode);
-    }
-
-    [Fact]
-    public async Task PerformPasswordChangeAsync_PwnedPassword_Disabled()
-    {
-        // Arrange
-        _options.EnablePwnedCheck = false;
-        _pwnedSearch.AddPwnedPassword("pwned123");
-        var provider = CreateProvider();
-
-        // Act
-        var result = await provider.PerformPasswordChangeAsync("user", "old", "pwned123");
-
-        // Assert
-        Assert.Null(result);
     }
 
     [Fact]


### PR DESCRIPTION
This PR refactors the password provider architecture to ensure strict separation of concerns, centralization of common logic (logging, validation, error mapping), and Linux CI safety.

Key changes:
1.  **Foundational Abstractions**: Created `PasswordChangeContext`, `PasswordChangeResult`, and a domain exception hierarchy (`InvalidCredentialsException`, etc.) in `Unosquare.PassCore.Common`.
2.  **Centralized Base Class**: Implemented `PasswordChangeProviderBase` which manages the password change workflow, including policy execution and logging with `OperationId`.
3.  **Policy System**: Introduced `IPasswordPolicy` and implemented concrete policies for length, complexity, distance, pwned check, and group membership. These are executed in the base class.
4.  **Provider Refactor**: Updated `Debug`, `LDAP`, and `AD` providers to inherit from the base class. They now focus solely on the core password change mechanism and translate local errors to domain exceptions.
5.  **Capability Interfaces**: Introduced `IPasswordLengthRequirement` and `IGroupMembershipTester` to allow the AD provider to expose its specific requirements to centralized policies.
6.  **Dependency Injection**: Registered all policies and updated provider constructors to receive them via DI.
7.  **Testing**: Added a new xUnit test project for `Common` logic and updated existing `Debug` provider tests. Verified all 15 tests pass on Linux.
8.  **Model Migration**: Moved `ClientSettings` and `ChangePasswordForm` to the `Common` project to avoid circular dependencies and support the refactor.

Verified build and tests pass on Linux with `PASSCORE_PROVIDER=DEBUG`.

---
*PR created automatically by Jules for task [5494937132637314244](https://jules.google.com/task/5494937132637314244) started by @ECRLib*