### PR TITLE
Harden LDAP provider: filter injection safety, AD error decoding, expired-password parity

### DIFF
--- a/src/Unosquare.PassCore.PasswordProvider.Debug/DebugPasswordChangeProvider.cs
+++ b/src/Unosquare.PassCore.PasswordProvider.Debug/DebugPasswordChangeProvider.cs
@@ -15,6 +15,14 @@ namespace Unosquare.PassCore.PasswordProvider.Debug;
 /// development and E2E scenarios. Supports forced error injection by
 /// username and simulated latency.
 /// </summary>
+/// <remarks>
+/// In addition to the configurable <see cref="DebugProviderOptions.ForcedErrors"/>
+/// map, a fixed legacy map turns a set of magic usernames (the local part,
+/// case-insensitive: "error", "invalidCredentials", "userNotFound", ...) into
+/// their matching error codes. Entries in <see cref="DebugProviderOptions.ForcedErrors"/>
+/// take precedence over the legacy map; pick usernames outside that set when a
+/// change should succeed.
+/// </remarks>
 public class DebugPasswordChangeProvider : PasswordChangeProviderBase
 {
     private static readonly IReadOnlyDictionary<string, ApiErrorCode> LegacyForcedErrors =

--- a/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeOptions.cs
+++ b/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeOptions.cs
@@ -64,6 +64,7 @@ public class LdapPasswordChangeOptions : IAppSettings
     /// <remarks>
     /// Optional, if 'true', then the specified port is a non-secured port by default
     /// and requires the use of the "StartTLS" command over LDAP to enable TLS.
+    /// Mutually exclusive with <see cref="LdapSecureSocketLayer"/>.
     /// </remarks>
     /// <value>
     ///   <c>true</c> if [LDAP start TLS]; otherwise, <c>false</c>.

--- a/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeProvider.cs
+++ b/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeProvider.cs
@@ -27,7 +27,9 @@ namespace Zyborg.PassCore.PasswordProvider.LDAP;
 ///
 /// Guarantees:
 /// - User existence is checked before authorization
-/// - User must prove knowledge of current password
+/// - User must prove knowledge of current password (on Active Directory,
+///   expired / must-change-at-next-logon passwords still count as proof)
+/// - User-supplied input cannot alter the structure of the LDAP search filter
 /// - Infrastructure failures never surface as auth or policy errors
 /// </summary>
 public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMembershipTester
@@ -35,6 +37,39 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
     private readonly LdapPasswordChangeOptions _options;
     private readonly LdapSearchConstraints _searchConstraints;
     private readonly LdapRemoteCertificateValidationCallback? _certValidator;
+
+    // Win32 error codes surfaced in Active Directory extended error messages.
+    // See Win32ErrorCode for the full catalog with descriptions.
+    private const int ErrorInvalidPassword = 0x56;
+    private const int ErrorWrongPassword = 0x52B;
+    private const int ErrorIllFormedPassword = 0x52C;
+    private const int ErrorPasswordRestriction = 0x52D;
+    private const int ErrorLogonFailure = 0x52E;
+    private const int ErrorPasswordExpired = 0x532;
+    private const int ErrorPasswordMustChange = 0x773;
+
+    // AD operation errors lead with the Win32 code, e.g.
+    // "0000052D: SvcErr: DSID-031A12D2, problem 5003 (WILL_NOT_PERFORM), data 0".
+    private static readonly Regex LeadingHexCodeRegex =
+        new("^\\s*([0-9a-fA-F]{1,8}):", RegexOptions.CultureInvariant);
+
+    // AD bind errors lead with a generic SEC_E code and carry the Win32 code
+    // in the "data" field, e.g.
+    // "80090308: LdapErr: DSID-0C0903A9, comment: AcceptSecurityContext error, data 52e, v2580".
+    private static readonly Regex DataSubCodeRegex =
+        new("\\bdata\\s+([0-9a-fA-F]+)", RegexOptions.CultureInvariant);
+
+    // Characters that are never valid in a sAMAccountName, per AD naming rules.
+    private static readonly Regex InvalidAccountNameCharsRegex =
+        new(@"[""/\\\[\]:;|=,+*?<>]", RegexOptions.CultureInvariant);
+
+    private static readonly Action<ILogger, Exception?> LogNoTransportSecurity =
+        LoggerMessage.Define(
+            LogLevel.Warning,
+            new EventId(100, nameof(LogNoTransportSecurity)),
+            "Neither LdapSecureSocketLayer nor LdapStartTls is enabled; user credentials " +
+            "and new passwords will be sent to the LDAP server unencrypted. Enable one of " +
+            "them unless the connection is protected by other means (e.g. a local test server).");
 
     private static readonly string[] RequiredAttributes =
     {
@@ -53,6 +88,9 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
         ArgumentNullException.ThrowIfNull(options);
         _options = options.Value;
         ValidateOptions(_options);
+
+        if (!_options.LdapSecureSocketLayer && !_options.LdapStartTls)
+            LogNoTransportSecurity(Logger, null);
 
         // First find user DN by username (SAM Account Name)
         _searchConstraints = new(
@@ -89,21 +127,57 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
         return Task.FromResult(isMember);
     }
 
-    private static bool DnMatchesGroup(string dn, string groupName)
+    internal static bool DnMatchesGroup(string dn, string groupName)
     {
         if (string.Equals(dn, groupName, StringComparison.OrdinalIgnoreCase))
             return true;
 
-        // Extract the first RDN value (the bit before the first comma, after the '=').
-        var firstComma = dn.IndexOf(',', StringComparison.Ordinal);
+        // Extract the first RDN value (the bit before the first unescaped comma,
+        // after the '='). RFC 4514 escapes literal commas in RDN values as "\,",
+        // which is the form AD uses in memberOf values.
+        var firstComma = IndexOfUnescapedComma(dn);
         var rdn = firstComma >= 0 ? dn[..firstComma] : dn;
 
         var equals = rdn.IndexOf('=', StringComparison.Ordinal);
         if (equals < 0)
             return false;
 
-        var cn = rdn[(equals + 1)..].Trim();
+        var cn = UnescapeRdnValue(rdn[(equals + 1)..].Trim());
         return string.Equals(cn, groupName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static int IndexOfUnescapedComma(string dn)
+    {
+        for (var i = 0; i < dn.Length; i++)
+        {
+            if (dn[i] == '\\')
+            {
+                i++; // Skip the escaped character
+                continue;
+            }
+
+            if (dn[i] == ',')
+                return i;
+        }
+
+        return -1;
+    }
+
+    private static string UnescapeRdnValue(string value)
+    {
+        if (!value.Contains('\\', StringComparison.Ordinal))
+            return value;
+
+        var sb = new StringBuilder(value.Length);
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (value[i] == '\\' && i + 1 < value.Length)
+                i++;
+
+            sb.Append(value[i]);
+        }
+
+        return sb.ToString();
     }
 
     // ---------------------------------------------------------------------
@@ -190,6 +264,16 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
     // Credential verification
     // ---------------------------------------------------------------------
 
+    /// <summary>
+    /// Verifies the user's current credentials by binding as the user.
+    /// On Active Directory, a bind rejected only because the password is
+    /// expired or must be changed at next logon (resultCode 49 with extended
+    /// error data 532/773) still proves the user knows the current password,
+    /// so those cases are allowed through — matching the Windows AD provider's
+    /// <c>ErrorPasswordMustChange</c>/<c>ErrorPasswordExpired</c> handling.
+    /// Generic LDAP servers do not emit these AD-specific data codes, so their
+    /// bind failures continue to surface as invalid credentials.
+    /// </summary>
     private void VerifyUserCredentials(string userDn, string password)
     {
         try
@@ -198,8 +282,32 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
         }
         catch (LdapBindException ex)
         {
+            if (ex.InnerException is LdapException ldapEx && IsPasswordExpiredOrMustChange(ldapEx))
+                return;
+
             throw new InvalidCredentialsException("Invalid current password", ex);
         }
+    }
+
+    /// <summary>
+    /// Detects the Active Directory bind failures that mean "the password is
+    /// correct but needs changing": resultCode 49 (invalidCredentials) whose
+    /// extended error message carries data sub-code 532 (ERROR_PASSWORD_EXPIRED)
+    /// or 773 (ERROR_PASSWORD_MUST_CHANGE).
+    /// </summary>
+    internal static bool IsPasswordExpiredOrMustChange(LdapException ex)
+    {
+        if (ex.ResultCode != LdapException.InvalidCredentials)
+            return false;
+
+        var message = ex.LdapErrorMessage;
+        if (string.IsNullOrEmpty(message))
+            return false;
+
+        var data = DataSubCodeRegex.Match(message);
+        return data.Success
+            && int.TryParse(data.Groups[1].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var code)
+            && code is ErrorPasswordExpired or ErrorPasswordMustChange;
     }
 
     // ---------------------------------------------------------------------
@@ -342,25 +450,64 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
     // Error translation
     // ---------------------------------------------------------------------
 
-    private static Exception TranslateLdapException(LdapException ex)
+    /// <summary>
+    /// Maps an <see cref="LdapException"/> raised during search or modify to a
+    /// domain exception, decoding Active Directory extended error messages when
+    /// present. AD emits two shapes: operation errors lead with the Win32 code
+    /// ("0000052D: SvcErr: ..., problem 5003 (WILL_NOT_PERFORM), data 0"), while
+    /// bind-style errors lead with a generic SEC_E code and carry the Win32 code
+    /// in the "data" field ("80090308: LdapErr: ..., data 52e, v2580"). Messages
+    /// from other LDAP servers (no recognizable Win32 code) surface verbatim as
+    /// a directory error.
+    /// </summary>
+    internal static Exception TranslateLdapException(LdapException ex)
     {
         if (string.IsNullOrWhiteSpace(ex.LdapErrorMessage))
             return new DirectoryUnavailableException(
                 "Unexpected LDAP error", ex);
 
-        var match = Regex.Match(ex.LdapErrorMessage,
-            "([0-9a-fA-F]+):");
-
-        if (!match.Success)
+        var known = ExtractWin32ErrorCode(ex.LdapErrorMessage);
+        if (known is null)
             return new DirectoryUnavailableException(
                 ex.LdapErrorMessage, ex);
 
-        var code = int.Parse(
-            match.Groups[1].Value,
-            NumberStyles.HexNumber);
+        return known.Code switch
+        {
+            ErrorInvalidPassword or ErrorWrongPassword or ErrorLogonFailure =>
+                new InvalidCredentialsException(known.Description, ex),
+            ErrorIllFormedPassword or ErrorPasswordRestriction =>
+                new PasswordPolicyViolationException(known.Description, ex),
+            _ => new DirectoryUnavailableException(
+                $"{known.CodeName}: {known.Description}", ex),
+        };
+    }
 
-        return new DirectoryUnavailableException(
-            $"LDAP error (Win32 code {code})", ex);
+    /// <summary>
+    /// Extracts the Win32 error code from an AD extended error message,
+    /// preferring the leading hex code when it is a known password-change
+    /// code and falling back to the "data" sub-code otherwise. Returns
+    /// <see langword="null"/> when neither resolves to a known code, so the
+    /// raw server message can be surfaced instead of a mislabeled number.
+    /// </summary>
+    internal static Win32ErrorCode? ExtractWin32ErrorCode(string message)
+    {
+        var leading = LeadingHexCodeRegex.Match(message);
+        if (leading.Success
+            && int.TryParse(leading.Groups[1].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var code)
+            && Win32ErrorCode.ByCode(code) is { } fromLeading)
+        {
+            return fromLeading;
+        }
+
+        var data = DataSubCodeRegex.Match(message);
+        if (data.Success
+            && int.TryParse(data.Groups[1].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var subCode)
+            && Win32ErrorCode.ByCode(subCode) is { } fromData)
+        {
+            return fromData;
+        }
+
+        return null;
     }
 
     // ---------------------------------------------------------------------
@@ -383,19 +530,69 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
 
         if (!opts.LdapSearchFilter.Contains("{Username}", StringComparison.Ordinal))
             throw new ArgumentException("Search filter must include {Username}");
+
+        if (opts.LdapSecureSocketLayer && opts.LdapStartTls)
+            throw new ArgumentException(
+                "LdapSecureSocketLayer and LdapStartTls are mutually exclusive: " +
+                "StartTLS is issued over a plaintext connection, while SecureSocketLayer " +
+                "expects TLS from the first byte. Enable at most one of them.");
     }
 
-    private static string SanitizeUsername(string username)
+    /// <summary>
+    /// Produces a value safe to substitute into <see cref="LdapPasswordChangeOptions.LdapSearchFilter"/>:
+    /// takes the local part of the username, rejects characters that are never
+    /// valid in a sAMAccountName (including control characters and the empty
+    /// string), then escapes the remaining RFC 4515 filter metacharacters so the
+    /// substituted value cannot alter the structure of the search filter.
+    /// </summary>
+    internal static string SanitizeUsername(string username)
     {
         var clean = username.Split('@')[0];
-        if (Regex.IsMatch(clean, @"[""/\\\[\]:;|=,+*?<>]"))
+
+        if (clean.Length == 0
+            || clean.Any(char.IsControl)
+            || InvalidAccountNameCharsRegex.IsMatch(clean))
+        {
             throw new InvalidCredentialsException(
                 "Invalid username format");
+        }
 
-        return clean;
+        return EscapeLdapSearchFilterValue(clean);
     }
 
-    private bool ValidateServerCertificate(
+    /// <summary>
+    /// Escapes the characters RFC 4515 §3 requires escaping inside a filter
+    /// value: '*', '(', ')', '\' and NUL. Applied after character validation
+    /// as defense in depth, so the substituted value is inert in the filter
+    /// even if the validation rules are relaxed in the future.
+    /// </summary>
+    internal static string EscapeLdapSearchFilterValue(string value)
+    {
+        var sb = new StringBuilder(value.Length);
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '\\': sb.Append("\\5c"); break;
+                case '*': sb.Append("\\2a"); break;
+                case '(': sb.Append("\\28"); break;
+                case ')': sb.Append("\\29"); break;
+                case '\0': sb.Append("\\00"); break;
+                default: sb.Append(c); break;
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Server certificate validation honoring the TLS options:
+    /// <see cref="LdapPasswordChangeOptions.LdapIgnoreTlsErrors"/> accepts any
+    /// certificate, while <see cref="LdapPasswordChangeOptions.LdapIgnoreTlsValidation"/>
+    /// accepts chain-trust failures only (e.g. self-signed or untrusted CA) and
+    /// still rejects name mismatches and other errors.
+    /// </summary>
+    internal bool ValidateServerCertificate(
         object sender,
         X509Certificate cert,
         X509Chain chain,
@@ -403,6 +600,12 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
     {
         if (_options.LdapIgnoreTlsErrors)
             return true;
+
+        if (_options.LdapIgnoreTlsValidation)
+        {
+            return (errors & ~System.Net.Security.SslPolicyErrors.RemoteCertificateChainErrors)
+                == System.Net.Security.SslPolicyErrors.None;
+        }
 
         return errors == System.Net.Security.SslPolicyErrors.None;
     }

--- a/src/Zyborg.PassCore.PasswordProvider.LDAP/Win32ErrorCode.cs
+++ b/src/Zyborg.PassCore.PasswordProvider.LDAP/Win32ErrorCode.cs
@@ -93,7 +93,7 @@ public class Win32ErrorCode
     /// <summary>
     /// Get Error Code by the code.
     /// </summary>
-    /// <param name=code>The code.</param>
+    /// <param name="code">The code.</param>
     /// <returns>A Win32ErrorCode from the code.</returns>
     public static Win32ErrorCode? ByCode(int code) =>
         ErrorByCode.TryGetValue(code, out var err) ? err : null;

--- a/src/Zyborg.PassCore.PasswordProvider.LDAP/Zyborg.PassCore.PasswordProvider.LDAP.csproj
+++ b/src/Zyborg.PassCore.PasswordProvider.LDAP/Zyborg.PassCore.PasswordProvider.LDAP.csproj
@@ -21,4 +21,8 @@
 		<ProjectReference Include="..\Unosquare.PassCore.Common\Unosquare.PassCore.Common.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<InternalsVisibleTo Include="Zyborg.PassCore.PasswordProvider.LDAP.Tests" />
+	</ItemGroup>
+
 </Project>

--- a/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/DnMatchesGroupTests.cs
+++ b/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/DnMatchesGroupTests.cs
@@ -1,0 +1,42 @@
+namespace Zyborg.PassCore.PasswordProvider.LDAP.Tests;
+
+public class DnMatchesGroupTests
+{
+    [Theory]
+    [InlineData("cn=Admins,ou=groups,dc=example,dc=com", "Admins")]
+    [InlineData("CN=Admins,OU=groups,DC=example,DC=com", "admins")]
+    [InlineData("cn=Admins,ou=groups,dc=example,dc=com", "cn=Admins,ou=groups,dc=example,dc=com")]
+    [InlineData("CN=Admins,OU=groups,DC=example,DC=com", "cn=admins,ou=groups,dc=example,dc=com")]
+    [InlineData("cn=Admins", "Admins")]
+    public void DnMatchesGroup_MatchingRdnValueOrFullDn_ReturnsTrue(string dn, string groupName)
+    {
+        Assert.True(LdapPasswordChangeProvider.DnMatchesGroup(dn, groupName));
+    }
+
+    [Theory]
+    [InlineData("cn=AdminsExtra,ou=groups,dc=example,dc=com", "Admins")]
+    [InlineData("cn=Admins,ou=groups,dc=example,dc=com", "AdminsExtra")]
+    [InlineData("cn=Admins,ou=groups,dc=example,dc=com", "groups")]
+    [InlineData("not-a-dn", "Admins")]
+    public void DnMatchesGroup_NonMatching_ReturnsFalse(string dn, string groupName)
+    {
+        Assert.False(LdapPasswordChangeProvider.DnMatchesGroup(dn, groupName));
+    }
+
+    [Fact]
+    public void DnMatchesGroup_EscapedCommaInRdnValue_MatchesFullValue()
+    {
+        // AD escapes literal commas in memberOf DN values per RFC 4514.
+        Assert.True(LdapPasswordChangeProvider.DnMatchesGroup(
+            "CN=Smith\\, John,OU=groups,DC=example,DC=com",
+            "Smith, John"));
+    }
+
+    [Fact]
+    public void DnMatchesGroup_EscapedCommaInRdnValue_DoesNotMatchTruncatedValue()
+    {
+        Assert.False(LdapPasswordChangeProvider.DnMatchesGroup(
+            "CN=Smith\\, John,OU=groups,DC=example,DC=com",
+            "Smith"));
+    }
+}

--- a/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/LdapExceptionTranslationTests.cs
+++ b/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/LdapExceptionTranslationTests.cs
@@ -1,0 +1,149 @@
+using Novell.Directory.Ldap;
+using Unosquare.PassCore.Common;
+using Unosquare.PassCore.Common.Exceptions;
+
+namespace Zyborg.PassCore.PasswordProvider.LDAP.Tests;
+
+public class LdapExceptionTranslationTests
+{
+    // Realistic AD extended error messages. Bind failures lead with a generic
+    // SEC_E code and carry the Win32 code in the "data" field; operation
+    // (modify/search) failures lead with the Win32 code itself.
+    private const string BindLogonFailure =
+        "80090308: LdapErr: DSID-0C0903A9, comment: AcceptSecurityContext error, data 52e, v2580";
+
+    private const string BindPasswordExpired =
+        "80090308: LdapErr: DSID-0C0903A9, comment: AcceptSecurityContext error, data 532, v2580";
+
+    private const string BindPasswordMustChange =
+        "80090308: LdapErr: DSID-0C0903A9, comment: AcceptSecurityContext error, data 773, v2580";
+
+    private const string ModifyPasswordRestriction =
+        "0000052D: SvcErr: DSID-031A12D2, problem 5003 (WILL_NOT_PERFORM), data 0";
+
+    private const string ModifyWrongOldPassword =
+        "00000056: AtrErr: DSID-03191083, #1:\n\t0: 00000056: DSID-03191083, problem 1005 (CONSTRAINT_ATT_TYPE), data 0, Att 9005a (unicodePwd)";
+
+    private static LdapException Ldap(string serverMessage, int resultCode = LdapException.Other) =>
+        new("test", resultCode, serverMessage);
+
+    [Fact]
+    public void Translate_BindStyleLogonFailure_MapsToInvalidCredentials()
+    {
+        var result = LdapPasswordChangeProvider.TranslateLdapException(
+            Ldap(BindLogonFailure, LdapException.InvalidCredentials));
+
+        Assert.IsType<InvalidCredentialsException>(result);
+    }
+
+    [Fact]
+    public void Translate_ModifyPasswordRestriction_MapsToPolicyViolation()
+    {
+        var result = LdapPasswordChangeProvider.TranslateLdapException(
+            Ldap(ModifyPasswordRestriction, LdapException.UnwillingToPerform));
+
+        var policy = Assert.IsType<PasswordPolicyViolationException>(result);
+        Assert.Equal(ApiErrorCode.ComplexPassword, policy.ErrorCode);
+    }
+
+    [Fact]
+    public void Translate_ModifyWrongOldPassword_MapsToInvalidCredentials()
+    {
+        var result = LdapPasswordChangeProvider.TranslateLdapException(
+            Ldap(ModifyWrongOldPassword, LdapException.ConstraintViolation));
+
+        Assert.IsType<InvalidCredentialsException>(result);
+    }
+
+    [Fact]
+    public void Translate_UnknownCode_SurfacesRawServerMessage()
+    {
+        const string message = "some vendor-specific failure without codes";
+
+        var result = LdapPasswordChangeProvider.TranslateLdapException(Ldap(message));
+
+        var dir = Assert.IsType<DirectoryUnavailableException>(result);
+        Assert.Equal(message, dir.Message);
+    }
+
+    [Fact]
+    public void Translate_EmptyServerMessage_MapsToDirectoryUnavailable()
+    {
+        var result = LdapPasswordChangeProvider.TranslateLdapException(Ldap(string.Empty));
+
+        Assert.IsType<DirectoryUnavailableException>(result);
+    }
+
+    [Fact]
+    public void Translate_KnownNonCredentialCode_ReportsCodeNameAndDescription()
+    {
+        // Account locked out: bind-style message with data 775
+        var result = LdapPasswordChangeProvider.TranslateLdapException(Ldap(
+            "80090308: LdapErr: DSID-0C0903A9, comment: AcceptSecurityContext error, data 775, v2580",
+            LdapException.InvalidCredentials));
+
+        var dir = Assert.IsType<DirectoryUnavailableException>(result);
+        Assert.Contains("ERROR_ACCOUNT_LOCKED_OUT", dir.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExtractWin32ErrorCode_BindStyle_PrefersDataSubCodeOverSecECode()
+    {
+        // The leading 80090308 is a generic SSPI code; the diagnostic is data 52e.
+        var code = LdapPasswordChangeProvider.ExtractWin32ErrorCode(BindLogonFailure);
+
+        Assert.NotNull(code);
+        Assert.Equal(0x52E, code.Code);
+    }
+
+    [Fact]
+    public void ExtractWin32ErrorCode_ModifyStyle_UsesLeadingCodeAndIgnoresDataZero()
+    {
+        var code = LdapPasswordChangeProvider.ExtractWin32ErrorCode(ModifyPasswordRestriction);
+
+        Assert.NotNull(code);
+        Assert.Equal(0x52D, code.Code);
+    }
+
+    [Fact]
+    public void ExtractWin32ErrorCode_NoRecognizableCode_ReturnsNull()
+    {
+        Assert.Null(LdapPasswordChangeProvider.ExtractWin32ErrorCode(
+            "Connection reset by peer"));
+    }
+
+    [Theory]
+    [InlineData(BindPasswordExpired)]
+    [InlineData(BindPasswordMustChange)]
+    public void IsPasswordExpiredOrMustChange_AdExpiredOrMustChangeBind_ReturnsTrue(string serverMessage)
+    {
+        var ex = Ldap(serverMessage, LdapException.InvalidCredentials);
+
+        Assert.True(LdapPasswordChangeProvider.IsPasswordExpiredOrMustChange(ex));
+    }
+
+    [Fact]
+    public void IsPasswordExpiredOrMustChange_PlainLogonFailure_ReturnsFalse()
+    {
+        var ex = Ldap(BindLogonFailure, LdapException.InvalidCredentials);
+
+        Assert.False(LdapPasswordChangeProvider.IsPasswordExpiredOrMustChange(ex));
+    }
+
+    [Fact]
+    public void IsPasswordExpiredOrMustChange_NonInvalidCredentialsResultCode_ReturnsFalse()
+    {
+        // Same message, but a result code other than 49 must not be trusted.
+        var ex = Ldap(BindPasswordExpired, LdapException.UnwillingToPerform);
+
+        Assert.False(LdapPasswordChangeProvider.IsPasswordExpiredOrMustChange(ex));
+    }
+
+    [Fact]
+    public void IsPasswordExpiredOrMustChange_GenericServerWithoutDataField_ReturnsFalse()
+    {
+        var ex = Ldap("Invalid credentials", LdapException.InvalidCredentials);
+
+        Assert.False(LdapPasswordChangeProvider.IsPasswordExpiredOrMustChange(ex));
+    }
+}

--- a/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/LdapTransportSecurityTests.cs
+++ b/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/LdapTransportSecurityTests.cs
@@ -1,0 +1,128 @@
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Unosquare.PassCore.Common;
+using Unosquare.PassCore.Common.Models;
+
+namespace Zyborg.PassCore.PasswordProvider.LDAP.Tests;
+
+public class LdapTransportSecurityTests
+{
+    private static LdapPasswordChangeOptions ValidOptions() => new()
+    {
+        LdapHostnames = new[] { "ldap.example.com" },
+        LdapPort = 636,
+        LdapUsername = "cn=admin,dc=example,dc=com",
+        LdapPassword = "secret",
+        LdapSearchBase = "dc=example,dc=com",
+        LdapSearchFilter = "(sAMAccountName={Username})",
+    };
+
+    private static LdapPasswordChangeProvider Construct(
+        LdapPasswordChangeOptions opts,
+        ILogger<LdapPasswordChangeProvider>? logger = null) =>
+        new(
+            logger ?? NullLogger<LdapPasswordChangeProvider>.Instance,
+            Options.Create(opts),
+            Options.Create(new ClientSettings()),
+            Array.Empty<IPasswordPolicy>());
+
+    [Fact]
+    public void Construct_SslAndStartTlsBothEnabled_Throws()
+    {
+        var opts = ValidOptions();
+        opts.LdapSecureSocketLayer = true;
+        opts.LdapStartTls = true;
+
+        Assert.Throws<ArgumentException>(() => Construct(opts));
+    }
+
+    [Fact]
+    public void Construct_NoTransportSecurity_LogsWarning()
+    {
+        var logger = new CapturingLogger();
+
+        Construct(ValidOptions(), logger);
+
+        Assert.Contains(logger.Entries, e =>
+            e.Level == LogLevel.Warning &&
+            e.Message.Contains("unencrypted", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void Construct_WithTransportSecurity_DoesNotLogWarning(bool ssl, bool startTls)
+    {
+        var logger = new CapturingLogger();
+        var opts = ValidOptions();
+        opts.LdapSecureSocketLayer = ssl;
+        opts.LdapStartTls = startTls;
+
+        Construct(opts, logger);
+
+        Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Warning);
+    }
+
+    [Theory]
+    [InlineData(SslPolicyErrors.None)]
+    [InlineData(SslPolicyErrors.RemoteCertificateChainErrors)]
+    [InlineData(SslPolicyErrors.RemoteCertificateNameMismatch)]
+    public void ValidateServerCertificate_IgnoreTlsErrors_AcceptsEverything(SslPolicyErrors errors)
+    {
+        var opts = ValidOptions();
+        opts.LdapIgnoreTlsErrors = true;
+
+        Assert.True(Validate(Construct(opts), errors));
+    }
+
+    [Fact]
+    public void ValidateServerCertificate_IgnoreTlsValidation_AcceptsChainErrorsOnly()
+    {
+        var opts = ValidOptions();
+        opts.LdapIgnoreTlsValidation = true;
+        var provider = Construct(opts);
+
+        Assert.True(Validate(provider, SslPolicyErrors.None));
+        Assert.True(Validate(provider, SslPolicyErrors.RemoteCertificateChainErrors));
+        Assert.False(Validate(provider, SslPolicyErrors.RemoteCertificateNameMismatch));
+        Assert.False(Validate(provider,
+            SslPolicyErrors.RemoteCertificateChainErrors | SslPolicyErrors.RemoteCertificateNameMismatch));
+    }
+
+    [Fact]
+    public void ValidateServerCertificate_NoIgnoreFlags_AcceptsOnlyCleanResult()
+    {
+        var provider = Construct(ValidOptions());
+
+        Assert.True(Validate(provider, SslPolicyErrors.None));
+        Assert.False(Validate(provider, SslPolicyErrors.RemoteCertificateChainErrors));
+        Assert.False(Validate(provider, SslPolicyErrors.RemoteCertificateNameMismatch));
+    }
+
+    private static bool Validate(LdapPasswordChangeProvider provider, SslPolicyErrors errors)
+    {
+        using var cert = new X509Certificate();
+        using var chain = new X509Chain();
+        return provider.ValidateServerCertificate(provider, cert, chain, errors);
+    }
+
+    private sealed class CapturingLogger : ILogger<LdapPasswordChangeProvider>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            Entries.Add((logLevel, formatter(state, exception)));
+    }
+}

--- a/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/LdapUsernameSanitizationTests.cs
+++ b/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/LdapUsernameSanitizationTests.cs
@@ -1,0 +1,106 @@
+using Unosquare.PassCore.Common.Exceptions;
+
+namespace Zyborg.PassCore.PasswordProvider.LDAP.Tests;
+
+public class LdapUsernameSanitizationTests
+{
+    [Theory]
+    [InlineData("jdoe", "jdoe")]
+    [InlineData("j.doe", "j.doe")]
+    [InlineData("jdoe@example.com", "jdoe")]
+    [InlineData("j-doe_2@example.com", "j-doe_2")]
+    public void SanitizeUsername_ValidInput_ReturnsLocalPart(string input, string expected)
+    {
+        Assert.Equal(expected, LdapPasswordChangeProvider.SanitizeUsername(input));
+    }
+
+    [Theory]
+    [InlineData("jd*e")]
+    [InlineData(@"jd\e")]
+    [InlineData("jd=e")]
+    [InlineData("jd,e")]
+    [InlineData("jd;e")]
+    [InlineData("jd|e")]
+    [InlineData("jd<e>")]
+    public void SanitizeUsername_InvalidAccountNameCharacters_Throws(string input)
+    {
+        Assert.Throws<InvalidCredentialsException>(
+            () => LdapPasswordChangeProvider.SanitizeUsername(input));
+    }
+
+    [Theory]
+    [InlineData("jd\0e")]
+    [InlineData("jd\ne")]
+    [InlineData("jd\te")]
+    public void SanitizeUsername_ControlCharacters_Throws(string input)
+    {
+        Assert.Throws<InvalidCredentialsException>(
+            () => LdapPasswordChangeProvider.SanitizeUsername(input));
+    }
+
+    [Fact]
+    public void SanitizeUsername_EmptyLocalPart_Throws()
+    {
+        Assert.Throws<InvalidCredentialsException>(
+            () => LdapPasswordChangeProvider.SanitizeUsername("@example.com"));
+    }
+
+    [Theory]
+    [InlineData("jd(e", "jd\\28e")]
+    [InlineData("jd)e", "jd\\29e")]
+    [InlineData("j(d)e", "j\\28d\\29e")]
+    public void SanitizeUsername_FilterMetacharacters_AreEscaped(string input, string expected)
+    {
+        Assert.Equal(expected, LdapPasswordChangeProvider.SanitizeUsername(input));
+    }
+
+    [Theory]
+    [InlineData("admin)(objectClass=person")]
+    [InlineData("*)(sAMAccountName=*")]
+    [InlineData("x)(|(cn=a)(cn=b)")]
+    [InlineData("jd(e")]
+    [InlineData("jd)e")]
+    [InlineData("plainuser")]
+    public void SanitizeUsername_OutputCannotAlterFilterStructure(string input)
+    {
+        string value;
+        try
+        {
+            value = LdapPasswordChangeProvider.SanitizeUsername(input);
+        }
+        catch (InvalidCredentialsException)
+        {
+            return; // Rejected outright is also structure-safe
+        }
+
+        // After substitution into "(attr={Username})" the value must contain no
+        // unescaped RFC 4515 metacharacters: every '\' introduces a two-hex-digit
+        // escape, and '(', ')', '*', NUL never appear raw.
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            Assert.True(c is not ('(' or ')' or '*' or '\0'),
+                $"Unescaped metacharacter '{c}' at index {i} in \"{value}\"");
+
+            if (c == '\\')
+            {
+                Assert.True(i + 2 < value.Length
+                    && Uri.IsHexDigit(value[i + 1])
+                    && Uri.IsHexDigit(value[i + 2]),
+                    $"Backslash at index {i} in \"{value}\" is not a valid \\XX escape");
+                i += 2;
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData("a*b", "a\\2ab")]
+    [InlineData("a\\b", "a\\5cb")]
+    [InlineData("a(b)c", "a\\28b\\29c")]
+    [InlineData("a\0b", "a\\00b")]
+    [InlineData("plain", "plain")]
+    public void EscapeLdapSearchFilterValue_EscapesRfc4515Metacharacters(string input, string expected)
+    {
+        Assert.Equal(expected, LdapPasswordChangeProvider.EscapeLdapSearchFilterValue(input));
+    }
+}


### PR DESCRIPTION
## Description

Review and hardening pass over `LdapPasswordChangeProvider` (and a doc-only touch on `DebugPasswordChangeProvider`), with new unit tests for every changed piece of logic.

### What was found and fixed

**1. LDAP filter injection surface in `SanitizeUsername` (security).** The deny-list rejected AD-invalid account-name characters but not `(`, `)`, or NUL/control characters — exactly the characters RFC 4515 says can alter filter structure — and let an empty local part (`@domain.com`) through. The sanitized value is now: local part → reject empty / control chars / AD-invalid characters → escape the RFC 4515 metacharacters (`\` `*` `(` `)` NUL as `\5c` `\2a` `\28` `\29` `\00`) before substitution into `LdapSearchFilter`. Validation plus escaping means the substituted value is inert in the filter even if the validation rules are relaxed later.

**2. `TranslateLdapException` decoded the wrong hex group (correctness).** The old regex grabbed the *first* `hex:` group. On AD bind-style extended errors (`80090308: LdapErr: DSID-..., comment: AcceptSecurityContext error, data 52e, v2580`) that is the generic SEC_E code, which was then reported as a bogus negative "Win32 code" while the actual diagnostic (`data 52e`) was ignored. The `Win32ErrorCode` table in the same project was dead code. Translation now handles both AD message shapes — operation errors that lead with the Win32 code (`0000052D: SvcErr: ..., data 0`) and bind-style errors that carry it in the `data` field — maps known codes through `Win32ErrorCode` (wrong password → `InvalidCredentialsException`, password restriction / ill-formed → `PasswordPolicyViolationException`), and surfaces unknown messages verbatim rather than mislabeling a number.

**3. Expired / must-change passwords could not be changed (parity gap).** Any bind failure in `VerifyUserCredentials` became "invalid current password". On AD, a bind with a correct-but-expired password fails with resultCode 49 and `data 532`/`data 773` — the Windows AD provider explicitly allows these through (`ErrorPasswordMustChange`/`ErrorPasswordExpired`), and letting users fix expired passwords is the main point of the tool. The LDAP provider now allows those two AD sub-codes through; the actual change still runs under the service account. Generic LDAP servers don't emit these AD-specific data codes, so their bind failures still surface as invalid credentials (noted in the XML docs).

**4. `LdapIgnoreTlsValidation` had no effect (correctness).** The certificate callback returned `errors == None` unless `LdapIgnoreTlsErrors` was set, so the "accept self-signed" option silently behaved like full validation. It now accepts chain-trust errors only, still rejecting name mismatches and other errors, matching the option's documentation.

**5. No transport-security validation.** `ValidateOptions` now rejects `LdapSecureSocketLayer` + `LdapStartTls` together (contradictory: StartTLS is issued over a plaintext connection), and the constructor logs a warning when neither is enabled, since credentials and new passwords would cross the wire unencrypted. A warning rather than an error keeps the MokAPI smoke test and other deliberate plaintext test setups working.

**6. `DnMatchesGroup` broke on escaped commas.** The first RDN was taken as everything before the first comma, so `CN=Smith\, John,OU=...` could never match "Smith, John". It now scans for the first *unescaped* comma and unescapes the RDN value before comparing.

Also: fixed a malformed XML doc comment in `Win32ErrorCode.cs` (`<param name=code>`).

### Investigated and deliberately left alone

- **Debug provider's legacy magic-string map**: it can surprise someone testing with a real username like `error`, but it's debug-only, layered *under* the configurable `ForcedErrors`, and pinned by existing tests (which this task must not weaken). Documented the behavior in the class XML docs instead of changing it.
- **`FindUser` taking the first entry when a search matches multiple**: with an exact-match escaped filter this requires a misconfigured `LdapSearchFilter` to happen; left as-is.
- **`ChangePasswordReplace`/`ChangePasswordDelAdd` semantics** and the AD provider itself: out of scope, untouched.
- **Hex-pair RDN escapes (`\2C`)** in `DnMatchesGroup`: AD emits backslash-char escapes in `memberOf` values; hex-pair unescaping was not added.

### Tests

63 new tests in `Zyborg.PassCore.PasswordProvider.LDAP.Tests` (internals exposed via `InternalsVisibleTo`): sanitization/escaping including a structure-preservation check over injection payloads, exception translation against realistic AD extended-error strings for both message shapes, expired/must-change detection (including the negative cases: wrong result code, plain logon failure, generic servers), DN/group matching, and TLS option handling. All previous tests pass unmodified: LDAP 70/70, Debug 20/20, Common 35/35, PwnedPasswordsSearch 4/4.

### Open questions for a human reviewer

1. The expired-password allow-through relies on AD's documented `data 532`/`data 773` extended-error format; I verified it against the documented format, not a live domain controller. A smoke test against real AD before release would be worthwhile.
2. Should plaintext LDAP (no SSL/StartTLS) be a hard error in production rather than a warning? I chose a warning to avoid breaking existing deployments and the mock-server smoke test.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation update
- [x] Testing/CI harness

## Checklist
- [x] All new code compiles under .NET 8.
- [x] `dotnet test` passes locally.
- [x] No external network calls are made in unit tests.
- [x] Documentation (if applicable) is updated.
- [ ] Debug provider is gated by `#if DEBUG` and cannot be enabled in Production. *(not applicable — no change to how the Debug provider is gated)*
- [ ] (Optional) Example e2e test runs against the Docker Compose test stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqqJZfw8hSz2n16KgdcQcG

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqqJZfw8hSz2n16KgdcQcG)_