### PR TITLE
Phase 4: Routing-matrix audit, reference doc, and consolidated upgrade note

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ Here is where Pwned Password API comes into play. Pwned Passwords are more than 
 All server-side settings and client-side settings are stored in the `/appsettings.json` file.
 The most relevant configuration entries are shown below. Make sure you make your changes to the `appsettings.json` file using a regular text editor like [Visual Studio Code](https://code.visualstudio.com)
 
+> **Upgrading from a pre-unified-error-routing build?** See [`docs/UPGRADING-error-routing.md`](docs/UPGRADING-error-routing.md) for the behavior changes and the two situations that need a config change. For how a directory failure maps to what the user sees (and the rules for adding a provider), see [`docs/error-routing-matrix.md`](docs/error-routing-matrix.md).
+
 - To enable reCAPTCHA
   1. Find the `PrivateKey` entry and enter your private key within double quotes (`"`)
   2. Find the `SiteKey` entry and enter your Site Key within double quotes (`"`)

--- a/docs/UPGRADING-error-routing.md
+++ b/docs/UPGRADING-error-routing.md
@@ -1,0 +1,110 @@
+# Upgrade note: unified error routing (error-disclosure + admin-reset)
+
+This release reworked how both real providers (Active Directory and LDAP)
+report password-change failures, so identical directory conditions produce
+identical responses. It adds two server-side settings and changes several
+default behaviors. Nothing about the wire contract changed — see
+[`error-routing-matrix.md`](./error-routing-matrix.md) for the full mapping.
+
+**Bottom line:** most deployments need no config change. Two situations do:
+LDAP sites that relied on `HideUserNotFound: false`, and AD service-account
+sites that relied on the old silent administrative reset. Both are covered
+below.
+
+## New settings (both under `AppSettings`, server-side only)
+
+Neither is ever sent to the browser.
+
+| Setting | Default | Effect |
+|---------|---------|--------|
+| `ErrorDisclosureMode` | `Hardened` | `Hardened`: unknown users and locked/disabled/restricted accounts are indistinguishable from a wrong password (no account oracle). `Informative`: unknown users get "user not found" and unusable accounts get "contact IT" guidance. |
+| `AllowAdministrativeReset` | `false` | When on, an account flagged "user cannot change password" completes its change as an administrative reset by the service account (after the current password is verified). This is the **only** condition it rescues. |
+
+## Action may be required
+
+### LDAP: you set `HideUserNotFound: false`
+
+`HideUserNotFound` is deprecated and **ignored**; disclosure is now governed by
+`ErrorDisclosureMode`. While the old key remains in your config a startup
+warning is logged.
+
+- You had `HideUserNotFound: true` (or unset) → no change; hardened default
+  matches. Remove the stale key to silence the warning.
+- You had `HideUserNotFound: false` (you *wanted* user-not-found disclosed) →
+  set `"ErrorDisclosureMode": "Informative"` to restore that behavior, then
+  remove `HideUserNotFound`.
+
+### AD: you run service-account mode (`UseAutomaticContext: false`)
+
+Previously **every** failed `ChangePassword` was silently retried as an
+administrative `SetPassword` — silently bypassing password history and
+minimum-age policy for all users. That silent fallback is **gone**.
+
+- Domain policy rejections (history, minimum age, complexity) now surface to
+  the user as a policy error (`ComplexPassword`) and are **never** rescued,
+  even with `AllowAdministrativeReset: true`. This is intentional — the option
+  no longer bypasses intentional policy.
+- If you relied on the fallback specifically to let **cannot-change-flagged**
+  accounts through, set `"AllowAdministrativeReset": true`. Every such reset is
+  now logged at Warning with a correlation ID, and only fires after the current
+  password is verified.
+
+### Either provider: inert option combinations (startup warning only)
+
+`AllowAdministrativeReset` is ignored, with a logged warning, when:
+
+- AD `UseAutomaticContext: true` (no service account to reset with), or
+- LDAP `LdapChangePasswordWithDelAdd: false` (that mechanism is already an
+  administrative replace).
+
+Remove the option in those cases, or switch the mode/mechanism if you want it.
+
+## Automatic changes (no action needed)
+
+- **Uniform credential responses.** All "invalid credentials" responses now
+  share one wire message. On AD, an unknown username now reports invalid
+  credentials instead of user-not-found by default (the hardened posture).
+- **No raw text on the wire.** `Generic` errors shown in the UI now read
+  *"An unexpected error occurred (ref: …)"* with a reference that correlates to
+  the server log, instead of a raw .NET/LDAP exception string. Pwned-password
+  (HIBP) outages show a clean retry message instead of client internals.
+- **LDAP cannot-change correction.** On AD-backed LDAP, an account flagged
+  "user cannot change password" now reports `ChangeNotPermitted` (after
+  verification) instead of being misreported as an LDAP/infrastructure problem.
+- **Flagged-account probing closed.** A flagged account probed with a wrong
+  password now returns invalid credentials in both modes, instead of disclosing
+  the flag before authentication. If a help-desk flow depended on that
+  pre-auth signal, it must now verify the current password first.
+- **Reworded default alerts.** The shipped `Alerts.ErrorComplexPassword` and
+  `Alerts.ErrorPasswordChangeNotAllowed` strings were reworded to read
+  correctly for the broader set of conditions now routed to them. If you
+  override these in your own config, your text is untouched.
+
+## What did not change
+
+- **`ApiErrorCode`** — no values added, renumbered, or removed. The wire
+  numbers are unchanged, so existing clients keep working.
+- **`ClientApp`** — no application code changed (only two E2E test-expectation
+  strings were updated to match the reworded alerts).
+- **Client settings payload** — the two new settings are server-side only and
+  do not appear in any client-visible response.
+- **Non-AD LDAP servers** — cannot-change detection reads AD security
+  descriptors; where that is unavailable it is skipped (logged at Debug) and
+  behavior is exactly as before.
+
+## Verification status
+
+The routing matrix and cross-provider convergence are covered by unit tests
+(`RoutingMatrixAuditTests`, `ProviderParityTests`). Two items require a live
+directory and were **not** exercised in CI — validate them in a staging domain
+before rollout if they matter to you:
+
+1. End-to-end administrative reset of a real cannot-change-flagged account
+   (option on → change completes with a Warning log; option off → user sees
+   `ChangeNotPermitted`), on **both** providers.
+2. The LDAP security-descriptor scan against a real AD `nTSecurityDescriptor`
+   (unit fixtures are hand-built from the MS-DTYP binary format).
+
+The Windows-only AD provider is not compiled by the cross-platform CI; its
+edits were compile-verified separately and it delegates to the same shared,
+fully-tested translator as the LDAP provider.

--- a/docs/error-routing-matrix.md
+++ b/docs/error-routing-matrix.md
@@ -1,0 +1,164 @@
+# Error routing matrix
+
+The single reference for how PassCore turns a directory failure into something
+the user sees. It is the source of truth for anyone adding or changing a
+password-change provider.
+
+Every row here is machine-verified by
+`RoutingMatrixAuditTests` (in `Zyborg.PassCore.PasswordProvider.LDAP.Tests`).
+If you change a routing decision, change that test and this document together —
+they are meant to disagree only while a change is in progress.
+
+## The one rule for provider authors
+
+**A provider never decides an `ApiErrorCode` itself.** It extracts a Win32/AD
+error code from whatever transport it speaks (an LDAP extended-error string, a
+COM `HResult`, a `LogonUser` last-error) and hands it to the shared
+`DirectoryErrorTranslator`. The translator owns the mapping below. This is why
+the two real providers produce identical results for identical conditions, and
+it is the only way to keep that true as providers are added.
+
+Structural conditions that have no error code (an empty search result, a null
+principal, a detected "cannot change password" flag) use the dedicated
+factories `DirectoryErrorTranslator.CreateUserNotFoundError` /
+`CreateChangeNotPermittedError`, which apply the same table.
+
+## Two message layers (read this before touching messages)
+
+A response carries an `ApiErrorItem { ErrorCode: int, Message: string }`. There
+are two different strings in play and it is easy to confuse them:
+
+1. **The wire `Message`** — a fixed, curated constant set by the translator
+   (the "wire message" column below). It never contains raw exception or
+   server text. For every non-`Generic` code **the browser ignores it.**
+2. **The displayed alert** — the frontend (`ChangePassword.tsx`) maps the
+   **integer** `ErrorCode` to an admin-configured string from
+   `ClientSettings.Alerts` (the "UI alert" column below) and shows that. The
+   wire `Message` is shown to the user **only** for `Generic` (code `0`), which
+   is why `Generic` must never carry raw text (it now carries
+   `"An unexpected error occurred (ref: …)"`).
+
+Consequence: the frontend map is keyed by the raw enum integer. That is the
+reason for the append-only rule further down.
+
+## Win32 / AD code → failure class
+
+The catalog lives in `Unosquare.PassCore.Common/Win32ErrorCode.cs`. Uncataloged
+codes classify as `Infrastructure` (safe default). AD emits these codes in two
+extended-error shapes (leading code for modify-time `WILL_NOT_PERFORM`; `data`
+sub-code for bind-time errors) and as `FACILITY_WIN32` HRESULTs; all three
+reduce to the same code.
+
+| Code | Name | Failure class |
+|------|------|---------------|
+| `0x05` | ERROR_ACCESS_DENIED | Infrastructure |
+| `0x56` | ERROR_INVALID_PASSWORD | Credentials |
+| `0x523` | ERROR_INVALID_ACCOUNT_NAME | Existence |
+| `0x524` | ERROR_USER_EXISTS | Infrastructure |
+| `0x525` | ERROR_NO_SUCH_USER | Existence |
+| `0x52B` | ERROR_WRONG_PASSWORD | Credentials |
+| `0x52C` | ERROR_ILL_FORMED_PASSWORD | NewPasswordPolicy |
+| `0x52D` | ERROR_PASSWORD_RESTRICTION | NewPasswordPolicy |
+| `0x52E` | ERROR_LOGON_FAILURE | Credentials |
+| `0x52F` | ERROR_ACCOUNT_RESTRICTION | AccountState |
+| `0x530` | ERROR_INVALID_LOGON_HOURS | AccountState |
+| `0x531` | ERROR_INVALID_WORKSTATION | AccountState |
+| `0x532` | ERROR_PASSWORD_EXPIRED | PasswordExpiredOrMustChange |
+| `0x533` | ERROR_ACCOUNT_DISABLED | AccountState |
+| `0x701` | ERROR_ACCOUNT_EXPIRED | AccountState |
+| `0x773` | ERROR_PASSWORD_MUST_CHANGE | PasswordExpiredOrMustChange |
+| `0x774` | ERROR_DOMAIN_CONTROLLER_NOT_FOUND | Infrastructure |
+| `0x775` | ERROR_ACCOUNT_LOCKED_OUT | AccountState |
+| `0x8C3` | NERR_PasswordCantChange | ChangeNotPermitted |
+| `0x8C4` | NERR_PasswordHistConflict | NewPasswordPolicy |
+| `0x8C5` | NERR_PasswordTooShort | NewPasswordPolicy |
+| `0x8C6` | NERR_PasswordTooRecent | NewPasswordPolicy |
+
+## The routing matrix: failure class × disclosure mode
+
+`ErrorDisclosureMode` (server-side only, default `Hardened`) is the only knob
+that changes the outcome for a given class. `PasswordExpiredOrMustChange` never
+reaches this table during a change — it is consumed at credential-verification
+time as *proof of the current password* and the change proceeds (both
+providers, via `DirectoryErrorTranslator.IsPasswordExpiredOrMustChange`); it is
+shown only for completeness.
+
+| Failure class | Mode | ApiErrorCode (int) | Wire message | UI alert (`Alerts.*`) |
+|---------------|------|--------------------|--------------|-----------------------|
+| Credentials | both | InvalidCredentials (4) | `InvalidCredentialsMessage` | `ErrorInvalidCredentials` |
+| Existence | Hardened | InvalidCredentials (4) | `InvalidCredentialsMessage` | `ErrorInvalidCredentials` |
+| Existence | Informative | UserNotFound (3) | `UserNotFoundMessage` | `ErrorInvalidUser` |
+| AccountState | Hardened | InvalidCredentials (4) | `InvalidCredentialsMessage` | `ErrorInvalidCredentials` |
+| AccountState | Informative | ChangeNotPermitted (6) | `AccountStateMessage` | `ErrorPasswordChangeNotAllowed` |
+| NewPasswordPolicy | both | ComplexPassword (9) | `NewPasswordPolicyMessage` | `ErrorComplexPassword` |
+| ChangeNotPermitted | both | ChangeNotPermitted (6) | `ChangeNotPermittedMessage` | `ErrorPasswordChangeNotAllowed` |
+| Infrastructure | both | LdapProblem (8) | `DirectoryFailureMessage` | `ErrorConnectionLdap` |
+| PasswordExpiredOrMustChange | both | *(allowed through — change proceeds)* | — | — |
+
+The wire-message constants live on `DirectoryErrorTranslator`. In **Hardened**
+mode the Credentials / Existence / AccountState rows are byte-identical on the
+wire (same code, same message), so an unauthenticated caller gets no
+account-existence or account-state oracle. **Informative** mode trades that
+oracle for actionable help-desk guidance.
+
+## The administrative-reset fallback dimension
+
+`AllowAdministrativeReset` (server-side, default off) adds a second dimension,
+but it changes the outcome for **exactly one** class:
+
+| Failure class | Reset off (default) | Reset on (+ current password verified) |
+|---------------|---------------------|-----------------------------------------|
+| ChangeNotPermitted | surfaces as the table row above | **rescued**: password set administratively, logged at Warning |
+| every other class | surfaces as the table row above | **unchanged** — surfaces identically |
+
+Eligibility is decided in one place, `AdministrativeReset.ShouldAttempt`, which
+returns true only for `ChangeNotPermitted` with the option enabled **and** the
+user's current credentials verified in the same request. It never rescues
+password-policy rejections (intentional policy is honored), account-state
+conditions, or infrastructure failures, and never runs before verification.
+
+## `ApiErrorCode` is append-only
+
+Because the frontend maps the **integer** value of `ApiErrorCode` to alert
+strings (see "Two message layers"), the wire numbers are a contract with the
+client:
+
+- **Never** renumber, reorder, or remove a member.
+- New members may only be **appended** (next unused integer), and adding one
+  requires a matching entry in the frontend `errorMessages` map and a new
+  `Alerts.*` string — otherwise the UI falls back to *"An unknown error
+  occurred."*
+- Prefer reusing an existing code with a curated message over adding a member.
+  The whole series added **zero** members: `0x52C`/`0x52D` deliberately collapse
+  into `ComplexPassword`, and account-state in informative mode reuses
+  `ChangeNotPermitted`.
+
+## Where the decisions live (choke points)
+
+| Concern | Single location |
+|---------|-----------------|
+| Code → failure class | `Win32ErrorCode.Codes` catalog |
+| Class × mode → domain exception | `DirectoryErrorTranslator.Translate` |
+| Exception → `ApiErrorCode` | `ApiErrorMapper.Map` |
+| Expired/must-change "allow through" | `DirectoryErrorTranslator.IsPasswordExpiredOrMustChange` |
+| Reset-fallback eligibility | `AdministrativeReset.ShouldAttempt` |
+| Disclosure mode / reset options | `IAppSettings` (bound from `AppSettings`, server-side only) |
+
+A provider supplies only transport-specific extraction and calls into these.
+
+## Known follow-up: Debug provider fidelity
+
+The Debug provider (`DebugPasswordChangeProvider`, the E2E reference) forces a
+final `ApiErrorCode` directly and **does not** route through
+`DirectoryErrorTranslator`. It therefore cannot simulate the two dimensions the
+series introduced:
+
+- the same underlying condition rendering differently under
+  `Hardened` vs `Informative` (it emits a fixed code regardless of mode), and
+- the administrative-reset fallback (cannot-change → reset vs. `ChangeNotPermitted`).
+
+This is acceptable for its current role (it still forces every terminal
+`ApiErrorCode`, including `UserNotFound`, `ChangeNotPermitted`, and
+`ComplexPassword`), but a future change could let it opt into translator-backed
+behavior so E2E can exercise mode/fallback end-to-end. Filed as a follow-up
+rather than expanded here, per the Phase 4 scope.

--- a/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/RoutingMatrixAuditTests.cs
+++ b/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/RoutingMatrixAuditTests.cs
@@ -1,0 +1,215 @@
+using Novell.Directory.Ldap;
+using Unosquare.PassCore.Common;
+
+namespace Zyborg.PassCore.PasswordProvider.LDAP.Tests;
+
+/// <summary>
+/// Phase 4 empirical consistency audit. Re-derives, from the merged code
+/// (not from documentation), that the two real providers now route every
+/// directory condition identically, in both disclosure modes and both
+/// administrative-reset states — the property the whole series set out to
+/// establish. The values asserted here are the source of truth transcribed
+/// into <c>docs/error-routing-matrix.md</c>; if a routing decision changes,
+/// this test and that document must change together.
+///
+/// The AD provider is Windows-only and cannot be compiled or run on the
+/// cross-platform CI host, so its column is exercised through
+/// <see cref="DirectoryErrorTranslator.TranslateException"/> — the exact call
+/// its catch block delegates to (verified by reading
+/// <c>PasswordChangeProvider.cs</c>). The LDAP column runs the provider's real
+/// <see cref="LdapPasswordChangeProvider.TranslateLdapException(LdapException, ErrorDisclosureMode)"/>.
+/// </summary>
+public class RoutingMatrixAuditTests
+{
+    private readonly record struct Wire(ApiErrorCode Code, string? Message)
+    {
+        public static Wire Of(System.Exception domainException)
+        {
+            var item = ApiErrorMapper.Map(domainException);
+            return new Wire(item.ErrorCode, item.Message);
+        }
+    }
+
+    // The same underlying Win32 code, rendered through each transport a real
+    // provider would receive it in.
+    private static Wire ViaLdapBind(int code, ErrorDisclosureMode mode) =>
+        Wire.Of(LdapPasswordChangeProvider.TranslateLdapException(
+            new LdapException("t", LdapException.InvalidCredentials,
+                $"80090308: LdapErr: DSID-0C090439, comment: AcceptSecurityContext error, data {code:x}, v3839"),
+            mode));
+
+    private static Wire ViaLdapModify(int code, ErrorDisclosureMode mode) =>
+        Wire.Of(LdapPasswordChangeProvider.TranslateLdapException(
+            new LdapException("t", LdapException.UnwillingToPerform,
+                $"{code:X8}: SvcErr: DSID-031A12D2, problem 5003 (WILL_NOT_PERFORM), data 0"),
+            mode));
+
+    private static Wire ViaAdHResult(int code, ErrorDisclosureMode mode) =>
+        Wire.Of(DirectoryErrorTranslator.TranslateException(
+            new HResultException(unchecked((int)0x80070000 | code)), mode));
+
+    // ------------------------------------------------------------------
+    // 1. Full catalog: every code, every transport, every mode converges.
+    // ------------------------------------------------------------------
+
+    public static TheoryData<int, ErrorDisclosureMode> CatalogXMode
+    {
+        get
+        {
+            var data = new TheoryData<int, ErrorDisclosureMode>();
+            foreach (var entry in Win32ErrorCode.Codes)
+            {
+                data.Add(entry.Code, ErrorDisclosureMode.Hardened);
+                data.Add(entry.Code, ErrorDisclosureMode.Informative);
+            }
+
+            return data;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(CatalogXMode))]
+    public void EveryCode_AllThreeTransports_ProduceOneWireResult(int code, ErrorDisclosureMode mode)
+    {
+        var ldapBind = ViaLdapBind(code, mode);
+        var ldapModify = ViaLdapModify(code, mode);
+        var adHResult = ViaAdHResult(code, mode);
+
+        Assert.Equal(ldapBind, ldapModify);
+        Assert.Equal(ldapBind, adHResult);
+
+        // The class the catalog assigns must be what actually drives the result.
+        var expected = ExpectedWire(DirectoryErrorTranslator.Classify(code), mode);
+        Assert.Equal(expected, ldapBind);
+    }
+
+    // ------------------------------------------------------------------
+    // 2. Canonical matrix: class x mode -> (code, message). This is the
+    //    table in docs/error-routing-matrix.md.
+    // ------------------------------------------------------------------
+
+    public static TheoryData<DirectoryFailureClass, ErrorDisclosureMode, ApiErrorCode, string?> Matrix => new()
+    {
+        // class, mode, expected ApiErrorCode, expected wire message
+        { DirectoryFailureClass.Credentials, ErrorDisclosureMode.Hardened, ApiErrorCode.InvalidCredentials, DirectoryErrorTranslator.InvalidCredentialsMessage },
+        { DirectoryFailureClass.Credentials, ErrorDisclosureMode.Informative, ApiErrorCode.InvalidCredentials, DirectoryErrorTranslator.InvalidCredentialsMessage },
+        { DirectoryFailureClass.PasswordExpiredOrMustChange, ErrorDisclosureMode.Hardened, ApiErrorCode.InvalidCredentials, DirectoryErrorTranslator.InvalidCredentialsMessage },
+        { DirectoryFailureClass.PasswordExpiredOrMustChange, ErrorDisclosureMode.Informative, ApiErrorCode.InvalidCredentials, DirectoryErrorTranslator.InvalidCredentialsMessage },
+        { DirectoryFailureClass.Existence, ErrorDisclosureMode.Hardened, ApiErrorCode.InvalidCredentials, DirectoryErrorTranslator.InvalidCredentialsMessage },
+        { DirectoryFailureClass.Existence, ErrorDisclosureMode.Informative, ApiErrorCode.UserNotFound, DirectoryErrorTranslator.UserNotFoundMessage },
+        { DirectoryFailureClass.AccountState, ErrorDisclosureMode.Hardened, ApiErrorCode.InvalidCredentials, DirectoryErrorTranslator.InvalidCredentialsMessage },
+        { DirectoryFailureClass.AccountState, ErrorDisclosureMode.Informative, ApiErrorCode.ChangeNotPermitted, DirectoryErrorTranslator.AccountStateMessage },
+        { DirectoryFailureClass.NewPasswordPolicy, ErrorDisclosureMode.Hardened, ApiErrorCode.ComplexPassword, DirectoryErrorTranslator.NewPasswordPolicyMessage },
+        { DirectoryFailureClass.NewPasswordPolicy, ErrorDisclosureMode.Informative, ApiErrorCode.ComplexPassword, DirectoryErrorTranslator.NewPasswordPolicyMessage },
+        { DirectoryFailureClass.ChangeNotPermitted, ErrorDisclosureMode.Hardened, ApiErrorCode.ChangeNotPermitted, DirectoryErrorTranslator.ChangeNotPermittedMessage },
+        { DirectoryFailureClass.ChangeNotPermitted, ErrorDisclosureMode.Informative, ApiErrorCode.ChangeNotPermitted, DirectoryErrorTranslator.ChangeNotPermittedMessage },
+        { DirectoryFailureClass.Infrastructure, ErrorDisclosureMode.Hardened, ApiErrorCode.LdapProblem, DirectoryErrorTranslator.DirectoryFailureMessage },
+        { DirectoryFailureClass.Infrastructure, ErrorDisclosureMode.Informative, ApiErrorCode.LdapProblem, DirectoryErrorTranslator.DirectoryFailureMessage },
+    };
+
+    [Theory]
+    [MemberData(nameof(Matrix))]
+    public void CanonicalMatrix_MatchesTranslatorOutput(
+        DirectoryFailureClass failureClass, ErrorDisclosureMode mode, ApiErrorCode expectedCode, string? expectedMessage)
+    {
+        Assert.Equal(new Wire(expectedCode, expectedMessage), ExpectedWire(failureClass, mode));
+    }
+
+    [Fact]
+    public void CanonicalMatrix_CoversEveryFailureClassInBothModes()
+    {
+        var covered = Matrix.Select(r => ((DirectoryFailureClass)r[0]!, (ErrorDisclosureMode)r[1]!)).ToHashSet();
+        foreach (var failureClass in System.Enum.GetValues<DirectoryFailureClass>())
+        {
+            Assert.Contains((failureClass, ErrorDisclosureMode.Hardened), covered);
+            Assert.Contains((failureClass, ErrorDisclosureMode.Informative), covered);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // 3. The reset-fallback dimension: only ChangeNotPermitted flips between
+    //    the two fallback states; everything else is identical on/off.
+    // ------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(DirectoryFailureClass.ChangeNotPermitted, true)]
+    [InlineData(DirectoryFailureClass.NewPasswordPolicy, false)]
+    [InlineData(DirectoryFailureClass.AccountState, false)]
+    [InlineData(DirectoryFailureClass.Credentials, false)]
+    [InlineData(DirectoryFailureClass.Existence, false)]
+    [InlineData(DirectoryFailureClass.Infrastructure, false)]
+    [InlineData(DirectoryFailureClass.PasswordExpiredOrMustChange, false)]
+    public void ResetFallback_OnlyChangeNotPermittedIsRescuable(DirectoryFailureClass failureClass, bool rescuableWhenOn)
+    {
+        // Verified (option on) always equals the class-eligibility; off is always false.
+        Assert.Equal(rescuableWhenOn, AdministrativeReset.ShouldAttempt(
+            allowAdministrativeReset: true, currentCredentialsVerified: true, failureClass));
+        Assert.False(AdministrativeReset.ShouldAttempt(
+            allowAdministrativeReset: false, currentCredentialsVerified: true, failureClass));
+    }
+
+    // ------------------------------------------------------------------
+    // 4. The original divergence table (top of the task brief), re-derived
+    //    for the merged state. Each row asserts the two providers now agree.
+    // ------------------------------------------------------------------
+
+    [Theory]
+    // "User not found"        -> hardened: both InvalidCredentials; informative: both UserNotFound
+    [InlineData(0x525, ErrorDisclosureMode.Hardened, ApiErrorCode.InvalidCredentials)]
+    [InlineData(0x525, ErrorDisclosureMode.Informative, ApiErrorCode.UserNotFound)]
+    // "Locked / disabled / logon-hours" -> hardened InvalidCredentials; informative ChangeNotPermitted
+    [InlineData(0x775, ErrorDisclosureMode.Hardened, ApiErrorCode.InvalidCredentials)]
+    [InlineData(0x775, ErrorDisclosureMode.Informative, ApiErrorCode.ChangeNotPermitted)]
+    // "UserCannotChangePassword flag" -> ChangeNotPermitted in both modes
+    [InlineData(0x8C3, ErrorDisclosureMode.Hardened, ApiErrorCode.ChangeNotPermitted)]
+    [InlineData(0x8C3, ErrorDisclosureMode.Informative, ApiErrorCode.ChangeNotPermitted)]
+    // "New password fails domain policy" -> ComplexPassword in both modes
+    [InlineData(0x52D, ErrorDisclosureMode.Hardened, ApiErrorCode.ComplexPassword)]
+    [InlineData(0x52D, ErrorDisclosureMode.Informative, ApiErrorCode.ComplexPassword)]
+    // "DC unreachable / service acct misconfigured" -> LdapProblem in both modes
+    [InlineData(0x5, ErrorDisclosureMode.Hardened, ApiErrorCode.LdapProblem)]
+    [InlineData(0x5, ErrorDisclosureMode.Informative, ApiErrorCode.LdapProblem)]
+    public void OriginalDivergenceTable_ConvergesAcrossProviders(int code, ErrorDisclosureMode mode, ApiErrorCode expected)
+    {
+        var ldap = ViaLdapBind(code, mode);
+        var ad = ViaAdHResult(code, mode);
+
+        Assert.Equal(expected, ldap.Code);
+        Assert.Equal(ldap, ad); // same code AND same wire message across providers
+    }
+
+    [Theory]
+    [InlineData(0x532)] // expired
+    [InlineData(0x773)] // must-change
+    public void OriginalDivergenceTable_ExpiredMustChange_AllowedThroughOnBothProviders(int code)
+    {
+        // Both providers treat these as proof of the current password during
+        // verification (they never reach change-time translation). The shared
+        // definition backs both.
+        Assert.True(DirectoryErrorTranslator.IsPasswordExpiredOrMustChange(code));
+    }
+
+    private static Wire ExpectedWire(DirectoryFailureClass failureClass, ErrorDisclosureMode mode)
+    {
+        // Drive an exception of the given class through the translator by using
+        // a representative catalog code, then map it — the same path a provider
+        // takes. Structural cannot-change (no code) uses the dedicated factory.
+        var code = failureClass switch
+        {
+            DirectoryFailureClass.Credentials => 0x52E,
+            DirectoryFailureClass.Existence => 0x525,
+            DirectoryFailureClass.AccountState => 0x775,
+            DirectoryFailureClass.NewPasswordPolicy => 0x52D,
+            DirectoryFailureClass.ChangeNotPermitted => 0x8C3,
+            DirectoryFailureClass.PasswordExpiredOrMustChange => 0x532,
+            _ => 0x5,
+        };
+
+        return Wire.Of(DirectoryErrorTranslator.Translate(code, mode));
+    }
+
+    private sealed class HResultException : System.Exception
+    {
+        public HResultException(int hresult) : base("raw transport detail") => HResult = hresult;
+    }
+}


### PR DESCRIPTION
## Description

Phase 4 (final) of the error-routing series — the lightweight consistency audit and documentation pass. **Documentation and tests only; zero production-code changes** (verified: the diff touches `docs/`, `README.md`, and one test file).

### What was found and changed

**Empirical parity audit (`RoutingMatrixAuditTests`, 78 assertions).** Re-derives — from the merged code, not from documentation — that the two real providers now route every cataloged Win32 code identically:
- Every code × both disclosure modes: LDAP bind-style, LDAP modify-style, and AD HRESULT transports all produce one identical `ApiErrorItem` (code + wire message). The AD leg runs the exact `DirectoryErrorTranslator.TranslateException` call the AD provider's catch delegates to (that provider is Windows-only and not CI-compiled — same caveat as #40–#42).
- The **original divergence table** from the task brief, re-derived for the merged state: the six diverging rows (user-not-found, locked/disabled/hours, cannot-change flag, new-password policy, DC-unreachable, expired/must-change) now produce identical results across both providers. This is the "empirical table" deliverable.
- The **reset-fallback dimension**: only `ChangeNotPermitted` flips between fallback states; every other class is identical on/off.
- A canonical `class × mode → (ApiErrorCode, message)` matrix with a completeness guard, which is the machine-verified source of truth for the doc.

**`docs/error-routing-matrix.md`** — the single reference for future provider authors: the code→class catalog, the `class × mode → ApiErrorCode → wire message + UI alert string` matrix, the reset-fallback dimension, the decision choke points, and the **append-only `ApiErrorCode` rule** with the client-int-keyed frontend map as the stated reason. It calls out the two-message-layer subtlety that's easy to miss — the curated wire `Message` vs. the int-keyed UI alert string, and that the browser only renders the wire message for `Generic`.

**`docs/UPGRADING-error-routing.md`** — consolidates the three phases' migration notes into one operator-facing upgrade note, headlined by the two action-required cases (LDAP `HideUserNotFound: false` → set `Informative`; AD service-account silent-reset removal), the automatic changes, and what did *not* change.

**README** links both docs from the configuration section.

### Empirical cross-cutting confirmations (whole series, `0bcf0ec..HEAD`)

- **Zero `ApiErrorCode` changes** — `git diff` on `ApiErrorCode.cs` across the series is empty.
- **ClientApp**: the only diff is Phase 2's two-line E2E expectation update (approved); zero application-code changes.
- **New settings absent from client payloads** — `ErrorDisclosureMode` / `AllowAdministrativeReset` appear nowhere in `ClientSettings`/`Models` or `ClientApp` (grep-confirmed); they bind from the server-only `AppSettings` section.

### Debug provider (E2E reference) — follow-up, not expanded here

`DebugPasswordChangeProvider` forces a final `ApiErrorCode` directly and does **not** route through `DirectoryErrorTranslator`, so it cannot simulate the two dimensions the series introduced (mode-dependent rendering of one condition; the reset fallback). It still forces every terminal code. Per the Phase 4 scope this is documented as a follow-up in the routing-matrix doc rather than expanded into a code change.

### Verification status (stated plainly, per the Phase 3 review)

Two items require a live directory and were **not** exercised in CI — flagged in the upgrade note and here rather than implied by unit-green:
1. End-to-end administrative reset of a real cannot-change-flagged account (option on → completes with Warning log; option off → `ChangeNotPermitted`) on both providers.
2. The LDAP security-descriptor scan against a real AD `nTSecurityDescriptor` (unit fixtures are hand-built MS-DTYP binary).

### Open questions

None blocking. If you'd prefer the routing-matrix doc live somewhere other than `docs/` (e.g. a `CONTRIBUTING` section), easy to move.

### Migration notes

None new — this phase is docs + tests. The consolidated note it adds supersedes the per-PR migration sections from #40–#42.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation update
- [x] Testing/CI harness

## Checklist
- [x] All new code compiles under .NET 8.
- [x] `dotnet test` passes locally.
- [x] No external network calls are made in unit tests.
- [x] Documentation (if applicable) is updated.
- [ ] Debug provider is gated by `#if DEBUG` and cannot be enabled in Production. *(not applicable — no provider changes)*
- [ ] (Optional) Example e2e test runs against the Docker Compose test stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqqJZfw8hSz2n16KgdcQcG

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqqJZfw8hSz2n16KgdcQcG)_