### PR TITLE
Task A: Distinguish service-account failures from end-user credential failures

### DIFF
--- a/docs/error-routing-matrix.md
+++ b/docs/error-routing-matrix.md
@@ -101,6 +101,43 @@ wire (same code, same message), so an unauthenticated caller gets no
 account-existence or account-state oracle. **Informative** mode trades that
 oracle for actionable help-desk guidance.
 
+## The actor dimension: same code, different actor, different class
+
+The Win32 code alone does not say **whose** credentials failed. A bind that
+fails with `0x52E` (ERROR_LOGON_FAILURE) is the **end user** proving their
+current password when it comes from the credential-verification step, but the
+application's own **service account** when it comes from connecting to or
+resolving against the directory. Reporting the latter as "invalid username or
+password" tells an end user their password is wrong when the real fault is a
+misconfigured service account.
+
+So every translation carries a `DirectoryActor`, and the class is computed by
+`ClassifyForActor(code, actor)`:
+
+| Actor | Effect on classification |
+|-------|--------------------------|
+| `User` (default) | Classified normally per the catalog. Every pre-existing caller gets this. |
+| `ServiceAccount` | The end-user-account signals — `Credentials`, `Existence`, `AccountState`, `PasswordExpiredOrMustChange` — collapse to `Infrastructure`. A service-account or connectivity failure can therefore **never** produce `InvalidCredentials` / `UserNotFound`; it is always `LdapProblem` + `DirectoryFailureMessage`, in both disclosure modes. `NewPasswordPolicy` / `ChangeNotPermitted` are left untouched (a connect/resolve step cannot raise them). |
+
+This is the single enforcement point for "a service-account failure is never an
+end-user credential failure." Providers pick the actor at the call site:
+
+- **LDAP** — `BindAsServiceAccount` translates with `ServiceAccount`;
+  `VerifyUserCredentials` and the modify path stay `User`. The distinction is by
+  call site, the reference behavior since the unified-routing work.
+- **AD** — `RunAsServiceAccount` wraps the service-account operations
+  (`AcquirePrincipalContext`, `FindByIdentity`, group reads) and translates
+  their failures with `ServiceAccount`; the modify path stays `User`, and the
+  end user's own wrong password is the explicit `InvalidCredentialsException`
+  from `ValidateUserCredentials`, unaffected.
+
+A `ServiceAccount` failure is also logged at Warning by `ServiceAccountFailure`
+(correlation ID when available, operation, host, underlying code) — the operator
+gets the diagnosis while the wire response stays curated. `0x532`
+(ERROR_PASSWORD_EXPIRED) is worth noting: as the **user** it is "proceed, the
+password is correct but expired"; as the **service account** it must never
+proceed — the actor coercion makes it `Infrastructure`.
+
 ## The administrative-reset fallback dimension
 
 `AllowAdministrativeReset` (server-side, default off) adds a second dimension,
@@ -138,13 +175,16 @@ client:
 | Concern | Single location |
 |---------|-----------------|
 | Code → failure class | `Win32ErrorCode.Codes` catalog |
+| Code + actor → failure class | `DirectoryErrorTranslator.ClassifyForActor` |
 | Class × mode → domain exception | `DirectoryErrorTranslator.Translate` |
 | Exception → `ApiErrorCode` | `ApiErrorMapper.Map` |
 | Expired/must-change "allow through" | `DirectoryErrorTranslator.IsPasswordExpiredOrMustChange` |
+| Service-account failure diagnostics | `ServiceAccountFailure.Log` |
 | Reset-fallback eligibility | `AdministrativeReset.ShouldAttempt` |
 | Disclosure mode / reset options | `IAppSettings` (bound from `AppSettings`, server-side only) |
 
-A provider supplies only transport-specific extraction and calls into these.
+A provider supplies only transport-specific extraction, **chooses the actor for
+each operation**, and calls into these.
 
 ## Known follow-up: Debug provider fidelity
 

--- a/src/Unosquare.PassCore.Common/DirectoryErrorTranslator.cs
+++ b/src/Unosquare.PassCore.Common/DirectoryErrorTranslator.cs
@@ -54,6 +54,37 @@ public enum DirectoryFailureClass
 }
 
 /// <summary>
+/// Identifies whose failure a directory error describes, so the same Win32
+/// code can route differently depending on the operation that raised it. The
+/// Win32 code alone cannot tell these apart: a bind that fails with
+/// <c>0x52E</c> is the end user proving their current password when it comes
+/// from the credential-verification step, but the application's own
+/// misconfigured service account when it comes from connecting to or resolving
+/// against the directory.
+/// </summary>
+public enum DirectoryActor
+{
+    /// <summary>
+    /// The failure describes the end user's request — their credential proof or
+    /// their password-change operation. Classified normally (the default; every
+    /// pre-existing caller gets this).
+    /// </summary>
+    User = 0,
+
+    /// <summary>
+    /// The failure arose while the application was acting as its own service
+    /// account (connecting, binding, or resolving a user). The failure
+    /// describes the service account, not the caller, so end-user-account
+    /// signals (wrong credentials, unknown user, unusable account,
+    /// expired/must-change) are meaningless to the end user and are collapsed
+    /// to <see cref="DirectoryFailureClass.Infrastructure"/> — a
+    /// service-account or connectivity failure can never surface as an end-user
+    /// credential error.
+    /// </summary>
+    ServiceAccount,
+}
+
+/// <summary>
 /// The single translation point from Win32/AD error semantics to the domain
 /// exceptions that <see cref="ApiErrorMapper"/> turns into wire-level
 /// <see cref="ApiErrorItem"/>s. Providers own only transport-specific
@@ -150,6 +181,38 @@ public static class DirectoryErrorTranslator
         Win32ErrorCode.ByCode(win32Code)?.FailureClass ?? DirectoryFailureClass.Infrastructure;
 
     /// <summary>
+    /// Classifies a Win32 code for a specific <see cref="DirectoryActor"/>.
+    /// Identical to <see cref="Classify(int)"/> for <see cref="DirectoryActor.User"/>;
+    /// for <see cref="DirectoryActor.ServiceAccount"/> the end-user-account
+    /// signals (<see cref="DirectoryFailureClass.Credentials"/>,
+    /// <see cref="DirectoryFailureClass.Existence"/>,
+    /// <see cref="DirectoryFailureClass.AccountState"/>,
+    /// <see cref="DirectoryFailureClass.PasswordExpiredOrMustChange"/>) collapse
+    /// to <see cref="DirectoryFailureClass.Infrastructure"/>, so a
+    /// service-account failure can never be reported as an end-user credential,
+    /// existence, or account-state condition. This is the single enforcement
+    /// point for that invariant; providers select the actor at the call site.
+    /// </summary>
+    /// <param name="win32Code">The Win32 error code.</param>
+    /// <param name="actor">Whose failure the code describes.</param>
+    /// <returns>The actor-adjusted failure classification.</returns>
+    public static DirectoryFailureClass ClassifyForActor(int win32Code, DirectoryActor actor)
+    {
+        var failureClass = Classify(win32Code);
+
+        if (actor == DirectoryActor.ServiceAccount && IsEndUserAccountSignal(failureClass))
+            return DirectoryFailureClass.Infrastructure;
+
+        return failureClass;
+    }
+
+    private static bool IsEndUserAccountSignal(DirectoryFailureClass failureClass) =>
+        failureClass is DirectoryFailureClass.Credentials
+            or DirectoryFailureClass.Existence
+            or DirectoryFailureClass.AccountState
+            or DirectoryFailureClass.PasswordExpiredOrMustChange;
+
+    /// <summary>
     /// Indicates whether the code means the current password was correct but
     /// expired (0x532) or must change at next logon (0x773) — the shared
     /// definition of the "allow the change to proceed" verification outcome,
@@ -172,9 +235,29 @@ public static class DirectoryErrorTranslator
     public static Exception Translate(
         int win32Code,
         ErrorDisclosureMode disclosureMode,
+        Exception? innerException = null) =>
+        Translate(win32Code, disclosureMode, DirectoryActor.User, innerException);
+
+    /// <summary>
+    /// Translates a Win32 error code to the domain exception described in the
+    /// class-level routing table, applying the configured disclosure posture
+    /// and the <see cref="DirectoryActor"/>. A
+    /// <see cref="DirectoryActor.ServiceAccount"/> failure can never produce an
+    /// end-user credential/existence/account-state result — see
+    /// <see cref="ClassifyForActor"/>.
+    /// </summary>
+    /// <param name="win32Code">The Win32 error code.</param>
+    /// <param name="disclosureMode">The configured disclosure posture.</param>
+    /// <param name="actor">Whose failure the code describes.</param>
+    /// <param name="innerException">The transport exception, preserved for logs.</param>
+    /// <returns>The domain exception to throw.</returns>
+    public static Exception Translate(
+        int win32Code,
+        ErrorDisclosureMode disclosureMode,
+        DirectoryActor actor,
         Exception? innerException = null)
     {
-        return Classify(win32Code) switch
+        return ClassifyForActor(win32Code, actor) switch
         {
             DirectoryFailureClass.Credentials or
             DirectoryFailureClass.PasswordExpiredOrMustChange =>
@@ -234,7 +317,23 @@ public static class DirectoryErrorTranslator
     /// <param name="disclosureMode">The configured disclosure posture.</param>
     /// <returns>The domain exception to throw.</returns>
     public static Exception TranslateException(Exception exception, ErrorDisclosureMode disclosureMode) =>
-        TranslateException(exception, disclosureMode, out _);
+        TranslateException(exception, disclosureMode, DirectoryActor.User, out _);
+
+    /// <summary>
+    /// Actor-aware overload of
+    /// <see cref="TranslateException(Exception, ErrorDisclosureMode)"/>. A
+    /// <see cref="DirectoryActor.ServiceAccount"/> failure is coerced to an
+    /// infrastructure result regardless of the code it carries, so
+    /// service-account and connectivity failures never surface as end-user
+    /// credential errors.
+    /// </summary>
+    /// <param name="exception">The exception raised by the directory operation.</param>
+    /// <param name="disclosureMode">The configured disclosure posture.</param>
+    /// <param name="actor">Whose failure the exception describes.</param>
+    /// <returns>The domain exception to throw.</returns>
+    public static Exception TranslateException(
+        Exception exception, ErrorDisclosureMode disclosureMode, DirectoryActor actor) =>
+        TranslateException(exception, disclosureMode, actor, out _);
 
     /// <summary>
     /// Same as <see cref="TranslateException(Exception, ErrorDisclosureMode)"/>
@@ -253,14 +352,37 @@ public static class DirectoryErrorTranslator
     public static Exception TranslateException(
         Exception exception,
         ErrorDisclosureMode disclosureMode,
+        out DirectoryFailureClass failureClass) =>
+        TranslateException(exception, disclosureMode, DirectoryActor.User, out failureClass);
+
+    /// <summary>
+    /// Actor-aware overload of
+    /// <see cref="TranslateException(Exception, ErrorDisclosureMode, out DirectoryFailureClass)"/>.
+    /// The reported <paramref name="failureClass"/> is the actor-adjusted class,
+    /// so a <see cref="DirectoryActor.ServiceAccount"/> failure reports
+    /// <see cref="DirectoryFailureClass.Infrastructure"/> and can never drive an
+    /// end-user-facing decision (e.g. the administrative-reset gate) as a
+    /// credential or account-state condition.
+    /// </summary>
+    /// <param name="exception">The exception raised by the directory operation.</param>
+    /// <param name="disclosureMode">The configured disclosure posture.</param>
+    /// <param name="actor">Whose failure the exception describes.</param>
+    /// <param name="failureClass">The actor-adjusted classification;
+    /// <see cref="DirectoryFailureClass.Infrastructure"/> when no Win32 code
+    /// could be recovered.</param>
+    /// <returns>The domain exception to throw.</returns>
+    public static Exception TranslateException(
+        Exception exception,
+        ErrorDisclosureMode disclosureMode,
+        DirectoryActor actor,
         out DirectoryFailureClass failureClass)
     {
         ArgumentNullException.ThrowIfNull(exception);
 
         if (TryGetWin32Code(exception, out var code))
         {
-            failureClass = Classify(code);
-            return Translate(code, disclosureMode, exception);
+            failureClass = ClassifyForActor(code, actor);
+            return Translate(code, disclosureMode, actor, exception);
         }
 
         failureClass = DirectoryFailureClass.Infrastructure;

--- a/src/Unosquare.PassCore.Common/ServiceAccountFailure.cs
+++ b/src/Unosquare.PassCore.Common/ServiceAccountFailure.cs
@@ -1,0 +1,57 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Unosquare.PassCore.Common;
+
+/// <summary>
+/// Shared, uniform logging for failures that arise while a provider is acting
+/// as its own service account (connecting, binding, or resolving against the
+/// directory). Such a failure is operator-actionable — a misconfigured
+/// service-account credential, a missing directory permission, or a
+/// connectivity problem — yet the end user receives only a curated
+/// infrastructure response with no server detail. This helper puts the real
+/// diagnosis in the log at Warning: correlation ID (when available), the
+/// operation, the host, and the underlying Win32 code when one can be
+/// recovered.
+/// </summary>
+public static class ServiceAccountFailure
+{
+    private static readonly Action<ILogger, string?, string, string, string, Exception?> LogDefinition =
+        LoggerMessage.Define<string?, string, string, string>(
+            LogLevel.Warning,
+            new EventId(111, "ServiceAccountFailure"),
+            "[{CorrelationId}] Directory operation '{Operation}' failed while acting as the " +
+            "configured service account (host: {Host}, underlying code: {UnderlyingCode}). This is " +
+            "an operator-actionable infrastructure condition — check the service-account " +
+            "credentials, its directory permissions, and connectivity to the host. The end user " +
+            "receives a generic directory-unavailable response; no account or credential detail " +
+            "is disclosed.");
+
+    /// <summary>
+    /// Logs a service-account operation failure at Warning.
+    /// </summary>
+    /// <param name="logger">The provider's logger.</param>
+    /// <param name="correlationId">The request correlation ID, when the calling
+    /// path has one; <see langword="null"/> otherwise (e.g. group-membership
+    /// lookups that carry no request context).</param>
+    /// <param name="operation">A short label for the operation that failed.</param>
+    /// <param name="host">The directory host involved, when known.</param>
+    /// <param name="failure">The underlying failure, whose chain is scanned for
+    /// a Win32 code and which is passed to the logger for full detail.</param>
+    public static void Log(
+        ILogger logger,
+        string? correlationId,
+        string operation,
+        string? host,
+        Exception failure)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(failure);
+
+        var underlyingCode = DirectoryErrorTranslator.TryGetWin32Code(failure, out var code)
+            ? $"0x{code:X}"
+            : "unknown";
+
+        LogDefinition(logger, correlationId ?? "n/a", operation, host ?? "n/a", underlyingCode, failure);
+    }
+}

--- a/src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs
+++ b/src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs
@@ -72,8 +72,18 @@ namespace Unosquare.PassCore.PasswordProvider
             {
                 var fixedUsername = FixUsernameWithDomain(context.Username);
 
-                using var principalContext = AcquirePrincipalContext(); // Acquire PrincipalContext for AD operations, using 'using' for automatic disposal
-                var userPrincipal = UserPrincipal.FindByIdentity(principalContext, _idType, fixedUsername); // Find the UserPrincipal object
+                // Acquiring the context and resolving the user are SERVICE-ACCOUNT
+                // operations: a failure here (bad bind credentials, unreachable DC)
+                // describes the application's own connection, never the end user's
+                // password. RunAsServiceAccount guarantees it surfaces as an
+                // infrastructure failure, so it can't be misreported as invalid
+                // credentials. A *successful* lookup that finds no user still
+                // returns null (not an exception) and remains UserNotFound below.
+                using var principalContext = RunAsServiceAccount(
+                    "acquire principal context", context.CorrelationId, AcquirePrincipalContext);
+                var userPrincipal = RunAsServiceAccount(
+                    "resolve user by identity", context.CorrelationId,
+                    () => UserPrincipal.FindByIdentity(principalContext, _idType, fixedUsername));
 
                 if (userPrincipal == null) // Check if UserPrincipal is null
                 {
@@ -134,10 +144,18 @@ namespace Unosquare.PassCore.PasswordProvider
         /// <inheritdoc />
         public Task<bool> IsMemberOfGroupAsync(string username, string groupName)
         {
+            // Every operation in this method is a service-account directory read
+            // (context, resolve, group enumeration); a failure is infrastructure,
+            // never an end-user credential signal. There is no request context
+            // here, so the correlation ID is unavailable — the base class logs the
+            // propagated failure with the correlation ID as a backstop.
             try
             {
-                using var principalContext = AcquirePrincipalContext();
-                var userPrincipal = UserPrincipal.FindByIdentity(principalContext, _idType, FixUsernameWithDomain(username));
+                using var principalContext = RunAsServiceAccount(
+                    "acquire principal context", correlationId: null, AcquirePrincipalContext);
+                var userPrincipal = RunAsServiceAccount(
+                    "resolve user by identity", correlationId: null,
+                    () => UserPrincipal.FindByIdentity(principalContext, _idType, FixUsernameWithDomain(username)));
                 if (userPrincipal == null) return Task.FromResult(false);
 
                 try
@@ -161,9 +179,11 @@ namespace Unosquare.PassCore.PasswordProvider
             }
             catch (Exception ex)
             {
-                // Group lookups run inside policy evaluation; without this wrap a raw
-                // AccountManagement exception would surface as Generic + raw text.
-                throw DirectoryErrorTranslator.TranslateException(ex, _options.ErrorDisclosureMode);
+                // Group enumeration failed: a service-account directory read, so
+                // translate as ServiceAccount — never as end-user credentials.
+                ServiceAccountFailure.Log(Logger, correlationId: null, "read group membership", ServiceAccountHost(), ex);
+                throw DirectoryErrorTranslator.TranslateException(
+                    ex, _options.ErrorDisclosureMode, DirectoryActor.ServiceAccount);
             }
         }
 
@@ -359,6 +379,50 @@ namespace Unosquare.PassCore.PasswordProvider
                 _ => IdentityType.UserPrincipalName // Default to UserPrincipalName if no match or invalid input
             };
         }
+
+        /// <summary>
+        /// Runs a service-account directory operation, guaranteeing that any
+        /// failure surfaces as an infrastructure error rather than an end-user
+        /// credential/existence/account-state error. This is the AD provider's
+        /// counterpart to the LDAP provider's <c>BindAsServiceAccount</c>: both
+        /// route through the shared <see cref="DirectoryErrorTranslator"/> with
+        /// <see cref="DirectoryActor.ServiceAccount"/>, which is the single point
+        /// enforcing "a service-account failure can never be reported as invalid
+        /// credentials." Every service-account operation in this provider goes
+        /// through this method, so a future maintainer adding one inherits the
+        /// guarantee. Domain exceptions (should any arise) pass through unchanged.
+        /// </summary>
+        /// <typeparam name="T">The operation's result type.</typeparam>
+        /// <param name="operation">A short label used for diagnostics logging.</param>
+        /// <param name="correlationId">The request correlation ID, or null when unavailable.</param>
+        /// <param name="action">The service-account operation to run.</param>
+        /// <returns>The operation's result.</returns>
+        private T RunAsServiceAccount<T>(string operation, string? correlationId, Func<T> action)
+        {
+            try
+            {
+                return action();
+            }
+            catch (PasswordChangeException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                ServiceAccountFailure.Log(Logger, correlationId, operation, ServiceAccountHost(), ex);
+                throw DirectoryErrorTranslator.TranslateException(
+                    ex, _options.ErrorDisclosureMode, DirectoryActor.ServiceAccount);
+            }
+        }
+
+        /// <summary>
+        /// Describes the directory host used for service-account operations,
+        /// for diagnostics logging only.
+        /// </summary>
+        private string ServiceAccountHost() =>
+            _options.UseAutomaticContext
+                ? "automatic domain context"
+                : _options.LdapHostnames.FirstOrDefault() ?? "n/a";
 
         /// <summary>
         /// Acquires a PrincipalContext object for Active Directory operations.

--- a/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeProvider.cs
+++ b/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeProvider.cs
@@ -228,8 +228,8 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
 
         try
         {
-            // 1. Resolve user DN
-            var user = FindUser(context.Username);
+            // 1. Resolve user DN (service-account bind + search)
+            var user = FindUser(context.Username, context.CorrelationId);
 
             // 2. Verify current credentials (portable across LDAP servers)
             VerifyUserCredentials(user.DistinguishedName, context.CurrentPassword);
@@ -246,10 +246,22 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
         }
         catch (LdapException ex)
         {
+            // Operation errors (search/modify) carry their Win32 code in the
+            // extended message; TranslateLdapException extracts and routes it.
             throw TranslateLdapException(ex, _options.ErrorDisclosureMode);
         }
         catch (Exception ex)
         {
+            // Intentionally does NOT attempt TryGetWin32Code, unlike the AD
+            // provider's generic catch. That is a legitimate difference: here the
+            // typed catch above already handles every LdapException (the only
+            // carrier of a Win32 code on this transport), plus service-account
+            // bind failures are converted at BindAsServiceAccount. Anything
+            // reaching this block is a non-LDAP, unexpected failure with no
+            // meaningful directory code, so it is infrastructure. The AD provider
+            // must extract in its generic catch because AccountManagement wraps
+            // its codes in assorted COM/Principal exception types with no single
+            // typed carrier.
             throw new DirectoryUnavailableException(
                 DirectoryErrorTranslator.DirectoryFailureMessage, ex);
         }
@@ -261,13 +273,13 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
     // User resolution
     // ---------------------------------------------------------------------
 
-    private LdapUser FindUser(string username)
+    private LdapUser FindUser(string username, string? correlationId = null)
     {
         var safeUsername = SanitizeUsername(username);
         var filter = _options.LdapSearchFilter.Replace(
             "{Username}", safeUsername, StringComparison.Ordinal);
 
-        using var ldap = BindAsServiceAccount();
+        using var ldap = BindAsServiceAccount(correlationId);
 
         var search = ldap.Search(
             _options.LdapSearchBase,
@@ -372,7 +384,7 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
     /// </summary>
     private void ChangePassword(string userDn, PasswordChangeContext context, bool currentPasswordVerified)
     {
-        using var ldap = BindAsServiceAccount();
+        using var ldap = BindAsServiceAccount(context.CorrelationId);
 
         if (!_options.LdapChangePasswordWithDelAdd)
         {
@@ -695,11 +707,18 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
     // ---------------------------------------------------------------------
 
     /// <summary>
-    /// Binds as the configured service account. A bind failure here is treated
-    /// as an infrastructure error (the operator misconfigured the bind credentials),
-    /// never as an end-user authentication error.
+    /// Binds as the configured service account. A bind or connect failure here
+    /// is a SERVICE-ACCOUNT failure and is routed through the shared
+    /// <see cref="DirectoryErrorTranslator"/> with
+    /// <see cref="DirectoryActor.ServiceAccount"/> — the same enforcement point
+    /// the AD provider uses — so it always surfaces as an infrastructure error
+    /// and can never be reported to the end user as invalid credentials. The
+    /// underlying diagnosis is logged at Warning via
+    /// <see cref="ServiceAccountFailure"/>; the wire response carries no server
+    /// detail.
     /// </summary>
-    private LdapConnection BindAsServiceAccount()
+    /// <param name="correlationId">The request correlation ID, when available.</param>
+    private LdapConnection BindAsServiceAccount(string? correlationId = null)
     {
         try
         {
@@ -707,10 +726,26 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
         }
         catch (LdapBindException ex)
         {
-            throw new DirectoryUnavailableException(
-                "Failed to bind as the configured LDAP service account.", ex);
+            // Bind rejected (wrong service-account credentials, the service
+            // account locked/expired, etc.). Under ServiceAccount actor every
+            // such end-user-account signal collapses to infrastructure.
+            ServiceAccountFailure.Log(Logger, correlationId, "service-account bind", ServiceAccountHost(), ex);
+            throw TranslateLdapException(
+                (LdapException)ex.InnerException!, _options.ErrorDisclosureMode, DirectoryActor.ServiceAccount);
+        }
+        catch (DirectoryUnavailableException ex)
+        {
+            // No configured host could be reached: already infrastructure; add
+            // the service-account diagnostic and rethrow unchanged.
+            ServiceAccountFailure.Log(Logger, correlationId, "service-account connect", ServiceAccountHost(), ex);
+            throw;
         }
     }
+
+    private string ServiceAccountHost() =>
+        _options.LdapHostnames.Length > 0
+            ? string.Join(", ", _options.LdapHostnames)
+            : "n/a";
 
     /// <summary>
     /// Connects to one of the configured hosts and binds with the supplied
@@ -795,11 +830,24 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
     /// exception, which reaches logs but never the wire.
     /// </summary>
     internal static Exception TranslateLdapException(LdapException ex, ErrorDisclosureMode disclosureMode) =>
-        TranslateLdapException(ex, disclosureMode, out _);
+        TranslateLdapException(ex, disclosureMode, DirectoryActor.User, out _);
 
     internal static Exception TranslateLdapException(
         LdapException ex,
         ErrorDisclosureMode disclosureMode,
+        DirectoryActor actor) =>
+        TranslateLdapException(ex, disclosureMode, actor, out _);
+
+    internal static Exception TranslateLdapException(
+        LdapException ex,
+        ErrorDisclosureMode disclosureMode,
+        out DirectoryFailureClass failureClass) =>
+        TranslateLdapException(ex, disclosureMode, DirectoryActor.User, out failureClass);
+
+    internal static Exception TranslateLdapException(
+        LdapException ex,
+        ErrorDisclosureMode disclosureMode,
+        DirectoryActor actor,
         out DirectoryFailureClass failureClass)
     {
         var known = string.IsNullOrWhiteSpace(ex.LdapErrorMessage)
@@ -812,8 +860,8 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
             return new DirectoryUnavailableException(DirectoryErrorTranslator.DirectoryFailureMessage, ex);
         }
 
-        failureClass = known.FailureClass;
-        return DirectoryErrorTranslator.Translate(known.Code, disclosureMode, ex);
+        failureClass = DirectoryErrorTranslator.ClassifyForActor(known.Code, actor);
+        return DirectoryErrorTranslator.Translate(known.Code, disclosureMode, actor, ex);
     }
 
     /// <summary>

--- a/tests/Unosquare.PassCore.Common.Tests/DirectoryErrorTranslatorTests.cs
+++ b/tests/Unosquare.PassCore.Common.Tests/DirectoryErrorTranslatorTests.cs
@@ -291,6 +291,106 @@ public class DirectoryErrorTranslatorTests
         Assert.Equal(DirectoryErrorTranslator.InvalidCredentialsMessage, item.Message);
     }
 
+    // ------------------------------------------------------------------
+    // Actor dimension: same code, different actor, different class.
+    // A service-account failure can never surface as an end-user credential,
+    // existence, or account-state result.
+    // ------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(0x52E)] // ERROR_LOGON_FAILURE (Credentials)
+    [InlineData(0x56)]  // ERROR_INVALID_PASSWORD (Credentials)
+    [InlineData(0x52B)] // ERROR_WRONG_PASSWORD (Credentials)
+    [InlineData(0x525)] // ERROR_NO_SUCH_USER (Existence)
+    [InlineData(0x523)] // ERROR_INVALID_ACCOUNT_NAME (Existence)
+    [InlineData(0x775)] // ERROR_ACCOUNT_LOCKED_OUT (AccountState)
+    [InlineData(0x533)] // ERROR_ACCOUNT_DISABLED (AccountState)
+    [InlineData(0x532)] // ERROR_PASSWORD_EXPIRED (PasswordExpiredOrMustChange — must NOT "proceed" for the service account)
+    [InlineData(0x773)] // ERROR_PASSWORD_MUST_CHANGE (PasswordExpiredOrMustChange)
+    public void ClassifyForActor_ServiceAccount_CoercesEndUserSignalsToInfrastructure(int code)
+    {
+        // As the user, these are genuine end-user account signals...
+        Assert.NotEqual(DirectoryFailureClass.Infrastructure,
+            DirectoryErrorTranslator.ClassifyForActor(code, DirectoryActor.User));
+        // ...but as the service account they are meaningless to the caller.
+        Assert.Equal(DirectoryFailureClass.Infrastructure,
+            DirectoryErrorTranslator.ClassifyForActor(code, DirectoryActor.ServiceAccount));
+    }
+
+    [Theory]
+    [InlineData(0x52D, DirectoryFailureClass.NewPasswordPolicy)]
+    [InlineData(0x8C3, DirectoryFailureClass.ChangeNotPermitted)]
+    [InlineData(0x5, DirectoryFailureClass.Infrastructure)]
+    public void ClassifyForActor_ServiceAccount_LeavesNonEndUserSignalClassesUntouched(
+        int code, DirectoryFailureClass expected)
+    {
+        Assert.Equal(expected, DirectoryErrorTranslator.ClassifyForActor(code, DirectoryActor.ServiceAccount));
+        Assert.Equal(expected, DirectoryErrorTranslator.ClassifyForActor(code, DirectoryActor.User));
+    }
+
+    [Theory]
+    [InlineData(0x52E, ErrorDisclosureMode.Hardened)]
+    [InlineData(0x52E, ErrorDisclosureMode.Informative)]
+    [InlineData(0x775, ErrorDisclosureMode.Hardened)]
+    [InlineData(0x775, ErrorDisclosureMode.Informative)]
+    [InlineData(0x532, ErrorDisclosureMode.Hardened)]  // the expired case: never "proceed" for the service account
+    [InlineData(0x532, ErrorDisclosureMode.Informative)]
+    [InlineData(0x525, ErrorDisclosureMode.Hardened)]
+    [InlineData(0x525, ErrorDisclosureMode.Informative)]
+    public void Translate_ServiceAccount_YieldsInfrastructure_NeverCredentials(int code, ErrorDisclosureMode mode)
+    {
+        var item = ApiErrorMapper.Map(DirectoryErrorTranslator.Translate(code, mode, DirectoryActor.ServiceAccount));
+
+        Assert.Equal(ApiErrorCode.LdapProblem, item.ErrorCode);
+        Assert.Equal(DirectoryErrorTranslator.DirectoryFailureMessage, item.Message);
+    }
+
+    [Fact]
+    public void Translate_ServiceAccount_NoCatalogCodeEverProducesCredentialsOrUserNotFound()
+    {
+        // The core invariant, exhaustively: whatever a service-account operation
+        // fails with, the end user never sees an account-existence or credential
+        // signal.
+        foreach (var entry in Win32ErrorCode.Codes)
+        {
+            foreach (var mode in new[] { ErrorDisclosureMode.Hardened, ErrorDisclosureMode.Informative })
+            {
+                var item = ApiErrorMapper.Map(
+                    DirectoryErrorTranslator.Translate(entry.Code, mode, DirectoryActor.ServiceAccount));
+
+                Assert.NotEqual(ApiErrorCode.InvalidCredentials, item.ErrorCode);
+                Assert.NotEqual(ApiErrorCode.UserNotFound, item.ErrorCode);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(ErrorDisclosureMode.Hardened)]
+    [InlineData(ErrorDisclosureMode.Informative)]
+    public void Translate_User_StillYieldsInvalidCredentials_RegressionGuard(ErrorDisclosureMode mode)
+    {
+        // The fix must not over-correct: the end user's own wrong password is
+        // still invalid credentials.
+        var item = ApiErrorMapper.Map(DirectoryErrorTranslator.Translate(0x52E, mode, DirectoryActor.User));
+        Assert.Equal(ApiErrorCode.InvalidCredentials, item.ErrorCode);
+    }
+
+    [Fact]
+    public void TranslateException_ServiceAccountHResult_MapsToInfrastructure()
+    {
+        // The exact call the AD provider's RunAsServiceAccount makes: a
+        // FACILITY_WIN32 logon-failure HRESULT from AccountManagement.
+        var raw = new HResultException(unchecked((int)0x8007052E), "raw AccountManagement text");
+
+        var item = ApiErrorMapper.Map(DirectoryErrorTranslator.TranslateException(
+            raw, ErrorDisclosureMode.Hardened, DirectoryActor.ServiceAccount, out var failureClass));
+
+        Assert.Equal(DirectoryFailureClass.Infrastructure, failureClass);
+        Assert.Equal(ApiErrorCode.LdapProblem, item.ErrorCode);
+        Assert.Equal(DirectoryErrorTranslator.DirectoryFailureMessage, item.Message);
+        Assert.DoesNotContain("raw AccountManagement text", item.Message, StringComparison.Ordinal);
+    }
+
     private sealed class HResultException : Exception
     {
         public HResultException(int hresult, string message = "test", Exception? inner = null)

--- a/tests/Unosquare.PassCore.Common.Tests/ServiceAccountFailureTests.cs
+++ b/tests/Unosquare.PassCore.Common.Tests/ServiceAccountFailureTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Microsoft.Extensions.Logging;
+
+namespace Unosquare.PassCore.Common.Tests;
+
+public class ServiceAccountFailureTests
+{
+    [Fact]
+    public void Log_EmitsWarningWithCorrelationIdOperationHostAndUnderlyingCode()
+    {
+        var logger = new CapturingLogger();
+        var failure = new Win32Exception(0x52E); // ERROR_LOGON_FAILURE
+
+        ServiceAccountFailure.Log(logger, "abc12345", "service-account bind", "dc1.example.com", failure);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("abc12345", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("service-account bind", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("dc1.example.com", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("0x52E", entry.Message, StringComparison.Ordinal);
+        Assert.Same(failure, entry.Exception);
+    }
+
+    [Fact]
+    public void Log_NullCorrelationIdAndUnrecoverableCode_StillLogsWithPlaceholders()
+    {
+        var logger = new CapturingLogger();
+        var failure = new InvalidOperationException("no win32 code here");
+
+        ServiceAccountFailure.Log(logger, correlationId: null, "service-account connect", host: null, failure);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("n/a", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("unknown", entry.Message, StringComparison.Ordinal);
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<(LogLevel Level, string Message, Exception? Exception)> Entries { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            Entries.Add((logLevel, formatter(state, exception), exception));
+    }
+}

--- a/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/LdapExceptionTranslationTests.cs
+++ b/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/LdapExceptionTranslationTests.cs
@@ -183,4 +183,43 @@ public class LdapExceptionTranslationTests
 
         Assert.False(LdapPasswordChangeProvider.IsPasswordExpiredOrMustChange(ex));
     }
+
+    // ------------------------------------------------------------------
+    // Actor dimension: the exact translation BindAsServiceAccount performs.
+    // The same bind rejection that means "wrong current password" for the end
+    // user means "misconfigured/unusable service account" — infrastructure —
+    // when it happens on the service-account bind.
+    // ------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(BindLogonFailure, ErrorDisclosureMode.Hardened)]      // 0x52E
+    [InlineData(BindLogonFailure, ErrorDisclosureMode.Informative)]
+    [InlineData(BindPasswordExpired, ErrorDisclosureMode.Hardened)]   // 0x532 — must NOT "proceed" for the service account
+    [InlineData(BindPasswordExpired, ErrorDisclosureMode.Informative)]
+    public void TranslateLdapException_ServiceAccountActor_MapsBindFailureToInfrastructure(
+        string serverMessage, ErrorDisclosureMode mode)
+    {
+        var result = LdapPasswordChangeProvider.TranslateLdapException(
+            Ldap(serverMessage, LdapException.InvalidCredentials), mode, DirectoryActor.ServiceAccount);
+
+        var dir = Assert.IsType<DirectoryUnavailableException>(result);
+        Assert.Equal(DirectoryErrorTranslator.DirectoryFailureMessage, dir.Message);
+        Assert.Equal(ApiErrorCode.LdapProblem, ApiErrorMapper.Map(dir).ErrorCode);
+    }
+
+    [Theory]
+    [InlineData(BindLogonFailure)]
+    [InlineData(BindPasswordExpired)]
+    public void TranslateLdapException_UserActor_SameBindFailureStillInvalidCredentials_RegressionGuard(
+        string serverMessage)
+    {
+        // The user-verification bind keeps its existing meaning: proof failed.
+        var result = LdapPasswordChangeProvider.TranslateLdapException(
+            Ldap(serverMessage, LdapException.InvalidCredentials),
+            ErrorDisclosureMode.Hardened, DirectoryActor.User);
+
+        // 0x532 is allowed through elsewhere as "proceed"; here (translation, not
+        // verification) it is InvalidCredentials — either way, never LdapProblem.
+        Assert.IsType<InvalidCredentialsException>(result);
+    }
 }

--- a/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/RoutingMatrixAuditTests.cs
+++ b/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/RoutingMatrixAuditTests.cs
@@ -189,6 +189,53 @@ public class RoutingMatrixAuditTests
         Assert.True(DirectoryErrorTranslator.IsPasswordExpiredOrMustChange(code));
     }
 
+    // ------------------------------------------------------------------
+    // 5. Actor dimension: same code, different actor, different class.
+    //    A service-account failure produces one identical infrastructure
+    //    result on both providers, in both modes — never a credential signal.
+    // ------------------------------------------------------------------
+
+    public static TheoryData<int, ErrorDisclosureMode> ServiceAccountSignalCodes
+    {
+        get
+        {
+            var data = new TheoryData<int, ErrorDisclosureMode>();
+            // The codes a service-account bind/resolve can plausibly carry — all
+            // end-user-account signals as the user, all infrastructure as the svc acct.
+            foreach (var code in new[] { 0x56, 0x52B, 0x52E, 0x523, 0x525, 0x52F, 0x530, 0x531, 0x532, 0x533, 0x701, 0x773, 0x775 })
+            {
+                data.Add(code, ErrorDisclosureMode.Hardened);
+                data.Add(code, ErrorDisclosureMode.Informative);
+            }
+
+            return data;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ServiceAccountSignalCodes))]
+    public void ServiceAccountActor_BothProviders_ConvergeOnInfrastructure(int code, ErrorDisclosureMode mode)
+    {
+        // LDAP transport, service-account bind (the BindAsServiceAccount path).
+        var ldap = Wire.Of(LdapPasswordChangeProvider.TranslateLdapException(
+            new LdapException("t", LdapException.InvalidCredentials,
+                $"80090308: LdapErr: DSID-0C090439, comment: AcceptSecurityContext error, data {code:x}, v3839"),
+            mode, DirectoryActor.ServiceAccount));
+
+        // AD transport, service-account op (the RunAsServiceAccount path).
+        var ad = Wire.Of(DirectoryErrorTranslator.TranslateException(
+            new HResultException(unchecked((int)0x80070000 | code)), mode, DirectoryActor.ServiceAccount));
+
+        var expected = new Wire(ApiErrorCode.LdapProblem, DirectoryErrorTranslator.DirectoryFailureMessage);
+        Assert.Equal(expected, ldap);
+        Assert.Equal(expected, ad);
+
+        // And as the USER the same code stays an end-user signal — proving the
+        // actor, not the code, is what changed the outcome.
+        var asUser = Wire.Of(DirectoryErrorTranslator.Translate(code, mode, DirectoryActor.User));
+        Assert.NotEqual(ApiErrorCode.LdapProblem, asUser.Code);
+    }
+
     private static Wire ExpectedWire(DirectoryFailureClass failureClass, ErrorDisclosureMode mode)
     {
         // Drive an exception of the given class through the translator by using


### PR DESCRIPTION
## Description

A directory failure's Win32 code says **what** failed but not **whose** credentials. `Classify(0x52E)` returns `Credentials` whether it was the end user proving their current password or the application's own service account connecting to the directory. The LDAP provider already compensated by call site (`BindAsServiceAccount` → `DirectoryUnavailable` vs `VerifyUserCredentials` → `InvalidCredentials`); the AD provider ran its service-account operations in the same `try` as the user-facing ones, so a misconfigured service account was reported to the end user as *"Invalid username or password."* This makes both providers reach the correct outcome through one shared, enforceable concept.

### Shape chosen: (b) explicit in the translator

I chose the actor/stage parameter over a purely structural per-provider fix, because it makes the invariant **enforceable at one point** for every current and future provider rather than a convention each provider must remember. The structural piece still exists (a wrapper per provider) but it *delegates* to the shared rule.

- **`DirectoryErrorTranslator`** gains `DirectoryActor { User, ServiceAccount }` and `ClassifyForActor(code, actor)`. Under `ServiceAccount`, the end-user-account-signal classes — `Credentials`, `Existence`, `AccountState`, `PasswordExpiredOrMustChange` — collapse to `Infrastructure`. So a service-account or connectivity failure can **never** produce `InvalidCredentials`/`UserNotFound`, in **both** disclosure modes. `Translate`/`TranslateException` gain actor-aware overloads; the pre-existing overloads delegate with `DirectoryActor.User`, so every current caller and test is unchanged. This is the single enforcement point.

### Enumerated service-account operations (AD provider)

`RunAsServiceAccount` wraps each and translates its failures with `ServiceAccount`:
- `AcquirePrincipalContext()` — including its lazy bind, and its own `InvalidOperationException("Failed to create PrincipalContext.", …)` wrapper (the COR-HRESULT wrapper is walked past to the inner FACILITY_WIN32 code; the wrapping never prevented the misclassification).
- `UserPrincipal.FindByIdentity()` — in both `ChangePasswordCore` and `IsMemberOfGroupAsync`.
- `GetGroups()` / `GetAuthorizationGroups()` — the group-membership reads.

The **user-credential verification** in `ValidateUserCredentials` is the only place `Credentials` stays reachable — and it's bool-based, so the sole `InvalidCredentials` is the explicit `throw` there. The modify path (`UpdatePassword` → `ChangePassword`/`SetPassword`) stays `User`, preserving Phase 3's `NewPasswordPolicy` → `ComplexPassword` and the reset gate.

**User-not-found is unaffected:** `FindByIdentity` returning *null* is not an exception — `RunAsServiceAccount` passes null through and the existing null-check still raises the posture-appropriate `UserNotFound`/`InvalidCredentials`. Only an *exception* from a service-account op is coerced.

### LDAP provider — generalized, not replaced

`BindAsServiceAccount` now expresses its (already-correct) behavior through the **same** shared concept: `TranslateLdapException(inner, mode, ServiceAccount)` instead of a bespoke `DirectoryUnavailableException`. `VerifyUserCredentials` and the modify path are untouched (`User`). This also stops leaking the "service account" wording on the wire — the wire message is now the curated `DirectoryFailureMessage`, with the specific detail in logs.

### Diagnostics

New shared `ServiceAccountFailure.Log` (Warning, EventId 111): correlation ID (threaded through `FindUser`/`ChangePassword`/`RunAsServiceAccount` where a request context exists; `null` for the context-less group path, where the base class logs the propagated failure with the correlation ID as backstop), operation label, host, and the underlying Win32 code when recoverable. The wire response carries no server detail.

### The `0x532` subtlety

Explicitly covered: `IsPasswordExpiredOrMustChange(0x532)` means "proceed, the password is correct but expired" during **user** verification, but for the **service account** it must never proceed. The actor coercion makes `0x532` → `Infrastructure`, and `RunAsServiceAccount` doesn't use the "proceed" logic at all — double-safe. Tested for both providers.

### LDAP generic-catch asymmetry — decided: legitimately different (documented)

The LDAP `catch (Exception)` goes straight to `DirectoryUnavailable` without `TryGetWin32Code`, while AD's attempts extraction. This is correct as-is: LDAP's typed `catch (LdapException)` already handles the only code-carrying exception on that transport (extracting from the extended message), and service-account bind failures are converted at `BindAsServiceAccount`; anything reaching LDAP's generic catch is a non-LDAP unexpected failure with no meaningful code. AD has no single typed carrier (AccountManagement wraps codes in assorted COM/Principal HRESULT types), so it *must* extract in its generic catch. A code comment now states this.

### Verification of the AccountManagement exception types/HRESULTs

I could **not** run `System.DirectoryServices.AccountManagement` here (the AD provider is `#if WINDOWS` / `net8.0-windows`; ubuntu CI never compiles it). The structural gap is confirmed by reading the code; the exact exception *type* per failure mode remains **unverified against a live DC** and is flagged as an open question. **The fix does not depend on the specific type:** `RunAsServiceAccount` catches any `Exception` and the translator coerces by actor regardless of type/code. I verified the translation path with a simulated `FACILITY_WIN32` `0x8007052E` HRESULT — the shape AccountManagement wraps around COM errors — through the exact `TranslateException(…, ServiceAccount)` call the provider makes. AD edits were compile-verified against the real `System.DirectoryServices.*` reference assemblies in a scratch `WINDOWS` build.

### Tests (extended existing files, no parallel table)

- **`DirectoryErrorTranslatorTests`**: `ClassifyForActor` coercion of every signal class; exhaustive "no catalog code yields `InvalidCredentials`/`UserNotFound` as `ServiceAccount`" in both modes; `0x52E`/`0x775`/`0x532`/`0x525` service-account → `LdapProblem`; end-user wrong-password `User`-actor regression guard; the AD `TranslateException(0x8007052E, …, ServiceAccount)` path.
- **`LdapExceptionTranslationTests`**: the exact `BindAsServiceAccount` translation (`ServiceAccount` bind failures → `LdapProblem`; `User` unchanged).
- **`RoutingMatrixAuditTests`**: cross-provider parity of the actor dimension — LDAP bind transport and AD HRESULT transport converge on `LdapProblem`/`DirectoryFailureMessage` for the same code, both modes, while the same code as `User` stays a signal.
- **`ServiceAccountFailureTests`**: log shape (Warning, correlation ID/operation/host/underlying code; `n/a`/`unknown` placeholders).
- 434 tests pass (Common 146, LDAP 264, Debug 20, Pwned 4); zero existing tests modified.

### Investigated and left alone

- **`AcquireDomainPasswordLength`/`GetMinimumLengthAsync`** already swallow every exception and return a default (6); they can't misreport, so they're left as-is (noted).
- **`SetLastPassword`/`UpdateLastPassword`** — untouched per the task (separate pending decision).
- **LDAP `IsMemberOfGroupAsync`'s post-bind `Search` `LdapException`** stays `User`-translated: the service-account *bind* (the actual auth failure) is already converted in `BindAsServiceAccount`, and an LDAP *search* operation error doesn't carry a credential code in practice. Kept minimal per "don't change the LDAP separation."

### Open questions

1. The exact `AccountManagement` exception type + HRESULT per service-account failure mode (bind rejected / locked / expired) — inferred and handled type-agnostically; worth confirming against a live DC.
2. LDAP `BindAsServiceAccount` wire message changed from "Failed to bind as the configured LDAP service account." to the curated `DirectoryFailureMessage` (detail moved to logs). This is an improvement (no operational wording on the wire) but is a visible-string change if anything scraped it.

### Migration notes

- **AD**: a misconfigured/unreachable service account now returns `LdapProblem` (code 8) instead of `InvalidCredentials` (code 4), and is logged at Warning with the underlying code. No end-user-facing change for correctly configured deployments.
- **LDAP**: the service-account bind-failure wire message is now the generic directory-unavailable string (same `LdapProblem` code); no behavior change otherwise.
- No `ApiErrorCode`/`ErrorDisclosureMode`/wire-shape changes; the reset gate and hardened-mode guarantee are untouched.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation update
- [x] Testing/CI harness

## Checklist
- [x] All new code compiles under .NET 8.
- [x] `dotnet test` passes locally.
- [x] No external network calls are made in unit tests.
- [x] Documentation (if applicable) is updated.
- [ ] Debug provider is gated by `#if DEBUG` and cannot be enabled in Production. *(not applicable — Debug provider untouched)*
- [ ] (Optional) Example e2e test runs against the Docker Compose test stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqqJZfw8hSz2n16KgdcQcG

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqqJZfw8hSz2n16KgdcQcG)_