### PR TITLE
Phase 2: Error-disclosure posture as a single server-side setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The most relevant configuration entries are shown below. Make sure you make your
   - Find the `MinimumScore` entry and set it to a numeric value (without quotes) between 1 and 4, where 1 is a bit secure and 4 is the most secure. Set to 0, for deactivate the validation.
 - To enable restricted group checking
   1. Find the `RestrictedADGroups` entry and add any groups that are sensitive.  Accounts in these groups (directly or inherited) will not be able to change their password.
+- To choose how much failed password changes disclose
+  - Find the `ErrorDisclosureMode` entry (in `AppSettings`, applies to both the AD and LDAP providers). `"Hardened"` (the default) makes unknown usernames and locked/disabled/expired/restricted accounts indistinguishable from a wrong password, so an attacker probing the form learns nothing about which accounts exist or their state. `"Informative"` tells legitimate users when the account was not found or cannot currently change its password ("contact IT"), which reduces help-desk confusion but hands that same information to attackers. This setting is server-side only and is never sent to the browser. It replaces the old LDAP-only `HideUserNotFound` setting, which is now ignored (a startup warning is logged if it is still present).
 - Find the `DefaultDomain` entry and set it to your default Active Directory domain. This should eliminate confusion about using e-mail domains / internal domain names. **NOTE:** if you are using a subdomain, and you have errors, please try using your top-level domain. 
 - To provide an optional parameter to the URL to set the username text box automatically
   1. `http://mypasscore.com/?userName=someusername`

--- a/src/Unosquare.PassCore.Common/DirectoryErrorTranslator.cs
+++ b/src/Unosquare.PassCore.Common/DirectoryErrorTranslator.cs
@@ -59,30 +59,42 @@ public enum DirectoryFailureClass
 /// <see cref="ApiErrorItem"/>s. Providers own only transport-specific
 /// extraction (parsing an LDAP extended-error message, unwrapping an HRESULT)
 /// and must delegate routing here so identical directory conditions produce
-/// identical results across providers.
+/// identical results across providers. Every entry point requires an
+/// <see cref="ErrorDisclosureMode"/>, so no caller can route without choosing
+/// the configured posture.
 ///
-/// Routing table (interim conservative/hardened posture — a later phase makes
-/// the existence/account-state rows configurable):
+/// Routing table (per <see cref="ErrorDisclosureMode"/>):
 /// <list type="bullet">
-/// <item><see cref="DirectoryFailureClass.Credentials"/>,
-/// <see cref="DirectoryFailureClass.Existence"/>,
-/// <see cref="DirectoryFailureClass.AccountState"/> and
+/// <item><see cref="DirectoryFailureClass.Credentials"/> and
 /// <see cref="DirectoryFailureClass.PasswordExpiredOrMustChange"/> →
 /// <see cref="InvalidCredentialsException"/> with the uniform
-/// <see cref="InvalidCredentialsMessage"/>, so an unauthenticated caller gets
-/// no account-existence or account-state oracle.</item>
+/// <see cref="InvalidCredentialsMessage"/> in both modes.</item>
+/// <item><see cref="DirectoryFailureClass.Existence"/> → hardened:
+/// <see cref="InvalidCredentialsException"/> (indistinguishable from a wrong
+/// password); informative: <see cref="UserNotFoundException"/> with
+/// <see cref="UserNotFoundMessage"/>.</item>
+/// <item><see cref="DirectoryFailureClass.AccountState"/> → hardened:
+/// <see cref="InvalidCredentialsException"/>; informative:
+/// <see cref="PasswordPolicyViolationException"/> with
+/// <see cref="ApiErrorCode.ChangeNotPermitted"/> and
+/// <see cref="AccountStateMessage"/> ("stop retrying, contact IT").</item>
 /// <item><see cref="DirectoryFailureClass.NewPasswordPolicy"/> →
 /// <see cref="PasswordPolicyViolationException"/> with an explicit
-/// <see cref="ApiErrorCode.ComplexPassword"/> (0x52C and 0x52D deliberately
-/// collapse into that code).</item>
+/// <see cref="ApiErrorCode.ComplexPassword"/> in both modes (0x52C and 0x52D
+/// deliberately collapse into that code).</item>
 /// <item><see cref="DirectoryFailureClass.ChangeNotPermitted"/> →
 /// <see cref="PasswordPolicyViolationException"/> with
-/// <see cref="ApiErrorCode.ChangeNotPermitted"/>.</item>
+/// <see cref="ApiErrorCode.ChangeNotPermitted"/> in both modes (this code is
+/// only produced by the directory after the caller proved the current
+/// password).</item>
 /// <item><see cref="DirectoryFailureClass.Infrastructure"/> and every
-/// uncataloged code → <see cref="DirectoryUnavailableException"/>.</item>
+/// uncataloged code → <see cref="DirectoryUnavailableException"/> in both
+/// modes.</item>
 /// </list>
 /// Exception messages are fixed curated strings; the specific code survives
-/// only in the inner exception, which reaches logs but never the wire.
+/// only in the inner exception, which reaches logs but never the wire. In
+/// hardened mode the credentials/existence/account-state rows are
+/// byte-identical on the wire (same code, same message).
 /// </summary>
 public static class DirectoryErrorTranslator
 {
@@ -114,6 +126,20 @@ public static class DirectoryErrorTranslator
         "The directory service could not complete the password change request";
 
     /// <summary>
+    /// Wire message for unknown users in
+    /// <see cref="ErrorDisclosureMode.Informative"/> mode only.
+    /// </summary>
+    public const string UserNotFoundMessage = "User not found";
+
+    /// <summary>
+    /// Wire message for unusable accounts (locked, disabled, expired,
+    /// hours/workstation-restricted) in
+    /// <see cref="ErrorDisclosureMode.Informative"/> mode only.
+    /// </summary>
+    public const string AccountStateMessage =
+        "This account cannot change its password at this time. Contact your administrator or IT help desk";
+
+    /// <summary>
     /// Classifies a Win32 error code via the <see cref="Win32ErrorCode"/>
     /// catalog. Uncataloged codes degrade to
     /// <see cref="DirectoryFailureClass.Infrastructure"/>; never throws.
@@ -137,30 +163,32 @@ public static class DirectoryErrorTranslator
 
     /// <summary>
     /// Translates a Win32 error code to the domain exception described in the
-    /// class-level routing table.
+    /// class-level routing table, applying the configured disclosure posture.
     /// </summary>
     /// <param name="win32Code">The Win32 error code.</param>
+    /// <param name="disclosureMode">The configured disclosure posture.</param>
     /// <param name="innerException">The transport exception, preserved for logs.</param>
     /// <returns>The domain exception to throw.</returns>
-    public static Exception Translate(int win32Code, Exception? innerException = null)
+    public static Exception Translate(
+        int win32Code,
+        ErrorDisclosureMode disclosureMode,
+        Exception? innerException = null)
     {
         return Classify(win32Code) switch
         {
             DirectoryFailureClass.Credentials or
-            DirectoryFailureClass.Existence or
-            DirectoryFailureClass.AccountState or
             DirectoryFailureClass.PasswordExpiredOrMustChange =>
-                innerException is null
-                    ? new InvalidCredentialsException(InvalidCredentialsMessage)
-                    : new InvalidCredentialsException(InvalidCredentialsMessage, innerException),
+                InvalidCredentials(innerException),
+            DirectoryFailureClass.Existence =>
+                CreateUserNotFoundError(disclosureMode, innerException),
+            DirectoryFailureClass.AccountState =>
+                disclosureMode == ErrorDisclosureMode.Informative
+                    ? PolicyViolation(AccountStateMessage, ApiErrorCode.ChangeNotPermitted, innerException)
+                    : InvalidCredentials(innerException),
             DirectoryFailureClass.NewPasswordPolicy =>
-                innerException is null
-                    ? new PasswordPolicyViolationException(NewPasswordPolicyMessage, ApiErrorCode.ComplexPassword)
-                    : new PasswordPolicyViolationException(NewPasswordPolicyMessage, ApiErrorCode.ComplexPassword, innerException),
+                PolicyViolation(NewPasswordPolicyMessage, ApiErrorCode.ComplexPassword, innerException),
             DirectoryFailureClass.ChangeNotPermitted =>
-                innerException is null
-                    ? new PasswordPolicyViolationException(ChangeNotPermittedMessage, ApiErrorCode.ChangeNotPermitted)
-                    : new PasswordPolicyViolationException(ChangeNotPermittedMessage, ApiErrorCode.ChangeNotPermitted, innerException),
+                PolicyViolation(ChangeNotPermittedMessage, ApiErrorCode.ChangeNotPermitted, innerException),
             _ =>
                 innerException is null
                     ? new DirectoryUnavailableException(DirectoryFailureMessage)
@@ -169,24 +197,61 @@ public static class DirectoryErrorTranslator
     }
 
     /// <summary>
+    /// Builds the exception for the structural "user could not be resolved"
+    /// condition (an empty search result or a null principal, where no Win32
+    /// code exists). Kept here so both providers report unknown users through
+    /// the same posture-aware routing as the coded existence failures:
+    /// hardened → indistinguishable from a wrong password; informative →
+    /// <see cref="UserNotFoundException"/>.
+    /// </summary>
+    /// <param name="disclosureMode">The configured disclosure posture.</param>
+    /// <param name="innerException">Optional transport exception, preserved for logs.</param>
+    /// <returns>The domain exception to throw.</returns>
+    public static Exception CreateUserNotFoundError(
+        ErrorDisclosureMode disclosureMode,
+        Exception? innerException = null)
+    {
+        if (disclosureMode == ErrorDisclosureMode.Informative)
+        {
+            return innerException is null
+                ? new UserNotFoundException(UserNotFoundMessage)
+                : new UserNotFoundException(UserNotFoundMessage, innerException);
+        }
+
+        return InvalidCredentials(innerException);
+    }
+
+    /// <summary>
     /// Translates an arbitrary exception raised by a directory operation:
     /// extracts a Win32 code from the exception chain when one is present and
-    /// routes it through <see cref="Translate(int, Exception?)"/>; anything
-    /// unrecognizable becomes a <see cref="DirectoryUnavailableException"/>
+    /// routes it through <see cref="Translate(int, ErrorDisclosureMode, Exception?)"/>;
+    /// anything unrecognizable becomes a <see cref="DirectoryUnavailableException"/>
     /// with the curated <see cref="DirectoryFailureMessage"/>. The original
     /// exception is preserved as the inner exception so its detail reaches
     /// logs, never the wire.
     /// </summary>
     /// <param name="exception">The exception raised by the directory operation.</param>
+    /// <param name="disclosureMode">The configured disclosure posture.</param>
     /// <returns>The domain exception to throw.</returns>
-    public static Exception TranslateException(Exception exception)
+    public static Exception TranslateException(Exception exception, ErrorDisclosureMode disclosureMode)
     {
         ArgumentNullException.ThrowIfNull(exception);
 
         return TryGetWin32Code(exception, out var code)
-            ? Translate(code, exception)
+            ? Translate(code, disclosureMode, exception)
             : new DirectoryUnavailableException(DirectoryFailureMessage, exception);
     }
+
+    private static InvalidCredentialsException InvalidCredentials(Exception? innerException) =>
+        innerException is null
+            ? new InvalidCredentialsException(InvalidCredentialsMessage)
+            : new InvalidCredentialsException(InvalidCredentialsMessage, innerException);
+
+    private static PasswordPolicyViolationException PolicyViolation(
+        string message, ApiErrorCode errorCode, Exception? innerException) =>
+        innerException is null
+            ? new PasswordPolicyViolationException(message, errorCode)
+            : new PasswordPolicyViolationException(message, errorCode, innerException);
 
     /// <summary>
     /// Walks an exception chain looking for a Win32 error code: a

--- a/src/Unosquare.PassCore.Common/ErrorDisclosureMode.cs
+++ b/src/Unosquare.PassCore.Common/ErrorDisclosureMode.cs
@@ -1,0 +1,28 @@
+namespace Unosquare.PassCore.Common;
+
+/// <summary>
+/// Server-side selection of how much a failed password change discloses to the
+/// caller. Configured once (the <c>AppSettings:ErrorDisclosureMode</c> key) and
+/// enforced inside <see cref="DirectoryErrorTranslator"/>, so both providers
+/// always apply the same posture. This value must never be exposed through any
+/// client-visible payload — a readable posture flag would tell an attacker
+/// which oracle exists.
+/// </summary>
+public enum ErrorDisclosureMode
+{
+    /// <summary>
+    /// Enumeration-resistant default: unknown-user and unusable-account
+    /// (locked, disabled, expired, hours/workstation-restricted) conditions are
+    /// indistinguishable from a wrong password, giving an unauthenticated
+    /// caller no account-existence or account-state oracle.
+    /// </summary>
+    Hardened = 0,
+
+    /// <summary>
+    /// Help-desk-friendly: unknown users are reported as not found and
+    /// unusable accounts as not permitted to change the password ("stop
+    /// retrying, contact IT"), at the cost of exposing those oracles to
+    /// unauthenticated callers.
+    /// </summary>
+    Informative = 1,
+}

--- a/src/Unosquare.PassCore.Common/IAppSettings.cs
+++ b/src/Unosquare.PassCore.Common/IAppSettings.cs
@@ -6,6 +6,24 @@
 public interface IAppSettings
 {
     /// <summary>
+    /// Gets or sets the error-disclosure posture applied when a password
+    /// change fails. Server-side only — never expose this value through a
+    /// client-visible payload.
+    /// </summary>
+    /// <remarks>
+    /// Optional, defaults to <see cref="ErrorDisclosureMode.Hardened"/>
+    /// (unknown users and unusable accounts are indistinguishable from a
+    /// wrong password). Set to <see cref="ErrorDisclosureMode.Informative"/>
+    /// to give legitimate users actionable guidance (user-not-found and
+    /// contact-IT responses) at the cost of exposing an account-existence
+    /// and account-state oracle to unauthenticated callers.
+    /// </remarks>
+    /// <value>
+    /// The error disclosure mode.
+    /// </value>
+    ErrorDisclosureMode ErrorDisclosureMode { get; set; }
+
+    /// <summary>
     /// Gets or sets the default domain.
     /// </summary>
     /// <value>

--- a/src/Unosquare.PassCore.Common/PasswordChangeProviderBase.cs
+++ b/src/Unosquare.PassCore.Common/PasswordChangeProviderBase.cs
@@ -88,7 +88,12 @@ public abstract class PasswordChangeProviderBase : IPasswordChangeProvider
         string username,
         string currentPassword,
         string newPassword) =>
-        ChangePasswordAsync(new PasswordChangeContext(username, currentPassword, newPassword, ClientSettings));
+        ChangePasswordAsync(new PasswordChangeContext(
+            username,
+            currentPassword,
+            newPassword,
+            ClientSettings,
+            correlationId: Guid.NewGuid().ToString("N")[..8]));
 
     protected virtual async Task<PasswordChangeResult> ChangePasswordAsync(PasswordChangeContext context, CancellationToken cancellationToken = default)
     {
@@ -136,7 +141,13 @@ public abstract class PasswordChangeProviderBase : IPasswordChangeProvider
         catch (Exception ex)
         {
             LogPasswordChangeFailed(Logger, context.CorrelationId, context.Username, ex);
-            return PasswordChangeResult.Fail(new ApiErrorItem(ApiErrorCode.Generic, ex.Message));
+
+            // Never serialize raw exception text: the Generic code renders its
+            // message verbatim in the UI. The correlation ID ties the clean
+            // surface text back to the full detail logged above.
+            return PasswordChangeResult.Fail(new ApiErrorItem(
+                ApiErrorCode.Generic,
+                $"An unexpected error occurred (ref: {context.CorrelationId ?? "n/a"})"));
         }
     }
 

--- a/src/Unosquare.PassCore.Common/Policies/PwnedPasswordPolicy.cs
+++ b/src/Unosquare.PassCore.Common/Policies/PwnedPasswordPolicy.cs
@@ -34,11 +34,20 @@ public class PwnedPasswordPolicy : IPasswordPolicy
         }
         catch (PwnedPasswordsApiException ex)
         {
-            throw new PasswordPolicyViolationException($"Error during Pwned Password API check: {ex.Message}", ApiErrorCode.Generic);
+            // Fail closed with a clean surface message: the Generic code renders
+            // its message verbatim in the UI, so the HIBP client's exception text
+            // must stay out of it. Full detail reaches logs via the inner
+            // exception (the base class logs policy failures with correlation ID).
+            throw new PasswordPolicyViolationException(
+                UnavailableMessage(context.CorrelationId), ApiErrorCode.Generic, ex);
         }
         catch (PwnedPasswordsSearchException ex)
         {
-            throw new PasswordPolicyViolationException($"Unexpected error during Pwned Password search: {ex.Message}", ApiErrorCode.Generic);
+            throw new PasswordPolicyViolationException(
+                UnavailableMessage(context.CorrelationId), ApiErrorCode.Generic, ex);
         }
     }
+
+    private static string UnavailableMessage(string? correlationId) =>
+        $"The compromised-password check could not be completed. Please try again later (ref: {correlationId ?? "n/a"})";
 }

--- a/src/Unosquare.PassCore.PasswordProvider/PasswordChangeOptions.cs
+++ b/src/Unosquare.PassCore.PasswordProvider/PasswordChangeOptions.cs
@@ -37,6 +37,9 @@ public class PasswordChangeOptions : IAppSettings
     public bool UpdateLastPassword { get; set; }
 
     /// <inheritdoc />
+    public ErrorDisclosureMode ErrorDisclosureMode { get; set; } = ErrorDisclosureMode.Hardened;
+
+    /// <inheritdoc />
     public string DefaultDomain
     {
         get => _defaultDomain ?? string.Empty;

--- a/src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs
+++ b/src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs
@@ -47,11 +47,10 @@ namespace Unosquare.PassCore.PasswordProvider
         /// <remarks>
         /// Directory failures are routed through
         /// <see cref="DirectoryErrorTranslator"/> so this provider and the LDAP
-        /// provider report identical conditions identically. An unresolvable
-        /// username reports as invalid credentials rather than user-not-found —
-        /// the interim conservative (hardened) posture shared with the LDAP
-        /// provider's <c>HideUserNotFound</c> default, pending the configurable
-        /// disclosure mode planned for a later phase.
+        /// provider report identical conditions identically. How much a failure
+        /// discloses (user-not-found, account state) is controlled by the
+        /// <see cref="IAppSettings.ErrorDisclosureMode"/> setting shared by both
+        /// providers; see <see cref="ErrorDisclosureMode"/> for the trade-off.
         /// </remarks>
         protected override Task ChangePasswordCore(PasswordChangeContext context, CancellationToken cancellationToken)
         {
@@ -66,8 +65,8 @@ namespace Unosquare.PassCore.PasswordProvider
 
                 if (userPrincipal == null) // Check if UserPrincipal is null
                 {
-                    // Interim conservative posture: do not disclose whether the account exists.
-                    throw new InvalidCredentialsException(DirectoryErrorTranslator.InvalidCredentialsMessage);
+                    // Posture-aware existence handling shared with the LDAP provider.
+                    throw DirectoryErrorTranslator.CreateUserNotFoundError(_options.ErrorDisclosureMode);
                 }
 
                 if (userPrincipal.UserCannotChangePassword) // Check if the UserCannotChangePassword flag is set
@@ -99,7 +98,7 @@ namespace Unosquare.PassCore.PasswordProvider
                 // COMException 0x800708C5 for a policy rejection) and route it through
                 // the shared translator; anything unrecognizable degrades to a
                 // curated directory-failure message with the detail preserved for logs.
-                throw DirectoryErrorTranslator.TranslateException(ex);
+                throw DirectoryErrorTranslator.TranslateException(ex, _options.ErrorDisclosureMode);
             }
 
             return Task.CompletedTask;
@@ -143,7 +142,7 @@ namespace Unosquare.PassCore.PasswordProvider
             {
                 // Group lookups run inside policy evaluation; without this wrap a raw
                 // AccountManagement exception would surface as Generic + raw text.
-                throw DirectoryErrorTranslator.TranslateException(ex);
+                throw DirectoryErrorTranslator.TranslateException(ex, _options.ErrorDisclosureMode);
             }
         }
 

--- a/src/Unosquare.PassCore.Web/ClientApp/tests/e2e/password-change.spec.ts
+++ b/src/Unosquare.PassCore.Web/ClientApp/tests/e2e/password-change.spec.ts
@@ -62,7 +62,7 @@ test.describe('Password Change Flow', () => {
 
     await responsePromise;
     await expect(page.getByTestId('snackbar-notification')).toBeVisible();
-    await expect(page.locator('text=You are not allowed to change your password')).toBeVisible();
+    await expect(page.locator('text=Your password cannot be changed at this time')).toBeVisible();
   });
 
   test('should show error for password policy violation', async ({ page }) => {
@@ -77,6 +77,6 @@ test.describe('Password Change Flow', () => {
 
     await responsePromise;
     await expect(page.getByTestId('snackbar-notification')).toBeVisible();
-    await expect(page.locator('text=Failed due to password complexity policies')).toBeVisible();
+    await expect(page.locator('text=The new password was rejected by the domain')).toBeVisible();
   });
 });

--- a/src/Unosquare.PassCore.Web/Controllers/PasswordController.cs
+++ b/src/Unosquare.PassCore.Web/Controllers/PasswordController.cs
@@ -105,18 +105,28 @@ public class PasswordController : Controller
         }
         catch (HttpRequestException ex)
         {
-            _logger.LogError(ex, "Failed to update password");
-
-            result.Errors.Add(new ApiErrorItem(ApiErrorCode.Generic, ex.Message));
+            result.Errors.Add(UnexpectedError(ex));
         }
         catch (InvalidOperationException ex)
         {
-            _logger.LogError(ex, "Failed to update password");
-
-            result.Errors.Add(new ApiErrorItem(ApiErrorCode.Generic, ex.Message));
+            result.Errors.Add(UnexpectedError(ex));
         }
 
         return BadRequest(result);
+    }
+
+    /// <summary>
+    /// Logs the exception under a fresh correlation reference and returns a
+    /// clean Generic error carrying only that reference — the Generic code's
+    /// message renders verbatim in the UI, so raw exception text must never
+    /// be placed in it.
+    /// </summary>
+    private ApiErrorItem UnexpectedError(Exception ex)
+    {
+        var reference = Guid.NewGuid().ToString("N")[..8];
+        _logger.LogError(ex, "Failed to update password (ref: {Reference})", reference);
+
+        return new ApiErrorItem(ApiErrorCode.Generic, $"An unexpected error occurred (ref: {reference})");
     }
 
     private async Task<bool> ValidateRecaptcha(string? recaptchaResponse)

--- a/src/Unosquare.PassCore.Web/appsettings.json
+++ b/src/Unosquare.PassCore.Web/appsettings.json
@@ -22,6 +22,7 @@
     "LdapChangePasswordWithDelAdd": true,
     "LdapSearchFilter": "(sAMAccountName={Username})", // Another value: "(&(objectClass=person)(cn={Username}))"
     // General options (valid for both providers)
+    "ErrorDisclosureMode": "Hardened", // "Hardened" (default): unknown users and locked/disabled/restricted accounts are indistinguishable from a wrong password, so attackers get no account oracle. "Informative": unknown users get "user not found" and unusable accounts get "contact IT" guidance, at the cost of that oracle. Server-side only; never sent to the browser. Replaces the deprecated LDAP-only "HideUserNotFound".
     "LdapHostnames": [ "" ], // Set your hostname(s)
     "LdapPort": 389, // Default for AD is 389, for LDAPS 636
     "LdapUsername": "", // Set the username or distinguish name (DN) to bind the LDAP server
@@ -79,14 +80,14 @@
     "Alerts": {
       "SuccessAlertTitle": "You have changed your password successfully.",
       "SuccessAlertBody": "Please note it may take a few hours for your new password to reach all domain controllers.",
-      "ErrorPasswordChangeNotAllowed": "You are not allowed to change your password. Please contact your system administrator.",
+      "ErrorPasswordChangeNotAllowed": "Your password cannot be changed at this time. Please contact your system administrator or IT help desk.",
       "ErrorInvalidCredentials": "You need to provide the correct current password.",
       "ErrorInvalidDomain": "You have supplied an invalid domain to logon to.",
       "ErrorInvalidUser": "We could not find your user account.",
       "ErrorCaptcha": "Could not verify you are not a robot.",
       "ErrorFieldRequired": "Fulfill all the fields.",
       "ErrorFieldMismatch": "The passwords do not match.",
-      "ErrorComplexPassword": "Failed due to password complexity policies: New password length is shorter than AD minimum password length",
+      "ErrorComplexPassword": "The new password was rejected by the domain's password policy. Check the minimum length and complexity requirements, that it was not used before, and that the current password is old enough to be changed.",
       "ErrorConnectionLdap": "Unhandled error connecting to the LDAP server.",
       "ErrorScorePassword": "The password you are trying to set is not secure enough.",
       "ErrorDistancePassword": "The password you are trying to set is not different enough from your last password.",

--- a/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeOptions.cs
+++ b/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeOptions.cs
@@ -109,18 +109,24 @@ public class LdapPasswordChangeOptions : IAppSettings
     public string? LdapSearchBase { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether [hide user not found].
+    /// Gets or sets the deprecated [hide user not found] switch.
     /// </summary>
     /// <remarks>
-    /// When the user cannot be located in the directory, you can
-    /// either expose that error, or hide it and treat like an arbitrary
-    /// bad credential -- in order to prevent brute force attack to
-    /// discover the presence or absence of a username.
+    /// Deprecated and non-functional: superseded by
+    /// <see cref="ErrorDisclosureMode"/>, which controls user-not-found
+    /// disclosure consistently across providers (<c>Hardened</c> hides it like
+    /// <c>HideUserNotFound=true</c> did; <c>Informative</c> discloses it like
+    /// <c>HideUserNotFound=false</c> did). The property remains only so that
+    /// configurations still carrying the key produce a startup warning instead
+    /// of silently changing meaning; its value has no effect.
     /// </remarks>
     /// <value>
-    ///   <c>true</c> if [hide user not found]; otherwise, <c>false</c>.
+    /// Non-null when the configuration still sets the deprecated key.
     /// </value>
-    public bool HideUserNotFound { get; set; } = true;
+    public bool? HideUserNotFound { get; set; }
+
+    /// <inheritdoc />
+    public ErrorDisclosureMode ErrorDisclosureMode { get; set; } = ErrorDisclosureMode.Hardened;
 
     /// <summary>
     /// Gets or sets a value indicating whether [LDAP change password with delete add].

--- a/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeProvider.cs
+++ b/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeProvider.cs
@@ -61,6 +61,16 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
             "and new passwords will be sent to the LDAP server unencrypted. Enable one of " +
             "them unless the connection is protected by other means (e.g. a local test server).");
 
+    private static readonly Action<ILogger, ErrorDisclosureMode, Exception?> LogHideUserNotFoundDeprecated =
+        LoggerMessage.Define<ErrorDisclosureMode>(
+            LogLevel.Warning,
+            new EventId(101, nameof(LogHideUserNotFoundDeprecated)),
+            "The HideUserNotFound setting is deprecated and has no effect. User-not-found " +
+            "disclosure is controlled by ErrorDisclosureMode (currently {ErrorDisclosureMode}): " +
+            "'Hardened' hides unknown users like HideUserNotFound=true did; 'Informative' " +
+            "discloses them like HideUserNotFound=false did. Remove HideUserNotFound from the " +
+            "configuration and set ErrorDisclosureMode explicitly if the default is not wanted.");
+
     private static readonly string[] RequiredAttributes =
     {
         "distinguishedName",
@@ -81,6 +91,9 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
 
         if (!_options.LdapSecureSocketLayer && !_options.LdapStartTls)
             LogNoTransportSecurity(Logger, null);
+
+        if (_options.HideUserNotFound.HasValue)
+            LogHideUserNotFoundDeprecated(Logger, _options.ErrorDisclosureMode, null);
 
         // First find user DN by username (SAM Account Name)
         _searchConstraints = new(
@@ -124,7 +137,7 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
         }
         catch (LdapException ex)
         {
-            throw TranslateLdapException(ex);
+            throw TranslateLdapException(ex, _options.ErrorDisclosureMode);
         }
         catch (Exception ex)
         {
@@ -217,7 +230,7 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
         }
         catch (LdapException ex)
         {
-            throw TranslateLdapException(ex);
+            throw TranslateLdapException(ex, _options.ErrorDisclosureMode);
         }
         catch (Exception ex)
         {
@@ -250,10 +263,9 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
 
         if (!search.HasMore())
         {
-            if (_options.HideUserNotFound)
-                throw new InvalidCredentialsException(DirectoryErrorTranslator.InvalidCredentialsMessage);
-
-            throw new UserNotFoundException("User not found");
+            // Posture-aware existence handling shared with the AD provider
+            // (replaces the deprecated LDAP-only HideUserNotFound switch).
+            throw DirectoryErrorTranslator.CreateUserNotFoundError(_options.ErrorDisclosureMode);
         }
 
         var entry = search.Next();
@@ -472,14 +484,14 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
     /// bind-style errors lead with a generic SEC_E code and carry the Win32 code
     /// in the "data" field ("80090308: LdapErr: ..., data 52e, v2580"). Routing
     /// of the extracted code is delegated to
-    /// <see cref="DirectoryErrorTranslator.Translate(int, Exception?)"/> — see
-    /// that class for the routing table and the interim conservative posture.
+    /// <see cref="DirectoryErrorTranslator.Translate(int, ErrorDisclosureMode, Exception?)"/> —
+    /// see that class for the per-mode routing table.
     /// Messages with no recognizable Win32 code become a
     /// <see cref="DirectoryUnavailableException"/> whose wire message is a fixed
     /// curated string; the server's diagnostic text survives only in the inner
     /// exception, which reaches logs but never the wire.
     /// </summary>
-    internal static Exception TranslateLdapException(LdapException ex)
+    internal static Exception TranslateLdapException(LdapException ex, ErrorDisclosureMode disclosureMode)
     {
         var known = string.IsNullOrWhiteSpace(ex.LdapErrorMessage)
             ? null
@@ -487,7 +499,7 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
 
         return known is null
             ? new DirectoryUnavailableException(DirectoryErrorTranslator.DirectoryFailureMessage, ex)
-            : DirectoryErrorTranslator.Translate(known.Code, ex);
+            : DirectoryErrorTranslator.Translate(known.Code, disclosureMode, ex);
     }
 
     /// <summary>

--- a/tests/Unosquare.PassCore.Common.Tests/DirectoryErrorTranslatorTests.cs
+++ b/tests/Unosquare.PassCore.Common.Tests/DirectoryErrorTranslatorTests.cs
@@ -7,42 +7,84 @@ namespace Unosquare.PassCore.Common.Tests;
 
 public class DirectoryErrorTranslatorTests
 {
-    // Expected routing for every cataloged Win32 code. Deliberately duplicated
-    // from the production table so that changing a routing decision requires a
-    // conscious change here too.
-    public static TheoryData<int, Type, ApiErrorCode, string> RoutingTable => new()
+    // Expected routing for every cataloged Win32 code in both disclosure modes.
+    // Deliberately duplicated from the production table so that changing a
+    // routing decision requires a conscious change here too.
+    public static TheoryData<int, ErrorDisclosureMode, Type, ApiErrorCode, string> RoutingTable
     {
-        { 0x005, typeof(DirectoryUnavailableException), ApiErrorCode.LdapProblem, DirectoryErrorTranslator.DirectoryFailureMessage },
-        { 0x056, typeof(InvalidCredentialsException), ApiErrorCode.InvalidCredentials, DirectoryErrorTranslator.InvalidCredentialsMessage },
-        { 0x523, typeof(InvalidCredentialsException), ApiErrorCode.InvalidCredentials, DirectoryErrorTranslator.InvalidCredentialsMessage },
-        { 0x524, typeof(DirectoryUnavailableException), ApiErrorCode.LdapProblem, DirectoryErrorTranslator.DirectoryFailureMessage },
-        { 0x525, typeof(InvalidCredentialsException), ApiErrorCode.InvalidCredentials, DirectoryErrorTranslator.InvalidCredentialsMessage },
-        { 0x52B, typeof(InvalidCredentialsException), ApiErrorCode.InvalidCredentials, DirectoryErrorTranslator.InvalidCredentialsMessage },
-        { 0x52C, typeof(PasswordPolicyViolationException), ApiErrorCode.ComplexPassword, DirectoryErrorTranslator.NewPasswordPolicyMessage },
-        { 0x52D, typeof(PasswordPolicyViolationException), ApiErrorCode.ComplexPassword, DirectoryErrorTranslator.NewPasswordPolicyMessage },
-        { 0x52E, typeof(InvalidCredentialsException), ApiErrorCode.InvalidCredentials, DirectoryErrorTranslator.InvalidCredentialsMessage },
-        { 0x52F, typeof(InvalidCredentialsException), ApiErrorCode.InvalidCredentials, DirectoryErrorTranslator.InvalidCredentialsMessage },
-        { 0x530, typeof(InvalidCredentialsException), ApiErrorCode.InvalidCredentials, DirectoryErrorTranslator.InvalidCredentialsMessage },
-        { 0x531, typeof(InvalidCredentialsException), ApiErrorCode.InvalidCredentials, DirectoryErrorTranslator.InvalidCredentialsMessage },
-        { 0x532, typeof(InvalidCredentialsException), ApiErrorCode.InvalidCredentials, DirectoryErrorTranslator.InvalidCredentialsMessage },
-        { 0x533, typeof(InvalidCredentialsException), ApiErrorCode.InvalidCredentials, DirectoryErrorTranslator.InvalidCredentialsMessage },
-        { 0x701, typeof(InvalidCredentialsException), ApiErrorCode.InvalidCredentials, DirectoryErrorTranslator.InvalidCredentialsMessage },
-        { 0x773, typeof(InvalidCredentialsException), ApiErrorCode.InvalidCredentials, DirectoryErrorTranslator.InvalidCredentialsMessage },
-        { 0x774, typeof(DirectoryUnavailableException), ApiErrorCode.LdapProblem, DirectoryErrorTranslator.DirectoryFailureMessage },
-        { 0x775, typeof(InvalidCredentialsException), ApiErrorCode.InvalidCredentials, DirectoryErrorTranslator.InvalidCredentialsMessage },
-        { 0x8C3, typeof(PasswordPolicyViolationException), ApiErrorCode.ChangeNotPermitted, DirectoryErrorTranslator.ChangeNotPermittedMessage },
-        { 0x8C4, typeof(PasswordPolicyViolationException), ApiErrorCode.ComplexPassword, DirectoryErrorTranslator.NewPasswordPolicyMessage },
-        { 0x8C5, typeof(PasswordPolicyViolationException), ApiErrorCode.ComplexPassword, DirectoryErrorTranslator.NewPasswordPolicyMessage },
-        { 0x8C6, typeof(PasswordPolicyViolationException), ApiErrorCode.ComplexPassword, DirectoryErrorTranslator.NewPasswordPolicyMessage },
-    };
+        get
+        {
+            var data = new TheoryData<int, ErrorDisclosureMode, Type, ApiErrorCode, string>();
+
+            // (code, hardened expectation, informative expectation)
+            foreach (var (code, hardened, informative) in new (int, Expectation, Expectation)[]
+            {
+                (0x005, Infra, Infra),
+                (0x056, Credentials, Credentials),
+                (0x523, Credentials, NotFound),
+                (0x524, Infra, Infra),
+                (0x525, Credentials, NotFound),
+                (0x52B, Credentials, Credentials),
+                (0x52C, Policy, Policy),
+                (0x52D, Policy, Policy),
+                (0x52E, Credentials, Credentials),
+                (0x52F, Credentials, AccountState),
+                (0x530, Credentials, AccountState),
+                (0x531, Credentials, AccountState),
+                (0x532, Credentials, Credentials),
+                (0x533, Credentials, AccountState),
+                (0x701, Credentials, AccountState),
+                (0x773, Credentials, Credentials),
+                (0x774, Infra, Infra),
+                (0x775, Credentials, AccountState),
+                (0x8C3, CannotChange, CannotChange),
+                (0x8C4, Policy, Policy),
+                (0x8C5, Policy, Policy),
+                (0x8C6, Policy, Policy),
+            })
+            {
+                data.Add(code, ErrorDisclosureMode.Hardened, hardened.ExceptionType, hardened.Code, hardened.Message);
+                data.Add(code, ErrorDisclosureMode.Informative, informative.ExceptionType, informative.Code, informative.Message);
+            }
+
+            return data;
+        }
+    }
+
+    private sealed record Expectation(Type ExceptionType, ApiErrorCode Code, string Message);
+
+    private static Expectation Credentials => new(
+        typeof(InvalidCredentialsException), ApiErrorCode.InvalidCredentials,
+        DirectoryErrorTranslator.InvalidCredentialsMessage);
+
+    private static Expectation NotFound => new(
+        typeof(UserNotFoundException), ApiErrorCode.UserNotFound,
+        DirectoryErrorTranslator.UserNotFoundMessage);
+
+    private static Expectation AccountState => new(
+        typeof(PasswordPolicyViolationException), ApiErrorCode.ChangeNotPermitted,
+        DirectoryErrorTranslator.AccountStateMessage);
+
+    private static Expectation Policy => new(
+        typeof(PasswordPolicyViolationException), ApiErrorCode.ComplexPassword,
+        DirectoryErrorTranslator.NewPasswordPolicyMessage);
+
+    private static Expectation CannotChange => new(
+        typeof(PasswordPolicyViolationException), ApiErrorCode.ChangeNotPermitted,
+        DirectoryErrorTranslator.ChangeNotPermittedMessage);
+
+    private static Expectation Infra => new(
+        typeof(DirectoryUnavailableException), ApiErrorCode.LdapProblem,
+        DirectoryErrorTranslator.DirectoryFailureMessage);
 
     [Theory]
     [MemberData(nameof(RoutingTable))]
-    public void Translate_CatalogedCode_RoutesPerTable(int code, Type exceptionType, ApiErrorCode apiCode, string message)
+    public void Translate_CatalogedCode_RoutesPerTable(
+        int code, ErrorDisclosureMode mode, Type exceptionType, ApiErrorCode apiCode, string message)
     {
         var inner = new InvalidOperationException("raw transport detail");
 
-        var translated = DirectoryErrorTranslator.Translate(code, inner);
+        var translated = DirectoryErrorTranslator.Translate(code, mode, inner);
 
         Assert.IsType(exceptionType, translated);
         Assert.Same(inner, translated.InnerException);
@@ -54,19 +96,64 @@ public class DirectoryErrorTranslatorTests
     }
 
     [Fact]
-    public void RoutingTable_CoversEntireCatalog()
+    public void RoutingTable_CoversEntireCatalogInBothModes()
     {
-        var testedCodes = RoutingTable.Select(row => (int)row[0]).OrderBy(c => c);
-        var catalogedCodes = Win32ErrorCode.Codes.Select(c => c.Code).OrderBy(c => c);
+        var testedCodes = RoutingTable
+            .Select(row => ((int)row[0], (ErrorDisclosureMode)row[1]))
+            .Distinct()
+            .OrderBy(pair => pair.Item1).ThenBy(pair => pair.Item2)
+            .ToList();
 
-        // A code added to the catalog must also get an explicit routing expectation here.
-        Assert.Equal(catalogedCodes, testedCodes);
+        var expected = Win32ErrorCode.Codes
+            .SelectMany(c => new[]
+            {
+                (c.Code, ErrorDisclosureMode.Hardened),
+                (c.Code, ErrorDisclosureMode.Informative),
+            })
+            .OrderBy(pair => pair.Item1).ThenBy(pair => pair.Item2)
+            .ToList();
+
+        // A code added to the catalog must also get explicit per-mode routing
+        // expectations here.
+        Assert.Equal(expected, testedCodes);
     }
 
     [Fact]
-    public void Translate_UnknownCode_DegradesToDirectoryUnavailable()
+    public void Translate_Hardened_WrongPasswordUnknownUserAndLockedAreByteIdentical()
     {
-        var translated = DirectoryErrorTranslator.Translate(0x9999);
+        // The hardened-mode guarantee: no oracle survives in the JSON.
+        var wrongPassword = ApiErrorMapper.Map(DirectoryErrorTranslator.Translate(0x52E, ErrorDisclosureMode.Hardened));
+        var unknownUser = ApiErrorMapper.Map(DirectoryErrorTranslator.Translate(0x525, ErrorDisclosureMode.Hardened));
+        var lockedOut = ApiErrorMapper.Map(DirectoryErrorTranslator.Translate(0x775, ErrorDisclosureMode.Hardened));
+        var disabled = ApiErrorMapper.Map(DirectoryErrorTranslator.Translate(0x533, ErrorDisclosureMode.Hardened));
+        var structuralNotFound = ApiErrorMapper.Map(
+            DirectoryErrorTranslator.CreateUserNotFoundError(ErrorDisclosureMode.Hardened));
+
+        foreach (var item in new[] { unknownUser, lockedOut, disabled, structuralNotFound })
+        {
+            Assert.Equal(wrongPassword.ErrorCode, item.ErrorCode);
+            Assert.Equal(wrongPassword.Message, item.Message);
+        }
+    }
+
+    [Theory]
+    [InlineData(ErrorDisclosureMode.Hardened, typeof(InvalidCredentialsException), ApiErrorCode.InvalidCredentials)]
+    [InlineData(ErrorDisclosureMode.Informative, typeof(UserNotFoundException), ApiErrorCode.UserNotFound)]
+    public void CreateUserNotFoundError_FollowsDisclosureMode(
+        ErrorDisclosureMode mode, Type exceptionType, ApiErrorCode apiCode)
+    {
+        var ex = DirectoryErrorTranslator.CreateUserNotFoundError(mode);
+
+        Assert.IsType(exceptionType, ex);
+        Assert.Equal(apiCode, ApiErrorMapper.Map(ex).ErrorCode);
+    }
+
+    [Theory]
+    [InlineData(ErrorDisclosureMode.Hardened)]
+    [InlineData(ErrorDisclosureMode.Informative)]
+    public void Translate_UnknownCode_DegradesToDirectoryUnavailableInBothModes(ErrorDisclosureMode mode)
+    {
+        var translated = DirectoryErrorTranslator.Translate(0x9999, mode);
 
         var dir = Assert.IsType<DirectoryUnavailableException>(translated);
         Assert.Equal(DirectoryErrorTranslator.DirectoryFailureMessage, dir.Message);
@@ -76,7 +163,7 @@ public class DirectoryErrorTranslatorTests
     [Fact]
     public void Translate_WithoutInnerException_Succeeds()
     {
-        var translated = DirectoryErrorTranslator.Translate(0x52E);
+        var translated = DirectoryErrorTranslator.Translate(0x52E, ErrorDisclosureMode.Hardened);
 
         Assert.IsType<InvalidCredentialsException>(translated);
         Assert.Null(translated.InnerException);
@@ -158,8 +245,10 @@ public class DirectoryErrorTranslatorTests
     // TranslateException end-to-end
     // ------------------------------------------------------------------
 
-    [Fact]
-    public void TranslateException_PolicyHResult_MapsToComplexPassword()
+    [Theory]
+    [InlineData(ErrorDisclosureMode.Hardened)]
+    [InlineData(ErrorDisclosureMode.Informative)]
+    public void TranslateException_PolicyHResult_MapsToComplexPasswordInBothModes(ErrorDisclosureMode mode)
     {
         // The AD automatic-context policy failure: previously escaped as
         // Generic + raw .NET message.
@@ -167,7 +256,7 @@ public class DirectoryErrorTranslatorTests
             unchecked((int)0x800708C5),
             "The password does not meet the password policy requirements (raw .NET text)");
 
-        var item = ApiErrorMapper.Map(DirectoryErrorTranslator.TranslateException(raw));
+        var item = ApiErrorMapper.Map(DirectoryErrorTranslator.TranslateException(raw, mode));
 
         Assert.Equal(ApiErrorCode.ComplexPassword, item.ErrorCode);
         Assert.Equal(DirectoryErrorTranslator.NewPasswordPolicyMessage, item.Message);
@@ -179,7 +268,7 @@ public class DirectoryErrorTranslatorTests
     {
         var raw = new InvalidOperationException("secret internal diagnostic");
 
-        var translated = DirectoryErrorTranslator.TranslateException(raw);
+        var translated = DirectoryErrorTranslator.TranslateException(raw, ErrorDisclosureMode.Hardened);
 
         var dir = Assert.IsType<DirectoryUnavailableException>(translated);
         Assert.Same(raw, dir.InnerException); // detail preserved for logs
@@ -195,7 +284,8 @@ public class DirectoryErrorTranslatorTests
     {
         var raw = new HResultException(unchecked((int)0x80070056));
 
-        var item = ApiErrorMapper.Map(DirectoryErrorTranslator.TranslateException(raw));
+        var item = ApiErrorMapper.Map(
+            DirectoryErrorTranslator.TranslateException(raw, ErrorDisclosureMode.Hardened));
 
         Assert.Equal(ApiErrorCode.InvalidCredentials, item.ErrorCode);
         Assert.Equal(DirectoryErrorTranslator.InvalidCredentialsMessage, item.Message);

--- a/tests/Unosquare.PassCore.Common.Tests/PasswordChangeProviderBaseTests.cs
+++ b/tests/Unosquare.PassCore.Common.Tests/PasswordChangeProviderBaseTests.cs
@@ -104,16 +104,45 @@ public class PasswordChangeProviderBaseTests
     }
 
     [Fact]
-    public async Task ChangePasswordAsync_GenericExceptionFromCore_MappedToGeneric()
+    public async Task ChangePasswordAsync_GenericExceptionFromCore_MappedToGenericWithoutRawText()
     {
+        // Expectation changed deliberately: the catch-all used to serialize the
+        // raw exception message ("Operation failed"), which the UI renders
+        // verbatim for the Generic code. It now returns a clean surface message
+        // carrying only a correlation reference; the detail stays in logs.
         var provider = new TestProvider();
         var context = new PasswordChangeContext("fail", "old", "new", new ClientSettings());
 
         var result = await provider.TestChangePasswordAsync(context);
 
         Assert.False(result.IsSuccessful);
-        Assert.Equal(ApiErrorCode.Generic, result.Errors.Single().ErrorCode);
-        Assert.Equal("Operation failed", result.Errors.Single().Message);
+        var error = result.Errors.Single();
+        Assert.Equal(ApiErrorCode.Generic, error.ErrorCode);
+        Assert.NotNull(error.Message);
+        Assert.StartsWith("An unexpected error occurred", error.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("Operation failed", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PerformPasswordChangeAsync_GeneratesCorrelationIdAndEmbedsItInGenericFailures()
+    {
+        string? observedCorrelationId = null;
+
+        var policy = new Mock<IPasswordPolicy>();
+        policy.Setup(p => p.ValidateAsync(It.IsAny<PasswordChangeContext>(), It.IsAny<IPasswordChangeProvider>()))
+            .Callback<PasswordChangeContext, IPasswordChangeProvider>((ctx, _) => observedCorrelationId = ctx.CorrelationId)
+            .Returns(Task.CompletedTask);
+
+        var provider = new TestProvider(new[] { policy.Object });
+
+        var result = await provider.PerformPasswordChangeAsync("fail", "old", "new");
+
+        Assert.False(string.IsNullOrWhiteSpace(observedCorrelationId));
+        Assert.False(result.IsSuccessful);
+        var error = result.Errors.Single();
+        Assert.Equal(ApiErrorCode.Generic, error.ErrorCode);
+        Assert.NotNull(error.Message);
+        Assert.Contains(observedCorrelationId!, error.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Unosquare.PassCore.Common.Tests/Policies/PwnedPasswordPolicyTests.cs
+++ b/tests/Unosquare.PassCore.Common.Tests/Policies/PwnedPasswordPolicyTests.cs
@@ -65,6 +65,31 @@ public class PwnedPasswordPolicyTests
         Assert.Equal(ApiErrorCode.Generic, ex.ErrorCode);
     }
 
+    [Theory]
+    [InlineData(typeof(PwnedPasswordsApiException))]
+    [InlineData(typeof(PwnedPasswordsSearchException))]
+    public async Task ValidateAsync_ApiFailure_NeverLeaksClientExceptionText(Type exceptionType)
+    {
+        // The Generic code renders its message verbatim in the UI, so the HIBP
+        // client's internal detail must never appear in it — only a clean
+        // message with the correlation reference.
+        var raw = (Exception)Activator.CreateInstance(
+            exceptionType, "HIBP internals: socket timed out at 10.0.0.5:443", null)!;
+        var search = new FaultySearch(raw);
+        var policy = new PwnedPasswordPolicy(search);
+        var settings = new ClientSettings { EnablePwnedPasswordCheck = true };
+        var context = new PasswordChangeContext("u", "old", "any", settings, correlationId: "abc12345");
+
+        var ex = await Assert.ThrowsAsync<PasswordPolicyViolationException>(
+            () => policy.ValidateAsync(context, provider: null!));
+
+        Assert.Equal(ApiErrorCode.Generic, ex.ErrorCode);
+        Assert.DoesNotContain("HIBP internals", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("10.0.0.5", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("abc12345", ex.Message, StringComparison.Ordinal);
+        Assert.Same(raw, ex.InnerException); // detail preserved for the base class's logging
+    }
+
     private sealed class ThrowingSearch : IPwnedPasswordSearch
     {
         public bool WasCalled { get; private set; }

--- a/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/LdapDisclosureOptionsTests.cs
+++ b/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/LdapDisclosureOptionsTests.cs
@@ -1,0 +1,79 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Unosquare.PassCore.Common;
+using Unosquare.PassCore.Common.Models;
+
+namespace Zyborg.PassCore.PasswordProvider.LDAP.Tests;
+
+public class LdapDisclosureOptionsTests
+{
+    private static LdapPasswordChangeOptions ValidOptions() => new()
+    {
+        LdapHostnames = new[] { "ldap.example.com" },
+        LdapPort = 636,
+        LdapUsername = "cn=admin,dc=example,dc=com",
+        LdapPassword = "secret",
+        LdapSearchBase = "dc=example,dc=com",
+        LdapSearchFilter = "(sAMAccountName={Username})",
+        LdapSecureSocketLayer = true,
+    };
+
+    private static CapturingLogger Construct(LdapPasswordChangeOptions opts)
+    {
+        var logger = new CapturingLogger();
+        _ = new LdapPasswordChangeProvider(
+            logger,
+            Options.Create(opts),
+            Options.Create(new ClientSettings()),
+            Array.Empty<IPasswordPolicy>());
+        return logger;
+    }
+
+    [Fact]
+    public void Construct_DefaultDisclosureMode_IsHardened()
+    {
+        Assert.Equal(ErrorDisclosureMode.Hardened, new LdapPasswordChangeOptions().ErrorDisclosureMode);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Construct_DeprecatedHideUserNotFoundConfigured_LogsWarning(bool value)
+    {
+        var opts = ValidOptions();
+        opts.HideUserNotFound = value;
+
+        var logger = Construct(opts);
+
+        Assert.Contains(logger.Entries, e =>
+            e.Level == LogLevel.Warning &&
+            e.Message.Contains("HideUserNotFound", StringComparison.Ordinal) &&
+            e.Message.Contains("ErrorDisclosureMode", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Construct_HideUserNotFoundAbsent_DoesNotLogDeprecationWarning()
+    {
+        var logger = Construct(ValidOptions());
+
+        Assert.DoesNotContain(logger.Entries, e =>
+            e.Message.Contains("HideUserNotFound", StringComparison.Ordinal));
+    }
+
+    private sealed class CapturingLogger : ILogger<LdapPasswordChangeProvider>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            Entries.Add((logLevel, formatter(state, exception)));
+    }
+}

--- a/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/LdapExceptionTranslationTests.cs
+++ b/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/LdapExceptionTranslationTests.cs
@@ -31,7 +31,8 @@ public class LdapExceptionTranslationTests
     public void Translate_BindStyleLogonFailure_MapsToInvalidCredentials()
     {
         var result = LdapPasswordChangeProvider.TranslateLdapException(
-            Ldap(BindLogonFailure, LdapException.InvalidCredentials));
+            Ldap(BindLogonFailure, LdapException.InvalidCredentials),
+            ErrorDisclosureMode.Hardened);
 
         Assert.IsType<InvalidCredentialsException>(result);
     }
@@ -40,7 +41,8 @@ public class LdapExceptionTranslationTests
     public void Translate_ModifyPasswordRestriction_MapsToPolicyViolation()
     {
         var result = LdapPasswordChangeProvider.TranslateLdapException(
-            Ldap(ModifyPasswordRestriction, LdapException.UnwillingToPerform));
+            Ldap(ModifyPasswordRestriction, LdapException.UnwillingToPerform),
+            ErrorDisclosureMode.Hardened);
 
         var policy = Assert.IsType<PasswordPolicyViolationException>(result);
         Assert.Equal(ApiErrorCode.ComplexPassword, policy.ErrorCode);
@@ -50,7 +52,8 @@ public class LdapExceptionTranslationTests
     public void Translate_ModifyWrongOldPassword_MapsToInvalidCredentials()
     {
         var result = LdapPasswordChangeProvider.TranslateLdapException(
-            Ldap(ModifyWrongOldPassword, LdapException.ConstraintViolation));
+            Ldap(ModifyWrongOldPassword, LdapException.ConstraintViolation),
+            ErrorDisclosureMode.Hardened);
 
         Assert.IsType<InvalidCredentialsException>(result);
     }
@@ -64,7 +67,7 @@ public class LdapExceptionTranslationTests
         const string message = "some vendor-specific failure without codes";
         var ldapEx = Ldap(message);
 
-        var result = LdapPasswordChangeProvider.TranslateLdapException(ldapEx);
+        var result = LdapPasswordChangeProvider.TranslateLdapException(ldapEx, ErrorDisclosureMode.Hardened);
 
         var dir = Assert.IsType<DirectoryUnavailableException>(result);
         Assert.Equal(DirectoryErrorTranslator.DirectoryFailureMessage, dir.Message);
@@ -75,25 +78,49 @@ public class LdapExceptionTranslationTests
     [Fact]
     public void Translate_EmptyServerMessage_MapsToDirectoryUnavailable()
     {
-        var result = LdapPasswordChangeProvider.TranslateLdapException(Ldap(string.Empty));
+        var result = LdapPasswordChangeProvider.TranslateLdapException(Ldap(string.Empty), ErrorDisclosureMode.Hardened);
 
         Assert.IsType<DirectoryUnavailableException>(result);
     }
 
+    private const string BindAccountLockedOut =
+        "80090308: LdapErr: DSID-0C0903A9, comment: AcceptSecurityContext error, data 775, v2580";
+
+    private const string BindNoSuchUser =
+        "80090308: LdapErr: DSID-0C0903A9, comment: AcceptSecurityContext error, data 525, v2580";
+
     [Fact]
-    public void Translate_AccountLockedOut_RoutesToInvalidCredentialsUnderConservativePosture()
+    public void Translate_AccountLockedOut_Hardened_IsIndistinguishableFromWrongCredentials()
     {
-        // Expectation changed deliberately: account-state codes (locked, disabled,
-        // hours, restriction) used to surface as a directory error naming the
-        // condition; under the interim conservative posture they are
-        // indistinguishable from wrong credentials so the account state leaks
-        // to no one. A later phase makes this configurable.
-        var result = LdapPasswordChangeProvider.TranslateLdapException(Ldap(
-            "80090308: LdapErr: DSID-0C0903A9, comment: AcceptSecurityContext error, data 775, v2580",
-            LdapException.InvalidCredentials));
+        var result = LdapPasswordChangeProvider.TranslateLdapException(
+            Ldap(BindAccountLockedOut, LdapException.InvalidCredentials),
+            ErrorDisclosureMode.Hardened);
 
         var cred = Assert.IsType<InvalidCredentialsException>(result);
         Assert.Equal(DirectoryErrorTranslator.InvalidCredentialsMessage, cred.Message);
+    }
+
+    [Fact]
+    public void Translate_AccountLockedOut_Informative_ReportsChangeNotPermitted()
+    {
+        var result = LdapPasswordChangeProvider.TranslateLdapException(
+            Ldap(BindAccountLockedOut, LdapException.InvalidCredentials),
+            ErrorDisclosureMode.Informative);
+
+        var policy = Assert.IsType<PasswordPolicyViolationException>(result);
+        Assert.Equal(ApiErrorCode.ChangeNotPermitted, policy.ErrorCode);
+        Assert.Equal(DirectoryErrorTranslator.AccountStateMessage, policy.Message);
+    }
+
+    [Fact]
+    public void Translate_NoSuchUser_Informative_ReportsUserNotFound()
+    {
+        var result = LdapPasswordChangeProvider.TranslateLdapException(
+            Ldap(BindNoSuchUser, LdapException.InvalidCredentials),
+            ErrorDisclosureMode.Informative);
+
+        var notFound = Assert.IsType<UserNotFoundException>(result);
+        Assert.Equal(DirectoryErrorTranslator.UserNotFoundMessage, notFound.Message);
     }
 
     [Fact]

--- a/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/ProviderParityTests.cs
+++ b/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/ProviderParityTests.cs
@@ -6,31 +6,35 @@ namespace Zyborg.PassCore.PasswordProvider.LDAP.Tests;
 /// <summary>
 /// Asserts that the same underlying Win32/AD condition produces an identical
 /// <see cref="ApiErrorItem"/> (code and message) regardless of the transport
-/// that surfaced it: an LDAP bind-style extended error, an LDAP modify-style
+/// that surfaced it — an LDAP bind-style extended error, an LDAP modify-style
 /// extended error, or a COM-style HRESULT as unwrapped from an
-/// AccountManagement exception chain. The first two run through the LDAP
-/// provider's real translation entry point; the third runs through
-/// <see cref="DirectoryErrorTranslator.TranslateException"/>, which is the
-/// exact call the Windows AD provider's catch block delegates to (that
-/// provider is compiled only on Windows, so its two-line glue cannot be
+/// AccountManagement exception chain — in both disclosure modes. The first two
+/// run through the LDAP provider's real translation entry point; the third
+/// runs through <see cref="DirectoryErrorTranslator.TranslateException"/>,
+/// which is the exact call the Windows AD provider's catch block delegates to
+/// (that provider is compiled only on Windows, so its two-line glue cannot be
 /// exercised by this cross-platform suite — noted limitation).
 /// </summary>
 public class ProviderParityTests
 {
-    public static TheoryData<int> CatalogedCodes
+    public static TheoryData<int, ErrorDisclosureMode> CatalogedCodesInBothModes
     {
         get
         {
-            var data = new TheoryData<int>();
+            var data = new TheoryData<int, ErrorDisclosureMode>();
             foreach (var entry in Win32ErrorCode.Codes)
-                data.Add(entry.Code);
+            {
+                data.Add(entry.Code, ErrorDisclosureMode.Hardened);
+                data.Add(entry.Code, ErrorDisclosureMode.Informative);
+            }
+
             return data;
         }
     }
 
     [Theory]
-    [MemberData(nameof(CatalogedCodes))]
-    public void AllTransports_SameWin32Code_ProduceIdenticalApiErrorItems(int code)
+    [MemberData(nameof(CatalogedCodesInBothModes))]
+    public void AllTransports_SameWin32Code_ProduceIdenticalApiErrorItems(int code, ErrorDisclosureMode mode)
     {
         // LDAP transport, bind-style: generic SEC_E leading code, Win32 code in "data".
         var bindStyle = new LdapException("test", LdapException.InvalidCredentials,
@@ -44,9 +48,9 @@ public class ProviderParityTests
         // shape AccountManagement wraps around COM errors.
         var adStyle = new HResultException(unchecked((int)0x80070000 | code));
 
-        var fromBind = ApiErrorMapper.Map(LdapPasswordChangeProvider.TranslateLdapException(bindStyle));
-        var fromModify = ApiErrorMapper.Map(LdapPasswordChangeProvider.TranslateLdapException(modifyStyle));
-        var fromHResult = ApiErrorMapper.Map(DirectoryErrorTranslator.TranslateException(adStyle));
+        var fromBind = ApiErrorMapper.Map(LdapPasswordChangeProvider.TranslateLdapException(bindStyle, mode));
+        var fromModify = ApiErrorMapper.Map(LdapPasswordChangeProvider.TranslateLdapException(modifyStyle, mode));
+        var fromHResult = ApiErrorMapper.Map(DirectoryErrorTranslator.TranslateException(adStyle, mode));
 
         Assert.Equal(fromBind.ErrorCode, fromModify.ErrorCode);
         Assert.Equal(fromBind.ErrorCode, fromHResult.ErrorCode);
@@ -59,8 +63,10 @@ public class ProviderParityTests
         Assert.DoesNotContain("DSID", fromModify.Message, StringComparison.Ordinal);
     }
 
-    [Fact]
-    public void AllTransports_UnknownCode_ProduceIdenticalInfrastructureItems()
+    [Theory]
+    [InlineData(ErrorDisclosureMode.Hardened)]
+    [InlineData(ErrorDisclosureMode.Informative)]
+    public void AllTransports_UnknownCode_ProduceIdenticalInfrastructureItems(ErrorDisclosureMode mode)
     {
         const int unknownCode = 0x9999;
 
@@ -68,8 +74,8 @@ public class ProviderParityTests
             $"80090308: LdapErr: DSID-0C090439, comment: AcceptSecurityContext error, data {unknownCode:x}, v3839");
         var adStyle = new HResultException(unchecked((int)0x80070000 | unknownCode));
 
-        var fromBind = ApiErrorMapper.Map(LdapPasswordChangeProvider.TranslateLdapException(bindStyle));
-        var fromHResult = ApiErrorMapper.Map(DirectoryErrorTranslator.TranslateException(adStyle));
+        var fromBind = ApiErrorMapper.Map(LdapPasswordChangeProvider.TranslateLdapException(bindStyle, mode));
+        var fromHResult = ApiErrorMapper.Map(DirectoryErrorTranslator.TranslateException(adStyle, mode));
 
         Assert.Equal(ApiErrorCode.LdapProblem, fromBind.ErrorCode);
         Assert.Equal(fromBind.ErrorCode, fromHResult.ErrorCode);


### PR DESCRIPTION
## Description

Phase 2 of the error-routing series (builds on the merged #40): the disclosure posture is now a **single server-side setting**, `AppSettings:ErrorDisclosureMode` (`"Hardened"` default / `"Informative"`), enforced exclusively inside `DirectoryErrorTranslator` and subsuming the LDAP-only `HideUserNotFound`. Also lands the mode-independent raw-text leak fixes (`PwnedPasswordPolicy`, `PasswordController`, and the base class catch-all) with real correlation-ID plumbing.

### What was found and changed, per area

**Naming and placement.** The property is declared on `IAppSettings`, which both provider option classes implement — and both bind from the *same* `"AppSettings"` configuration section (`Program.cs` binds `LdapPasswordChangeOptions` and `PasswordChangeOptions` to `GetSection("AppSettings")`), so one JSON key drives both providers by construction. Structural enforcement: the Phase-1 mode-less translator overloads were **removed**, so every translation call must supply the configured mode — a provider cannot route around the posture.

**The mode table (implemented and tested per code, per mode):**

| Condition class | Hardened | Informative |
|---|---|---|
| Existence (`523`, `525`, empty search / null principal) | `InvalidCredentials`, uniform message | `UserNotFound` |
| Account state (`52F`, `530`, `531`, `533`, `701`, `775`) | `InvalidCredentials`, uniform message | `ChangeNotPermitted`, "contact your administrator or IT help desk" |
| Credentials (`56`, `52B`, `52E`) | `InvalidCredentials` | `InvalidCredentials` |
| New-password policy (`52C`, `52D`, `8C4`–`8C6`) | `ComplexPassword` | `ComplexPassword` |
| Expired/must-change (`532`, `773`) | allow through (unchanged, mode-independent) | allow through |
| Cannot-change flag (`8C3`) | `ChangeNotPermitted` | `ChangeNotPermitted` |
| Infra (`5`, `524`, `774`, unknown) | `LdapProblem` | `LdapProblem` |

The structural existence paths (LDAP empty search result, AD null principal) go through a new shared `CreateUserNotFoundError(mode)` helper so they follow the same posture as the coded `525`/`523` failures and cannot drift.

**Wire-message rule.** Non-`Generic` codes carry fixed curated constants — one per class per mode, never per-condition text in hardened mode. A dedicated test proves the hardened guarantee: wrong-password, unknown-user, locked, and disabled produce **byte-identical** `ApiErrorItem`s (code *and* message). `8C3` remains disclosed in both modes: it's only ever produced by the directory after the caller proved the current password (flagged as an open question on #40; unchanged here — one-line table change if you want it hidden).

**Default value: Hardened** (secure by default). The migration consequences are spelled out below — as the series brief noted, one provider's deployments change behavior no matter which default is chosen; Phase 1 already moved AD to hidden, so the hardened default is behavior-preserving for AD and for LDAP deployments using the old `HideUserNotFound=true` default.

**`HideUserNotFound` subsumption: honor-presence-and-warn, behaviorally removed.** The property became nullable and non-functional; if the key is still present in configuration, the provider logs a prominent startup warning (EventId 101) explaining the replacement and the mapping (`true` ≈ Hardened, `false` ≈ Informative). Behavior comes only from `ErrorDisclosureMode`. Rationale: an "honor the old value" bridge cannot be reconciled with an explicitly-set new mode (the binder can't distinguish explicit defaults), and a silent removal would flip `HideUserNotFound=false` deployments without a trace. The warning makes the change loud without forking the routing logic.

**Correlation-ID plumbing — verified and found broken.** The base class *logged* `context.CorrelationId` but nothing ever populated it (always null). `PerformPasswordChangeAsync` now generates an 8-char reference per request. The base catch-all returns `"An unexpected error occurred (ref: …)"` instead of raw `ex.Message` (which the UI renders verbatim for `Generic`).

**The two unconditional leak fixes.** `PwnedPasswordPolicy` no longer embeds HIBP client exception text — it fails closed with a clean "check could not be completed… (ref: …)" message, preserving the original exception as inner (the base class logs policy failures with full detail). `PasswordController`'s two catch-alls log under a fresh reference and return the same clean pattern.

**Alert strings** (`appsettings.json`): `ErrorComplexPassword` reworded per Decision #4 to cover history and minimum-age alongside length/complexity; `ErrorPasswordChangeNotAllowed` softened to "cannot be changed at this time… contact your system administrator or IT help desk" so it reads correctly for both its group-policy use and the new informative account-state responses.

### Grep-level proof of no client leak

`ErrorDisclosureMode` appears in exactly: `Common/ErrorDisclosureMode.cs`, `Common/IAppSettings.cs`, `Common/DirectoryErrorTranslator.cs`, the two provider options/providers, and `appsettings.json` (`AppSettings` section). **Zero occurrences** in `ClientSettings.cs`/`Models` (the only object `PasswordController.Get()` serializes), zero in `ClientApp`. The setting lives in the `AppSettings` config section, which is never bound into `ClientSettings`.

### ClientApp diff — one approved test-only exception

The alert-string rewording mandated by Decision #4 broke four Playwright E2E assertions that hardcoded the *old* default strings (`password-change.spec.ts`, "change not permitted" and "policy violation" tests, chromium+firefox). Per the series constraint I stopped and asked before touching ClientApp; the maintainer approved updating the two expectation strings (`b82ca52`) over the alternative of overriding the old wording in `appsettings.Test.json`, which would have stopped E2E from covering the shipped defaults. **No ClientApp application code is changed** — the diff is two expectation strings in one test spec.

### Investigated and deliberately left alone

- **Recaptcha `BadRequest(ApiResult.InvalidCaptcha())` path**: already a fixed, non-leaking message; unchanged.
- **`ApiErrorMapper`'s fallback branch** (`Generic` + `exception.Message`): only reachable with `PasswordChangeException`-family exceptions, whose messages are curated by construction after Phases 1–2; left as-is rather than adding a defensive rewrite that would obscure the mapper's contract.
- **`appsettings.Test.json` / `appsettings.LdapTest.json`**: neither sets `HideUserNotFound` nor needs the new key (default applies); untouched, and the MokAPI smoke-test expectations (`errorCode 4` for nonexistent user etc.) are preserved by the hardened default.
- **Debug provider**: untouched — it doesn't route through the translator. Whether it should be able to *simulate* both modes is Phase 4's Debug-provider audit item.
- **`UpdatePassword` fallback semantics**: untouched (Phase 3).

### Tests

253 total, all green (Common 107, LDAP 122, Debug 20, Pwned 4). The Phase 1 routing and parity suites were **extended, not duplicated**: the routing table now lists an expectation per cataloged code *per mode* with a completeness guard; the parity suite runs bind-style/modify-style/HRESULT transports across both modes. New: hardened byte-identity test, `CreateUserNotFoundError` mode tests, informative-mode locked/not-found tests, `HideUserNotFound` deprecation-warning tests, correlation-ID generation/embedding tests, and no-leak tests for the Pwned policy (asserting the HIBP text stays out of the message while remaining the inner exception).

**Justified test changes:** `ChangePasswordAsync_GenericExceptionFromCore_MappedToGeneric` asserted the catch-all's raw `ex.Message` passthrough — the exact behavior the series bans — and now asserts the clean ref-pattern message instead (in-test comment explains). The four Playwright expectations described above asserted the old alert wording that Decision #4 replaced.

**Same Windows caveat as #40:** the AD provider is `#if WINDOWS`/`net8.0-windows`, so ubuntu CI doesn't compile it; my edits were compile-verified against real `System.DirectoryServices.*` reference assemblies in a scratch `WINDOWS`-defined build, and the mode-threaded calls it makes are the same Common entry points the tests exercise.

### Open questions for the reviewer

1. **Default = Hardened** flips LDAP deployments that explicitly set `HideUserNotFound=false` to hidden (with a startup warning naming the fix). If you'd rather ship one release honoring the old key's value as the mode fallback, say so — I avoided it because it can't be reconciled with an explicitly-set `ErrorDisclosureMode`.
2. The informative account-state message and the reworded alert strings are wording — happy to adjust phrasing.
3. `8C3` disclosure in hardened mode (carried over from #40's open question #2).

### Migration notes for existing deployments

- **LDAP with `HideUserNotFound=false`**: user-not-found is now hidden by default; set `"ErrorDisclosureMode": "Informative"` to restore disclosure. A startup warning fires while the old key remains in config. (`HideUserNotFound=true`/unset deployments see no change.)
- **Informative mode is new behavior for everyone**: account-state conditions (locked/disabled/expired/hours) report `ChangeNotPermitted` instead of `InvalidCredentials` when enabled.
- **All deployments**: `Generic` errors shown in the UI now read "An unexpected error occurred (ref: …)" instead of raw exception text — the reference correlates with server logs. HIBP outages during pwned-password checks show a clean retry message instead of client internals.
- **Alert strings**: deployments that override `ErrorComplexPassword`/`ErrorPasswordChangeNotAllowed` in their own config keep their overrides; only the shipped defaults changed.
- No `ApiErrorCode` changes, no CI changes, no new dependencies; Phase 1's parity guarantees are preserved and re-tested in both modes.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Refactoring
- [x] Documentation update
- [ ] Testing/CI harness

## Checklist
- [x] All new code compiles under .NET 8.
- [x] `dotnet test` passes locally.
- [x] No external network calls are made in unit tests.
- [x] Documentation (if applicable) is updated.
- [ ] Debug provider is gated by `#if DEBUG` and cannot be enabled in Production. *(not applicable — Debug provider untouched)*
- [ ] (Optional) Example e2e test runs against the Docker Compose test stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqqJZfw8hSz2n16KgdcQcG