### PR TITLE
Task B: remove the pre-auth pwdLastSet write and the UpdateLastPassword option

### DIFF
--- a/docs/UPGRADING-error-routing.md
+++ b/docs/UPGRADING-error-routing.md
@@ -9,7 +9,8 @@ default behaviors. Nothing about the wire contract changed — see
 **Bottom line:** most deployments need no config change. Two situations do:
 LDAP sites that relied on `HideUserNotFound: false`, and AD service-account
 sites that relied on the old silent administrative reset. Both are covered
-below.
+below. One AD setting — `UpdateLastPassword` — was **removed**; leaving it in
+your config is harmless, and the removal is also covered below.
 
 ## New settings (both under `AppSettings`, server-side only)
 
@@ -19,6 +20,62 @@ Neither is ever sent to the browser.
 |---------|---------|--------|
 | `ErrorDisclosureMode` | `Hardened` | `Hardened`: unknown users and locked/disabled/restricted accounts are indistinguishable from a wrong password (no account oracle). `Informative`: unknown users get "user not found" and unusable accounts get "contact IT" guidance. |
 | `AllowAdministrativeReset` | `false` | When on, an account flagged "user cannot change password" completes its change as an administrative reset by the service account (after the current password is verified). This is the **only** condition it rescues. |
+
+## Removed setting: `UpdateLastPassword` (AD provider)
+
+**No action needed.** It is documented here because it was found during this
+series' audit and because it interacts with the administrative-reset change
+below.
+
+The AD provider had an `UpdateLastPassword` option that, when enabled, wrote
+`pwdLastSet = -1` to the user's directory entry **before** the caller's current
+password had been verified. The option, the write, and the `SetLastPassword`
+method that performed it are gone. `PasswordChangeOptions` no longer has the
+property, and the key is no longer in the shipped `appsettings.json`.
+
+Why it went away:
+
+- **It ran before authentication.** Everything preceding credential
+  verification runs for a caller who has supplied nothing but a username. Per
+  Microsoft's ADSI documentation, `pwdLastSet = 0` means "user must change
+  password at next logon" and `-1` *removes* that requirement (no other value
+  can be written by anything but the system). The old code's comment claimed
+  it forced a change at next logon; it did the opposite. So a caller who knew
+  a valid username — and no password — could clear the must-change flag, and a
+  help-desk-issued temporary password would silently stop being temporary.
+- **AD maintains `pwdLastSet` itself.** The schema defines it as the time the
+  password was last changed, its update privilege is "set by the system", and
+  it is stamped on every successful password change or administrative reset.
+  There was nothing for PassCore to maintain.
+- **It defeated the change it was trying to enable.** The `pwdLastSet == 0`
+  state is what exempts an account from the domain's *minimum password age*.
+  Writing `-1` destroyed that exemption and started the minimum-age clock, so
+  the change attempted moments later was rejected by AD (`0x52D`). The default
+  domain policy sets a minimum password age of 1 day, so this was the default
+  configuration, not an edge case. It used to be masked by the old always-on
+  administrative `SetPassword` fallback (resets bypass minimum age); now that
+  the fallback is opt-in and off by default, the failure had become visible —
+  reported as `ComplexPassword`, which is misleading for a minimum-age
+  rejection.
+
+What changes for you:
+
+- **You never set it (the default, `false`)** → nothing changes at all.
+- **You set `"UpdateLastPassword": true`** → accounts flagged "user must change
+  password at next logon" should now work *better*. Their flag is left alone,
+  they keep their minimum-age exemption, credential verification recognises the
+  must-change state as proof of the current password and proceeds, and the
+  change succeeds. Nothing that worked before stops working.
+- **A stale key is harmless.** Configuration binding ignores unknown keys, so a
+  deployment whose `appsettings.json` still contains `"UpdateLastPassword"`
+  starts normally. Delete the line at your convenience. (Unlike
+  `HideUserNotFound` below, there is no startup warning for it: detecting the
+  stale key would require keeping a property for it, which is exactly the shim
+  the removal set out to avoid.)
+
+Forcing a must-change *after* a successful administrative reset — writing
+`pwdLastSet = 0`, the opposite operation — is a separate feature that has not
+been built and is not implied by this removal.
 
 ## Action may be required
 
@@ -107,4 +164,8 @@ before rollout if they matter to you:
 
 The Windows-only AD provider is not compiled by the cross-platform CI; its
 edits were compile-verified separately and it delegates to the same shared,
-fully-tested translator as the LDAP provider.
+fully-tested translator as the LDAP provider. Because it cannot be loaded or
+exercised from the cross-platform suite at all, the two properties that have no
+shared-code equivalent — no directory write before credential verification, and
+no `ApiErrorCode` decided inside the provider — are held by a source audit,
+`AdProviderDirectoryWriteAuditTests`.

--- a/src/Unosquare.PassCore.PasswordProvider/PasswordChangeOptions.cs
+++ b/src/Unosquare.PassCore.PasswordProvider/PasswordChangeOptions.cs
@@ -28,14 +28,6 @@ public class PasswordChangeOptions : IAppSettings
     /// </summary>
     public string? IdTypeForUser { get; set; }
 
-    /// <summary>
-    /// Gets or sets a value indicating whether [update last password].
-    /// </summary>
-    /// <value>
-    ///   <c>true</c> if [update last password]; otherwise, <c>false</c>.
-    /// </value>
-    public bool UpdateLastPassword { get; set; }
-
     /// <inheritdoc />
     public ErrorDisclosureMode ErrorDisclosureMode { get; set; } = ErrorDisclosureMode.Hardened;
 

--- a/src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs
+++ b/src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs
@@ -99,11 +99,12 @@ namespace Unosquare.PassCore.PasswordProvider
                     throw DirectoryErrorTranslator.CreateUserNotFoundError(_options.ErrorDisclosureMode);
                 }
 
-                if (_options.UpdateLastPassword && userPrincipal.LastPasswordSet == null) // Check if 'UpdateLastPassword' option is enabled and LastPasswordSet is null
-                {
-                    SetLastPassword(userPrincipal); // Update the 'pwdLastSet' attribute if conditions are met
-                }
-
+                // NOTHING may write to the directory above this line. Everything
+                // before it runs for a caller who has supplied only a username,
+                // so a write here would be an unauthenticated modification. (A
+                // pre-flight 'pwdLastSet' write used to sit exactly here; see
+                // docs/UPGRADING-error-routing.md.) Directory writes belong
+                // after verification: ChangePassword / SetPassword / Save below.
                 if (!ValidateUserCredentials(userPrincipal.UserPrincipalName, context.CurrentPassword, principalContext)) // Validate provided current password
                 {
                     throw new InvalidCredentialsException(DirectoryErrorTranslator.InvalidCredentialsMessage);
@@ -256,32 +257,6 @@ namespace Unosquare.PassCore.PasswordProvider
 
             // Append domain to username if no domain part is present and default domain is configured
             return parts.Length > 1 || string.IsNullOrWhiteSpace(_options.DefaultDomain) ? username : $"{username}@{_options.DefaultDomain}";
-        }
-
-        /// <summary>
-        /// Sets the 'pwdLastSet' attribute to -1 to force password change at next logon.
-        /// This is used when the 'UpdateLastPassword' option is enabled and the LastPasswordSet is null.
-        /// </summary>
-        /// <param name="userPrincipal">The UserPrincipal object for which to set the 'pwdLastSet' attribute.</param>
-        private void SetLastPassword(Principal userPrincipal)
-        {
-            var directoryEntry = (DirectoryEntry)userPrincipal.GetUnderlyingObject(); // Get the underlying DirectoryEntry object
-            var pwdLastSetProperty = directoryEntry.Properties["pwdLastSet"]; // Get the 'pwdLastSet' property
-
-            if (pwdLastSetProperty == null) // Check if 'pwdLastSet' property exists
-            {
-                throw new PasswordPolicyViolationException("The 'pwdLastSet' property is missing on the user principal.", ApiErrorCode.Generic);
-            }
-
-            try
-            {
-                pwdLastSetProperty.Value = -1; // Set 'pwdLastSet' to -1 to force password change at next logon
-                directoryEntry.CommitChanges(); // Commit changes to Active Directory
-            }
-            catch (Exception) // Catch exceptions during attribute update
-            {
-                throw new PasswordPolicyViolationException("Failed to update 'pwdLastSet' attribute.", ApiErrorCode.ChangeNotPermitted);
-            }
         }
 
         /// <summary>

--- a/src/Unosquare.PassCore.Web/appsettings.json
+++ b/src/Unosquare.PassCore.Web/appsettings.json
@@ -14,7 +14,6 @@
     // The following options for AD Provider (remove if you don't use this Provider)
     "UseAutomaticContext": true, // Set true to allow PassCore to reset password using the same credentials, or false if you will fill the credentials below
     "IdTypeForUser": "UPN", // Possible values are "DN", "GUID", "Name", "SAM", "SID" and "UPN" (Default UPN)
-    "UpdateLastPassword": false, // Set true to allow PassCore to  update the last password timestamp
     // The following options are for LDAP Provider (remove if you don't use this Provider)
     "LdapSearchBase": "ou=people,dc=example,dc=com",
     "LdapSecureSocketLayer": false, // Default for AD is true when using LDAPS 636

--- a/tests/Unosquare.PassCore.Common.Tests/AdProviderDirectoryWriteAuditTests.cs
+++ b/tests/Unosquare.PassCore.Common.Tests/AdProviderDirectoryWriteAuditTests.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Unosquare.PassCore.Common.Tests;
+
+/// <summary>
+/// Guards two properties of the Active Directory provider that cannot be
+/// asserted at runtime here: it performs no directory write before the
+/// caller's current password has been verified, and it never decides an
+/// <see cref="ApiErrorCode"/> itself (the one rule in
+/// <c>docs/error-routing-matrix.md</c>).
+///
+/// <para><b>Why a source audit and not a behavioral test.</b> The AD provider
+/// targets <c>net8.0-windows</c>, its whole implementation is inside
+/// <c>#if WINDOWS</c>, and every directory operation goes through concrete
+/// AccountManagement / ADSI types (<c>UserPrincipal</c>, <c>DirectoryEntry</c>)
+/// with no injectable seam. It therefore cannot be referenced, loaded, or
+/// exercised from the cross-platform test suite at all — not even to assert
+/// "no write happened", because there is nothing to observe the write with
+/// short of a live directory. The same constraint is why
+/// <c>RoutingMatrixAuditTests</c> covers the AD column through the shared
+/// translator rather than the provider. A source audit is the honest
+/// alternative: it is not a proxy for behavior, but it does fail loudly if the
+/// removed <c>pwdLastSet</c> pre-flight write (or any equivalent) is
+/// reintroduced, which is exactly what it exists to prevent.</para>
+///
+/// <para>Scanning runs over a skeleton of the source with comments removed and
+/// string literals blanked, so prose about the removed code cannot mask a real
+/// reintroduction of it.</para>
+/// </summary>
+public class AdProviderDirectoryWriteAuditTests
+{
+    private const string ProviderRelativePath =
+        "src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs";
+
+    private const string OptionsRelativePath =
+        "src/Unosquare.PassCore.PasswordProvider/PasswordChangeOptions.cs";
+
+    private const string AppSettingsRelativePath =
+        "src/Unosquare.PassCore.Web/appsettings.json";
+
+    /// <summary>
+    /// Calls that modify the directory, or that hand out the raw
+    /// <c>DirectoryEntry</c> through which anything can be modified. Written as
+    /// they appear in code so a mention in prose is not what fails the test
+    /// (comments are stripped before scanning regardless).
+    /// </summary>
+    private static readonly string[] WriteCapableCalls =
+    [
+        ".Save(",
+        ".ChangePassword(",
+        ".SetPassword(",
+        ".CommitChanges(",
+        ".SetInfo(",
+        ".GetUnderlyingObject(",
+        ".Properties[",
+    ];
+
+    [Fact]
+    public void AdProvider_HasNoPwdLastSetWriteAnywhere()
+    {
+        var code = CodeSkeleton(ReadRepoFile(ProviderRelativePath));
+
+        // The attribute itself, the method that wrote it, and the option that
+        // gated it. `minPwdLength` (a read, elsewhere in the provider) does not
+        // contain any of these.
+        Assert.DoesNotContain("pwdLastSet", code, StringComparison.Ordinal);
+        Assert.DoesNotContain("SetLastPassword", code, StringComparison.Ordinal);
+        Assert.DoesNotContain("UpdateLastPassword", code, StringComparison.Ordinal);
+
+        // AD maintains pwdLastSet itself on every successful change or reset,
+        // so the provider has no reason to reach for the raw directory entry or
+        // to commit an attribute edit anywhere.
+        Assert.DoesNotContain(".GetUnderlyingObject(", code, StringComparison.Ordinal);
+        Assert.DoesNotContain(".CommitChanges(", code, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ChangePasswordCore_PerformsNoDirectoryWriteBeforeCredentialVerification()
+    {
+        var body = ExtractMethodBody(
+            CodeSkeleton(ReadRepoFile(ProviderRelativePath)),
+            "Task ChangePasswordCore(");
+
+        var verificationAt = body.IndexOf("ValidateUserCredentials(", StringComparison.Ordinal);
+        Assert.True(
+            verificationAt >= 0,
+            "ChangePasswordCore no longer calls ValidateUserCredentials; the ordering this test " +
+            "guards has no anchor. Re-establish credential verification before reviewing this test.");
+
+        foreach (var call in WriteCapableCalls)
+        {
+            var firstUse = body.IndexOf(call, StringComparison.Ordinal);
+            if (firstUse < 0) continue;
+
+            Assert.True(
+                firstUse > verificationAt,
+                $"'{call}' appears in ChangePasswordCore at offset {firstUse}, before the " +
+                $"ValidateUserCredentials call at offset {verificationAt}. Everything above that " +
+                "call runs for a caller who supplied only a username, so a directory write there " +
+                "is an unauthenticated modification. See docs/UPGRADING-error-routing.md.");
+        }
+    }
+
+    [Fact]
+    public void AdProvider_ProducesNoApiErrorCodeOfItsOwn()
+    {
+        // Every wire-visible code must come from DirectoryErrorTranslator or the
+        // shared policy layer; a provider that names ApiErrorCode is deciding
+        // one itself and bypasses the routing matrix.
+        var code = CodeSkeleton(ReadRepoFile(ProviderRelativePath));
+
+        Assert.DoesNotContain("ApiErrorCode", code, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UpdateLastPasswordOption_IsGoneFromCodeAndShippedConfiguration()
+    {
+        Assert.DoesNotContain(
+            "UpdateLastPassword",
+            CodeSkeleton(ReadRepoFile(OptionsRelativePath)),
+            StringComparison.Ordinal);
+
+        // No shim, no obsolete property, and no shipped key. A stale key left in
+        // a deployment's own appsettings.json is harmless — configuration
+        // binding ignores unknown keys.
+        Assert.DoesNotContain(
+            "UpdateLastPassword",
+            ReadRepoFile(AppSettingsRelativePath),
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Removes comments and blanks string/char literal contents, leaving the
+    /// executable shape of the file. Literals are blanked (not deleted) so that
+    /// braces or parentheses inside them cannot unbalance the body extraction.
+    /// </summary>
+    private static string CodeSkeleton(string source) =>
+        Regex.Replace(
+            source,
+            """(?<verbatim>@"(?:[^"]|"")*")|(?<literal>"(?:[^"\\\n]|\\.)*")|(?<ch>'(?:[^'\\\n]|\\.)*')|(?<line>//[^\n]*)|(?<block>/\*.*?\*/)""",
+            static match => match.Groups["line"].Success || match.Groups["block"].Success ? string.Empty : "\"\"",
+            RegexOptions.Singleline);
+
+    /// <summary>
+    /// Returns the brace-delimited body of the first method whose declaration
+    /// contains <paramref name="signatureFragment"/>.
+    /// </summary>
+    private static string ExtractMethodBody(string code, string signatureFragment)
+    {
+        var declarationAt = code.IndexOf(signatureFragment, StringComparison.Ordinal);
+        Assert.True(declarationAt >= 0, $"Could not find '{signatureFragment}' in the provider source.");
+
+        var open = code.IndexOf('{', declarationAt);
+        Assert.True(open >= 0, $"Could not find a body for '{signatureFragment}'.");
+
+        var depth = 0;
+        for (var i = open; i < code.Length; i++)
+        {
+            if (code[i] == '{') depth++;
+            else if (code[i] == '}' && --depth == 0) return code[(open + 1)..i];
+        }
+
+        throw new InvalidOperationException($"Unbalanced braces while reading the body of '{signatureFragment}'.");
+    }
+
+    private static string ReadRepoFile(string relativePath)
+    {
+        var path = Path.Combine(RepositoryRoot(), relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Assert.True(File.Exists(path), $"Expected to find '{relativePath}' at '{path}'.");
+
+        return File.ReadAllText(path);
+    }
+
+    private static string RepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        var visited = new List<string>();
+
+        while (directory != null)
+        {
+            visited.Add(directory.FullName);
+            if (File.Exists(Path.Combine(directory.FullName, "Unosquare.PassCore.sln")))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException(
+            "Could not locate the repository root (no Unosquare.PassCore.sln found above " +
+            $"'{AppContext.BaseDirectory}'). Searched: {string.Join(", ", visited)}. This audit " +
+            "reads provider source, so it must run from a source checkout.");
+    }
+}

--- a/tests/Unosquare.PassCore.Common.Tests/AdProviderDirectoryWriteAuditTests.cs
+++ b/tests/Unosquare.PassCore.Common.Tests/AdProviderDirectoryWriteAuditTests.cs
@@ -169,7 +169,9 @@ public class AdProviderDirectoryWriteAuditTests
 
     private static string ReadRepoFile(string relativePath)
     {
-        var path = Path.Combine(RepositoryRoot(), relativePath.Replace('/', Path.DirectorySeparatorChar));
+        // Path.Join, not Path.Combine: Join always concatenates, where Combine
+        // discards everything before a segment it considers rooted.
+        var path = Path.Join(RepositoryRoot(), relativePath.Replace('/', Path.DirectorySeparatorChar));
         Assert.True(File.Exists(path), $"Expected to find '{relativePath}' at '{path}'.");
 
         return File.ReadAllText(path);
@@ -183,7 +185,7 @@ public class AdProviderDirectoryWriteAuditTests
         while (directory != null)
         {
             visited.Add(directory.FullName);
-            if (File.Exists(Path.Combine(directory.FullName, "Unosquare.PassCore.sln")))
+            if (File.Exists(Path.Join(directory.FullName, "Unosquare.PassCore.sln")))
                 return directory.FullName;
 
             directory = directory.Parent;


### PR DESCRIPTION
## Description

The AD provider wrote `pwdLastSet = -1` to the user's directory entry **before** `ValidateUserCredentials` had run, gated on the `UpdateLastPassword` option and on `LastPasswordSet == null`. Removed in full — the option, its shipped config key, the call site, and the `SetLastPassword` method.

**Removed**

| Where | What |
|---|---|
| `PasswordChangeProvider.ChangePasswordCore` | the `if (_options.UpdateLastPassword && …)` pre-flight block |
| `PasswordChangeProvider` | the `SetLastPassword` method (and its inverted XML doc) |
| `PasswordChangeOptions` | `public bool UpdateLastPassword` |
| `appsettings.json` | `"UpdateLastPassword": false,` and its inline comment |

No shim, no `[Obsolete]` property, no renamed option. Configuration binding ignores unknown keys, so a deployment that still carries `"UpdateLastPassword"` starts normally.

**Why it had to go rather than move**

- **It ran before authentication.** A caller who knew only a valid username could clear the must-change flag off a flagged account — a help-desk-issued temporary password silently stopped being temporary.
- **It did the opposite of what its comment claimed.** Per Microsoft's ADSI documentation, `0` forces a change at next logon and `-1` *removes* that requirement; the code cleared the flag it said it was setting.
- **It defeated the change it was meant to enable.** `pwdLastSet == 0` is what exempts an account from minimum password age. Writing `-1` started the min-age clock, and AD rejected the change a few lines later (`0x52D`). The default domain policy sets a 1-day minimum, so this was the default configuration — previously masked by the always-on administrative `SetPassword` fallback, which Phase 3 correctly made opt-in.
- **AD maintains the attribute itself.** The schema's update privilege is "set by the system", stamped on every successful change or reset.
- **Both throws hand-rolled an `ApiErrorCode`,** bypassing `DirectoryErrorTranslator` and reaching the wire untranslated through the outer `catch (PasswordChangeException) { throw; }`. `ApiErrorCode` is now named nowhere in the AD provider.

**Behavior change is an improvement.** For a must-change account with `UpdateLastPassword: true`: the flag is now left alone, the account keeps its min-age exemption, `ValidateUserCredentials` recognises the must-change state as proof of the current password via `IsPasswordExpiredOrMustChange`, and the change succeeds. Nobody loses a working capability.

**Deliberately not built:** forcing a must-change *after* an administrative reset (`pwdLastSet = 0` in `PerformAdministrativeReset`) is the opposite operation and a separate product decision. Out of scope here.

**Not changed:** `error-routing-matrix.md` never referenced these hand-rolled throws, so it is untouched. `ValidateUserCredentials`, `IsPasswordExpiredOrMustChange`, the reset gate, `RunAsServiceAccount`, `ApiErrorCode`, and the LDAP and Debug providers are all untouched.

## Type of Change
- [x] Bug fix — a directory write reachable without authentication
- [ ] New feature
- [x] Refactoring
- [x] Documentation update
- [x] Testing/CI harness

## Checklist
- [x] All new code compiles under .NET 8. The Windows-only AD provider was compile-verified with `WINDOWS` defined against `net8.0-windows` (0 errors, no unused-using diagnostics).
- [x] `dotnet test` passes locally — 445 tests across all four projects, no existing test modified.
- [x] No external network calls are made in unit tests. The new audit reads files from the checkout only.
- [x] Documentation updated — migration note appended to `docs/UPGRADING-error-routing.md`.
- [x] Debug provider gated by `#if DEBUG` and cannot be enabled in Production — untouched by this change.
- [ ] (Optional) Example e2e test runs against the Docker Compose test stack — not applicable; no wire-visible or client-visible shape changed.

## Tests

`AdProviderDirectoryWriteAuditTests` (4 tests, in `Unosquare.PassCore.Common.Tests`) guards the removal:

1. no `pwdLastSet` / `SetLastPassword` / `UpdateLastPassword`, and no `GetUnderlyingObject` or `CommitChanges`, anywhere in the provider;
2. no write-capable call (`.Save(`, `.ChangePassword(`, `.SetPassword(`, `.CommitChanges(`, `.SetInfo(`, `.GetUnderlyingObject(`, `.Properties[`) precedes `ValidateUserCredentials` in `ChangePasswordCore`;
3. the provider names no `ApiErrorCode`;
4. `UpdateLastPassword` is gone from both `PasswordChangeOptions` and `appsettings.json`.

It is a **source audit, not a behavioral test** — stated plainly because that is a real limitation. The AD provider targets `net8.0-windows` behind `#if WINDOWS` and reaches the directory through concrete AccountManagement/ADSI types with no injectable seam, so it cannot be referenced, loaded, or exercised from the cross-platform suite at all; there is nothing to observe a write with short of a live directory. This is the same constraint that makes `RoutingMatrixAuditTests` cover the AD column through the shared translator. The audit scans a skeleton of the source with comments stripped and string literals blanked, so prose about the removed code cannot mask its reintroduction — **verified by re-injecting the removed block, which fails 2 of the 4 tests.**

---
_Generated by [Claude Code](https://claude.ai/code/session_011y6Xen4NEhD42xXpudKaGV)_