### PR TITLE
Task C: Diagnostics, silent-degradation, and doc-accuracy cleanup

### DIFF
--- a/docs/error-routing-matrix.md
+++ b/docs/error-routing-matrix.md
@@ -138,6 +138,24 @@ gets the diagnosis while the wire response stays curated. `0x532`
 password is correct but expired"; as the **service account** it must never
 proceed — the actor coercion makes it `Infrastructure`.
 
+## Terminal catch
+
+Both providers end `ChangePasswordCore` with the same last-resort
+`catch (Exception ex)`: **construct `DirectoryUnavailableException(
+DirectoryFailureMessage, ex)` directly — do not re-scan the chain for a Win32
+code.** Every failure that carries a meaningful directory code is already
+handled at its stage (typed `LdapException` / `TryGetWin32Code` extraction for
+the transport, service-account operations via `BindAsServiceAccount` /
+`RunAsServiceAccount`, the modify itself in the LDAP `ChangePasswordDelAdd`
+catch and the AD `UpdatePassword` catch). An exception reaching the terminal
+catch is therefore an unexpected, non-directory-typed fault with no reliable
+code, so speculative extraction there is inappropriate — it could only
+mislabel a non-directory fault. Classifying it as infrastructure is correct and
+identical on both providers. (Earlier the AD provider re-scanned via
+`TranslateException` here while the LDAP provider did not; standardized on the
+LDAP behavior.) The raw detail stays in the inner exception for logs, never on
+the wire.
+
 ## The administrative-reset fallback dimension
 
 `AllowAdministrativeReset` (server-side, default off) adds a second dimension,

--- a/src/Unosquare.PassCore.Common/DomainPasswordPolicy.cs
+++ b/src/Unosquare.PassCore.Common/DomainPasswordPolicy.cs
@@ -1,0 +1,75 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Unosquare.PassCore.Common;
+
+/// <summary>
+/// Shared, transport-agnostic resolution of the domain's minimum password
+/// length, with the fallback decision made in one testable place. A provider
+/// supplies the directory-specific lookup; this helper decides what to do when
+/// it fails or returns nothing — crucially, it does so without silence.
+/// </summary>
+/// <remarks>
+/// When the lookup fails (unreachable DC, service account cannot read
+/// <c>minPwdLength</c>) or the value is absent, PassCore would otherwise
+/// advertise a minimum length <b>weaker</b> than the domain actually enforces:
+/// the user passes client-side validation, submits, and the directory rejects
+/// the password as too short with nothing in the logs explaining why. The
+/// fallback value is kept at the long-standing default so a working deployment
+/// is unaffected, but the failure is logged at Warning as an operator-actionable
+/// condition.
+/// </remarks>
+public static class DomainPasswordPolicy
+{
+    /// <summary>
+    /// The minimum password length advertised when the domain policy cannot be
+    /// read. Historically the default and kept to avoid changing behavior for
+    /// deployments where the lookup works; the log makes the fallback visible
+    /// when it does not.
+    /// </summary>
+    public const int DefaultMinimumLength = 6;
+
+    private static readonly Action<ILogger, int, Exception?> LogLookupFailed =
+        LoggerMessage.Define<int>(
+            LogLevel.Warning,
+            new EventId(112, "MinimumPasswordLengthLookupFailed"),
+            "Could not read the domain minimum password length (minPwdLength); advertising the " +
+            "fallback of {FallbackLength}. If the domain enforces a longer minimum, users will " +
+            "pass client-side length validation and then be rejected by the directory. Check " +
+            "connectivity to the domain controller and that the service account can read the " +
+            "domain password policy.");
+
+    /// <summary>
+    /// Resolves the minimum password length: returns the looked-up value when
+    /// present, otherwise logs at Warning and returns <paramref name="fallback"/>.
+    /// Never throws — a lookup failure is turned into the logged fallback.
+    /// </summary>
+    /// <param name="logger">The provider's logger.</param>
+    /// <param name="lookup">The directory-specific lookup; returns the domain's
+    /// minimum length, or <see langword="null"/> when it is unavailable. May throw,
+    /// in which case the exception is logged and the fallback is returned.</param>
+    /// <param name="fallback">The value to advertise when the lookup yields nothing.</param>
+    /// <returns>The resolved minimum length.</returns>
+    public static int ResolveMinimumLength(
+        ILogger logger,
+        Func<int?> lookup,
+        int fallback = DefaultMinimumLength)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(lookup);
+
+        try
+        {
+            if (lookup() is { } minLength)
+                return minLength;
+
+            LogLookupFailed(logger, fallback, null);
+            return fallback;
+        }
+        catch (Exception ex)
+        {
+            LogLookupFailed(logger, fallback, ex);
+            return fallback;
+        }
+    }
+}

--- a/src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs
+++ b/src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs
@@ -40,6 +40,14 @@ namespace Unosquare.PassCore.PasswordProvider
                 "administrative reset with. Configure explicit LdapUsername/LdapPassword bind " +
                 "credentials (UseAutomaticContext=false) if the fallback is wanted.");
 
+        private static readonly Action<ILogger, Exception?> LogGroupEnumerationFallback =
+            LoggerMessage.Define(
+                LogLevel.Debug,
+                new EventId(104, nameof(LogGroupEnumerationFallback)),
+                "GetGroups() failed; falling back to GetAuthorizationGroups(). The two behave " +
+                "differently across environments so the fallback is expected, but a persistent " +
+                "GetGroups failure indicates a misconfiguration worth investigating.");
+
         public PasswordChangeProvider(
             ILogger<PasswordChangeProvider> logger,
             IOptions<PasswordChangeOptions> options,
@@ -124,12 +132,19 @@ namespace Unosquare.PassCore.PasswordProvider
             }
             catch (Exception ex)
             {
-                // Never let raw AccountManagement/COM exception text reach the wire:
-                // recover the Win32 code from the exception chain when present (e.g.
-                // COMException 0x800708C5 for a policy rejection) and route it through
-                // the shared translator; anything unrecognizable degrades to a
-                // curated directory-failure message with the detail preserved for logs.
-                throw DirectoryErrorTranslator.TranslateException(ex, _options.ErrorDisclosureMode);
+                // Terminal backstop. Every failure that carries a meaningful
+                // directory code is already handled at its stage — service-account
+                // operations via RunAsServiceAccount, the modify itself via
+                // UpdatePassword's catch, the cannot-change flag pre-flight. An
+                // exception reaching HERE is an unexpected, non-directory-typed
+                // fault (e.g. a Save() failure) with no reliable Win32 code, so
+                // it is classified as infrastructure directly rather than by
+                // speculatively re-scanning the chain. This matches the LDAP
+                // provider's terminal catch (see the routing-matrix doc, "Terminal
+                // catch"). Raw exception text stays in the inner exception (logs),
+                // never on the wire.
+                throw new DirectoryUnavailableException(
+                    DirectoryErrorTranslator.DirectoryFailureMessage, ex);
             }
 
             return Task.CompletedTask;
@@ -164,8 +179,13 @@ namespace Unosquare.PassCore.PasswordProvider
                     if (groups.Any(group => group.Name.Equals(groupName, StringComparison.OrdinalIgnoreCase)))
                         return Task.FromResult(true);
                 }
-                catch
+                catch (Exception ex)
                 {
+                    // The fallback is expected (the two calls fail in different
+                    // environments), but leave a trace so a persistent GetGroups
+                    // misconfiguration is not invisible.
+                    LogGroupEnumerationFallback(Logger, ex);
+
                     var groups = userPrincipal.GetAuthorizationGroups();
                     if (groups.Any(group => group.Name.Equals(groupName, StringComparison.OrdinalIgnoreCase)))
                         return Task.FromResult(true);
@@ -269,9 +289,12 @@ namespace Unosquare.PassCore.PasswordProvider
         /// ChangePassword. On failure, an administrative SetPassword fallback
         /// may fire — but only when <see cref="PasswordChangeOptions.AllowAdministrativeReset"/>
         /// is enabled (default off), the user's current password was verified in
-        /// this request, the failure is one a reset can cure (new-password
-        /// policy or cannot-change; the shared <see cref="AdministrativeReset"/>
-        /// gate), and the provider is bound with service-account credentials
+        /// this request, the failure is the cannot-change-password condition
+        /// (<see cref="DirectoryFailureClass.ChangeNotPermitted"/> — the only
+        /// class the shared <see cref="AdministrativeReset"/> gate rescues;
+        /// new-password policy rejections such as history or minimum age are
+        /// deliberately excluded so intentional domain policy is never bypassed),
+        /// and the provider is bound with service-account credentials
         /// (automatic-context mode never resets). Every reset is logged at
         /// Warning with the request correlation ID. With the fallback disabled
         /// or ineligible, the failure surfaces through
@@ -462,32 +485,33 @@ namespace Unosquare.PassCore.PasswordProvider
         }
 
         /// <summary>
-        /// Retrieves the minimum password length policy from Active Directory.
-        /// Uses either automatic domain context or specified LDAP connection details based on 'UseAutomaticContext' option.
-        /// Returns a default value of 6 if retrieval fails.
+        /// Retrieves the minimum password length policy from Active Directory,
+        /// falling back — visibly, via a logged Warning — to
+        /// <see cref="DomainPasswordPolicy.DefaultMinimumLength"/> when the domain
+        /// policy cannot be read. The fallback/log decision lives in the shared,
+        /// testable <see cref="DomainPasswordPolicy.ResolveMinimumLength"/>; this
+        /// method supplies only the AccountManagement-specific lookup.
         /// </summary>
         /// <returns>The minimum password length as an integer.</returns>
-        private int AcquireDomainPasswordLength()
+        private int AcquireDomainPasswordLength() =>
+            DomainPasswordPolicy.ResolveMinimumLength(Logger, ReadMinPwdLength);
+
+        /// <summary>
+        /// Reads <c>minPwdLength</c> from the domain. Returns <see langword="null"/>
+        /// when the value is absent; throws when the directory cannot be reached
+        /// or read — both are turned into the logged fallback by
+        /// <see cref="DomainPasswordPolicy.ResolveMinimumLength"/>.
+        /// </summary>
+        private int? ReadMinPwdLength()
         {
-            DirectoryEntry? entry = null; // Initialize to null for try-finally and error handling
+            DirectoryEntry? entry = null; // Initialize to null for try-finally
             try
             {
                 entry = _options.UseAutomaticContext
                     ? Domain.GetCurrentDomain().GetDirectoryEntry()
                     : GetDirectoryEntry();
 
-                if (entry?.Properties["minPwdLength"]?.Value is int minLength) // Null-conditional checks and type check
-                {
-                    return minLength;
-                }
-                else
-                {
-                    return 6; // Default minimum password length
-                }
-            }
-            catch (Exception)
-            {
-                return 6; // Default minimum password length in case of exception
+                return entry?.Properties["minPwdLength"]?.Value is int minLength ? minLength : null;
             }
             finally
             {
@@ -498,10 +522,10 @@ namespace Unosquare.PassCore.PasswordProvider
 
         /// <summary>
         /// Creates and returns a DirectoryEntry object using LDAP connection details from options.
-        /// This method is extracted for better readability and reusability.
-        /// Returns null and logs a warning if LDAP Hostnames are not configured.
+        /// Returns <see langword="null"/> only when no LDAP hostnames are configured; a construction
+        /// failure is allowed to propagate so the caller can log it (rather than being swallowed here).
         /// </summary>
-        /// <returns>A <see cref="DirectoryEntry"/> object configured with LDAP credentials, or null if configuration is missing.</returns>
+        /// <returns>A <see cref="DirectoryEntry"/> object configured with LDAP credentials, or null if no hostnames are configured.</returns>
         private DirectoryEntry? GetDirectoryEntry()
         {
             if (!_options.LdapHostnames.Any()) // Check if LdapHostnames is empty
@@ -510,17 +534,14 @@ namespace Unosquare.PassCore.PasswordProvider
             }
 
             var domain = $"{_options.LdapHostnames.First()}:{_options.LdapPort}"; // Construct domain string
-            try
-            {
-                return new DirectoryEntry( // Create DirectoryEntry with LDAP credentials
-                    domain,
-                    _options.LdapUsername,
-                    _options.LdapPassword);
-            }
-            catch (Exception)
-            {
-                return null; // Return null if DirectoryEntry creation fails
-            }
+
+            // No local catch: a construction failure propagates to
+            // ResolveMinimumLength, which logs it and returns the fallback. This
+            // removes the previous silent swallow that hid the real reason.
+            return new DirectoryEntry( // Create DirectoryEntry with LDAP credentials
+                domain,
+                _options.LdapUsername,
+                _options.LdapPassword);
         }
     }
 }

--- a/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeProvider.cs
+++ b/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeProvider.cs
@@ -252,16 +252,14 @@ public sealed class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGr
         }
         catch (Exception ex)
         {
-            // Intentionally does NOT attempt TryGetWin32Code, unlike the AD
-            // provider's generic catch. That is a legitimate difference: here the
-            // typed catch above already handles every LdapException (the only
-            // carrier of a Win32 code on this transport), plus service-account
-            // bind failures are converted at BindAsServiceAccount. Anything
-            // reaching this block is a non-LDAP, unexpected failure with no
-            // meaningful directory code, so it is infrastructure. The AD provider
-            // must extract in its generic catch because AccountManagement wraps
-            // its codes in assorted COM/Principal exception types with no single
-            // typed carrier.
+            // Terminal backstop, consistent with the AD provider (see the
+            // routing-matrix doc, "Terminal catch"). Every failure carrying a
+            // meaningful directory code is already handled at its stage — the
+            // typed LdapException catch above, and service-account bind failures
+            // at BindAsServiceAccount. An exception reaching HERE is an
+            // unexpected, non-LDAP fault with no reliable Win32 code, so it is
+            // classified as infrastructure directly rather than by speculatively
+            // scanning the chain. Raw text stays in the inner exception.
             throw new DirectoryUnavailableException(
                 DirectoryErrorTranslator.DirectoryFailureMessage, ex);
         }

--- a/tests/Unosquare.PassCore.Common.Tests/DirectoryErrorTranslatorTests.cs
+++ b/tests/Unosquare.PassCore.Common.Tests/DirectoryErrorTranslatorTests.cs
@@ -391,6 +391,39 @@ public class DirectoryErrorTranslatorTests
         Assert.DoesNotContain("raw AccountManagement text", item.Message, StringComparison.Ordinal);
     }
 
+    // ------------------------------------------------------------------
+    // C-4: terminal-catch consistency. Both providers' last-resort
+    // catch (Exception) now constructs DirectoryUnavailableException directly.
+    // For the non-directory exceptions that actually reach it, that produces
+    // the same wire result the former AD-side TranslateException did — so the
+    // standardization is behavior-preserving for the expected input, and both
+    // providers land on the same infrastructure result.
+    // ------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(ErrorDisclosureMode.Hardened)]
+    [InlineData(ErrorDisclosureMode.Informative)]
+    public void TerminalCatch_NonDirectoryException_YieldsInfrastructureIdenticallyToFormerAdBehavior(
+        ErrorDisclosureMode mode)
+    {
+        var nonDirectory = new InvalidOperationException("unexpected non-directory fault");
+
+        // What both providers' terminal catch now does (direct construction).
+        var standardized = ApiErrorMapper.Map(
+            new DirectoryUnavailableException(DirectoryErrorTranslator.DirectoryFailureMessage, nonDirectory));
+
+        // What the AD provider's terminal catch used to do (chain re-scan). For a
+        // non-directory exception there is no Win32 code to find, so it degrades
+        // to the same infrastructure result — proving the change is safe.
+        var formerAd = ApiErrorMapper.Map(
+            DirectoryErrorTranslator.TranslateException(nonDirectory, mode));
+
+        Assert.Equal(ApiErrorCode.LdapProblem, standardized.ErrorCode);
+        Assert.Equal(standardized.ErrorCode, formerAd.ErrorCode);
+        Assert.Equal(standardized.Message, formerAd.Message);
+        Assert.DoesNotContain("non-directory fault", standardized.Message!, StringComparison.Ordinal);
+    }
+
     private sealed class HResultException : Exception
     {
         public HResultException(int hresult, string message = "test", Exception? inner = null)

--- a/tests/Unosquare.PassCore.Common.Tests/DomainPasswordPolicyTests.cs
+++ b/tests/Unosquare.PassCore.Common.Tests/DomainPasswordPolicyTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Unosquare.PassCore.Common.Tests;
+
+public class DomainPasswordPolicyTests
+{
+    [Fact]
+    public void ResolveMinimumLength_LookupReturnsValue_ReturnsItWithoutLogging()
+    {
+        var logger = new CapturingLogger();
+
+        var result = DomainPasswordPolicy.ResolveMinimumLength(logger, () => 14);
+
+        Assert.Equal(14, result);
+        Assert.Empty(logger.Entries);
+    }
+
+    [Fact]
+    public void ResolveMinimumLength_LookupReturnsNull_LogsWarningAndReturnsFallback()
+    {
+        var logger = new CapturingLogger();
+
+        var result = DomainPasswordPolicy.ResolveMinimumLength(logger, () => null);
+
+        Assert.Equal(DomainPasswordPolicy.DefaultMinimumLength, result);
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("minPwdLength", entry.Message, StringComparison.Ordinal);
+        Assert.Null(entry.Exception);
+    }
+
+    [Fact]
+    public void ResolveMinimumLength_LookupThrows_LogsWarningWithExceptionAndReturnsFallback()
+    {
+        var logger = new CapturingLogger();
+        var boom = new InvalidOperationException("DC unreachable");
+
+        var result = DomainPasswordPolicy.ResolveMinimumLength(logger, () => throw boom);
+
+        Assert.Equal(DomainPasswordPolicy.DefaultMinimumLength, result);
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Same(boom, entry.Exception);
+    }
+
+    [Fact]
+    public void ResolveMinimumLength_CustomFallback_IsHonored()
+    {
+        var logger = new CapturingLogger();
+
+        var result = DomainPasswordPolicy.ResolveMinimumLength(logger, () => null, fallback: 12);
+
+        Assert.Equal(12, result);
+    }
+
+    [Fact]
+    public void ResolveMinimumLength_NeverThrows_EvenWhenLookupDoes()
+    {
+        var logger = new CapturingLogger();
+
+        var ex = Record.Exception(() =>
+            DomainPasswordPolicy.ResolveMinimumLength(logger, () => throw new TimeoutException()));
+
+        Assert.Null(ex);
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<(LogLevel Level, string Message, Exception? Exception)> Entries { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            Entries.Add((logLevel, formatter(state, exception), exception));
+    }
+}


### PR DESCRIPTION
## Description

Low-risk cleanup batch: failures that disappeared without a trace, and one doc that no longer matched the code. No wire-shape changes; no `ApiErrorCode`/`ErrorDisclosureMode` changes; the reset gate is untouched.

### C-1 — Stale `UpdatePassword` XML doc (AD provider) — doc only

The summary block still described the *original* reset gate ("the failure is one a reset can cure (new-password policy or cannot-change)"). The gate was narrowed to rescue **only** `ChangeNotPermitted`, and the method's own inline comment already said so — the file contradicted itself. Corrected the summary to state the actual eligibility and *why* policy rejections are excluded (intentional domain policy is never bypassed).

**Stale-doc audit (required):** I grepped both providers and the shared translator for other leftover reset-eligibility phrasing (`reset can cure`, `rescuable`, `AdministrativeReset` in docs, `ChangeNotPermitted`). **Result: no others.** The inline comment (`PasswordChangeProvider.cs:300`) and both LDAP member docs (`:382`, `:455`) already state "only `ChangeNotPermitted` is rescuable" correctly. This one summary was the sole miss from the narrowing change.

### C-2 — `AcquireDomainPasswordLength` silently advertised a weaker policy (AD provider)

`AcquireDomainPasswordLength` caught every exception and returned `6` with no log; `GetDirectoryEntry` swallowed construction failures to `null`. So an unreachable DC or an unreadable `minPwdLength` made PassCore advertise a minimum length **weaker** than the domain enforces — the user passes client-side validation, submits, and AD rejects it as `ComplexPassword` with nothing in the logs.

- The fallback/log decision now lives in a **shared, testable** `DomainPasswordPolicy.ResolveMinimumLength` (Common): it logs at **Warning** (EventId 112, operator-actionable) and returns the fallback when the lookup returns `null` or throws. **Never throws.**
- The AD provider supplies only the AccountManagement lookup (`ReadMinPwdLength`); `GetDirectoryEntry` no longer swallows construction failures — they propagate to be logged with the real reason.
- **Fallback value: kept at `6`, justified in writing** (the helper's XML docs). Changing it is the wrong lever — a *higher* fallback causes false client-side rejections of valid passwords; a *lower* one is what we already have. The defensible fix is to keep the long-standing default (so working deployments are unaffected) and make the failure **loud** so operators can act. The silence was the actual defect.
- **Caching:** `minPwdLength` is read once per change request (via `LengthPasswordPolicy`). Caching a value that effectively never changes is a legitimate optimization but introduces invalidation concerns; noted as an **optional future improvement, not done** (scope discipline — the task listed it as optional).

### C-3 — Unlogged swallow in `IsMemberOfGroupAsync` (AD provider) — logging only

The inner `catch { }` around `GetGroups()` discarded the exception before retrying with `GetAuthorizationGroups()`. The fallback is legitimate (the two fail in different environments), but a persistent `GetGroups` misconfiguration was invisible because the fallback quietly succeeds. Now logs at **Debug** (EventId 104) with the exception.

### C-4 — Generic-catch asymmetry — decided and made consistent

The AD terminal `catch (Exception)` re-scanned the chain via `TranslateException`; the LDAP terminal catches constructed `DirectoryUnavailableException` directly. **Decision: standardize on the LDAP behavior** (direct construction, no speculative extraction), on both providers.

**Reasoning (recorded in the routing-matrix doc, new "Terminal catch" section):** every failure carrying a meaningful directory code is already handled at its stage — typed `LdapException`/`TryGetWin32Code` extraction for the transport, service-account operations via `BindAsServiceAccount`/`RunAsServiceAccount` (Task A), the modify itself in the LDAP del/add catch and the AD `UpdatePassword` catch. An exception reaching the *terminal* catch is therefore an unexpected, non-directory-typed fault with **no reliable code**, so re-scanning could only mislabel it. Classifying it as infrastructure directly is correct and now identical on both providers.

**Interaction with Task A (checked, as the task asked):** Task A already gave the AD `IsMemberOfGroupAsync` terminal catch explicit `ServiceAccount`-actor semantics + `ServiceAccountFailure` logging (group reads *are* service-account ops) — that is deliberate coercion *away* from credentials, not the speculative-extraction pattern C-4 objects to, so it is left as-is (removing it would regress the very diagnostics C-3 adds). C-4 changes the **`ChangePasswordCore` terminal catch** specifically, which is where the AD-vs-LDAP asymmetry actually was. The change is behavior-preserving for the non-directory exceptions that reach it (a test proves the former AD `TranslateException` path and the new direct path produce an identical `LdapProblem`/`DirectoryFailureMessage` for such inputs).

## Tests

- **`DomainPasswordPolicyTests`** (C-2): lookup returns value → returned, no log; returns `null` → Warning + fallback; throws → Warning (with exception) + fallback; custom fallback honored; never throws. Fully exercised on CI via the Common seam — no live DC needed.
- **Terminal-catch equivalence** (C-4): a non-directory exception yields `LdapProblem`/`DirectoryFailureMessage` both via direct construction (the new terminal behavior) and via the former AD `TranslateException`, proving the standardization is safe.
- 441 tests pass; **existing tests unmodified** (only appended).

### Verified by inspection rather than test

The AD provider is `#if WINDOWS`/`net8.0-windows` and not CI-compiled, so its private terminal catch and the `ReadMinPwdLength`/`GetDirectoryEntry` wiring are verified by **inspection + the scratch `WINDOWS` build** (against the real `System.DirectoryServices.*` reference assemblies). The *decision logic* they delegate to — the fallback/log in `ResolveMinimumLength` and the infrastructure classification — is fully unit-tested in Common. The C-3 Debug log and the C-1 doc are logging/documentation only.

## Scope

No production behavior changes beyond: the added logging (C-2, C-3), the `minPwdLength` fallback made visible (C-2, value unchanged), and the C-4 terminal-catch consistency (behavior-preserving for expected inputs). `SetLastPassword`/`UpdateLastPassword` untouched. No raw exception text added to any user-visible message.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation update
- [x] Testing/CI harness

## Checklist
- [x] All new code compiles under .NET 8.
- [x] `dotnet test` passes locally.
- [x] No external network calls are made in unit tests.
- [x] Documentation (if applicable) is updated.
- [ ] Debug provider is gated by `#if DEBUG` and cannot be enabled in Production. *(not applicable — Debug provider untouched)*
- [ ] (Optional) Example e2e test runs against the Docker Compose test stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqqJZfw8hSz2n16KgdcQcG

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqqJZfw8hSz2n16KgdcQcG)_