### PR TITLE
Task D: credential-failure diagnostics, EventId collision, and doc accuracy

### DIFF
--- a/docs/error-routing-matrix.md
+++ b/docs/error-routing-matrix.md
@@ -101,6 +101,61 @@ wire (same code, same message), so an unauthenticated caller gets no
 account-existence or account-state oracle. **Informative** mode trades that
 oracle for actionable help-desk guidance.
 
+### Reachability caveat: `AccountState | Informative`
+
+That row describes what the translator produces when it is *asked* to translate
+an account-state code. It is **not** what a locked-out, disabled, or
+logon-hours-restricted user sees when they try to change their password —
+in the ordinary case they get `InvalidCredentials` in *both* modes.
+
+The reason is that account state is discovered at **credential-verification**
+time, and neither provider routes that step through the translator; both
+hardcode `InvalidCredentialsException` for anything that is not
+expired/must-change:
+
+- **AD** — `ValidateUserCredentials` returns `false` for every code except
+  `0x532` / `0x773`, and the caller throws `InvalidCredentialsException`. (The
+  code itself is not lost: it is attached as the inner exception and reaches
+  the log — see "Diagnostics" below.)
+- **LDAP** — `VerifyUserCredentials` catches `LdapBindException`, checks
+  expired/must-change, and otherwise throws `InvalidCredentialsException` with
+  the bind failure as the inner exception.
+
+So the `AccountState | Informative` row is reachable only from **modify-time**
+account-state errors — a lockout that occurs mid-request, or a logon-hours
+boundary crossed between verification and modify — which is a narrow window,
+not the everyday case.
+
+Two facts worth having straight, because they are the inputs to a pending
+decision about whether verification-time failures should route through
+`Translate(code, mode, DirectoryActor.User)` (that decision has **not** been
+made; nothing here advocates either way):
+
+- **Existence and account state are treated differently within Informative
+  mode.** Both providers call `CreateUserNotFoundError(mode)` when the lookup
+  finds nobody — before any credential check — so in Informative mode a
+  nonexistent user *is* disclosed pre-verification, while a locked or disabled
+  one is not disclosed at all. As far as the audit could establish this is an
+  inconsistency rather than a deliberate distinction.
+- **In Hardened mode the question is moot.** The translator collapses
+  account-state to `InvalidCredentials` regardless, so only Informative-mode
+  deployments would see any difference from such a change.
+
+### Diagnostics: what the wire hides, the log keeps
+
+Hardened mode's collapse is deliberate, which makes the server log the
+compensating control for the conditions it hides. Both providers attach the
+underlying failure to the thrown `InvalidCredentialsException` as an **inner
+exception** — AD via `CredentialFailureDetail.ForWin32Code` (a
+`Win32Exception` carrying the code, plus the catalog name and curated
+description when the code is cataloged), LDAP via the original
+`LdapBindException`. The base class logs it at Warning with the correlation ID
+(EventId 4), so an operator can distinguish a lockout from a mistyped password.
+
+`ApiErrorMapper.Map` reads only `Exception.Message` and never walks
+`InnerException`, so none of this detail can reach `ApiErrorItem.Message` or
+any other wire field, in either mode.
+
 ## The actor dimension: same code, different actor, different class
 
 The Win32 code alone does not say **whose** credentials failed. A bind that

--- a/src/Unosquare.PassCore.Common/CredentialFailureDetail.cs
+++ b/src/Unosquare.PassCore.Common/CredentialFailureDetail.cs
@@ -1,0 +1,69 @@
+using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace Unosquare.PassCore.Common;
+
+/// <summary>
+/// Builds the diagnostic inner exception that accompanies a failed
+/// credential verification.
+/// <para>
+/// <see cref="ErrorDisclosureMode.Hardened"/> — the default — deliberately
+/// collapses wrong-password, unknown-user, and locked/disabled/restricted
+/// account conditions into one indistinguishable
+/// <see cref="Exceptions.InvalidCredentialsException"/> so that no account
+/// oracle survives on the wire. That is the intended posture, and it leaves
+/// the server log as the only place the real condition can still be read.
+/// Attaching the result of this factory as the verification failure's inner
+/// exception is what keeps that compensating control working: the provider's
+/// existing failure log (EventId 4) records the chain, so an operator holding
+/// a correlation ID can tell a mistyped password from a lockout while the
+/// caller still learns nothing.
+/// </para>
+/// <para>
+/// The detail is <b>log-only by construction</b>. <see cref="ApiErrorMapper"/>
+/// reads <see cref="Exception.Message"/> of the thrown exception and never
+/// walks <see cref="Exception.InnerException"/>, so nothing produced here can
+/// reach <see cref="ApiErrorItem.Message"/> or any other wire field in either
+/// disclosure mode.
+/// </para>
+/// </summary>
+public static class CredentialFailureDetail
+{
+    /// <summary>
+    /// Creates a <see cref="Win32Exception"/> describing a credential-verification
+    /// failure, or <see langword="null"/> when there is no code to describe.
+    /// <para>
+    /// The code is carried in <see cref="Win32Exception.NativeErrorCode"/>, so
+    /// <see cref="DirectoryErrorTranslator.TryGetWin32Code"/> recovers it from
+    /// the chain exactly as it does for the LDAP provider's transport
+    /// exceptions. Cataloged codes additionally get the symbolic name and the
+    /// curated <see cref="Win32ErrorCode.Description"/> as the message —
+    /// deterministic across platforms and locales, unlike the OS-supplied text
+    /// that an uncataloged code falls back to.
+    /// </para>
+    /// </summary>
+    /// <param name="win32Code">The Win32 code reported by the failed
+    /// verification. Zero means "no code was reported" and yields
+    /// <see langword="null"/>, leaving the failure exactly as detail-free as it
+    /// was before.</param>
+    /// <returns>The diagnostic exception, or <see langword="null"/>.</returns>
+    public static Exception? ForWin32Code(int win32Code)
+    {
+        if (win32Code == 0)
+            return null;
+
+        var cataloged = Win32ErrorCode.ByCode(win32Code);
+
+        return cataloged == null
+            ? new Win32Exception(win32Code)
+            : new Win32Exception(
+                win32Code,
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0} (0x{1:X}): {2}",
+                    cataloged.CodeName,
+                    win32Code,
+                    cataloged.Description));
+    }
+}

--- a/src/Unosquare.PassCore.Common/PasswordChangeProviderBase.cs
+++ b/src/Unosquare.PassCore.Common/PasswordChangeProviderBase.cs
@@ -29,6 +29,19 @@ public abstract class PasswordChangeProviderBase : IPasswordChangeProvider
         Policies = policies ?? Array.Empty<IPasswordPolicy>();
     }
 
+    // EventId allocation across the solution. Provider selection is build-time,
+    // so an AD-built and an LDAP-built instance never share a process — but their
+    // logs are routinely aggregated together, so an ID must mean one thing
+    // everywhere. Ranges, and the next free number in each:
+    //
+    //   1-9      this base class (password-change and policy lifecycle)   next: 10
+    //   100-105  provider-specific events (LDAP 100-102, 104; AD 103, 105) next: 106
+    //   110-112  shared helpers (AdministrativeReset, ServiceAccountFailure,
+    //            DomainPasswordPolicy)                                     next: 113
+    //   300-304  PwnedPasswordsSearch                                      next: 305
+    //
+    // Take the next free number in the appropriate range; never reuse or
+    // renumber one that has shipped.
     private static readonly Action<ILogger, string?, string, Exception?> LogStartingPasswordChange =
         LoggerMessage.Define<string?, string>(
             LogLevel.Information,

--- a/src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs
+++ b/src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs
@@ -43,7 +43,7 @@ namespace Unosquare.PassCore.PasswordProvider
         private static readonly Action<ILogger, Exception?> LogGroupEnumerationFallback =
             LoggerMessage.Define(
                 LogLevel.Debug,
-                new EventId(104, nameof(LogGroupEnumerationFallback)),
+                new EventId(105, nameof(LogGroupEnumerationFallback)),
                 "GetGroups() failed; falling back to GetAuthorizationGroups(). The two behave " +
                 "differently across environments so the fallback is expected, but a persistent " +
                 "GetGroups failure indicates a misconfiguration worth investigating.");
@@ -105,9 +105,21 @@ namespace Unosquare.PassCore.PasswordProvider
                 // pre-flight 'pwdLastSet' write used to sit exactly here; see
                 // docs/UPGRADING-error-routing.md.) Directory writes belong
                 // after verification: ChangePassword / SetPassword / Save below.
-                if (!ValidateUserCredentials(userPrincipal.UserPrincipalName, context.CurrentPassword, principalContext)) // Validate provided current password
+                if (!ValidateUserCredentials(userPrincipal.UserPrincipalName, context.CurrentPassword, principalContext, out var verificationCode)) // Validate provided current password
                 {
-                    throw new InvalidCredentialsException(DirectoryErrorTranslator.InvalidCredentialsMessage);
+                    // The wire message is unchanged and carries no detail. The
+                    // reason travels as the INNER exception only, so the base
+                    // class's existing failure log (EventId 4) records it with
+                    // the correlation ID while the caller still learns nothing
+                    // — the compensating control for hardened mode collapsing
+                    // every credential/account-state condition into one
+                    // response. This mirrors the LDAP provider, which passes
+                    // its LdapBindException the same way.
+                    var detail = CredentialFailureDetail.ForWin32Code(verificationCode);
+
+                    throw detail == null
+                        ? new InvalidCredentialsException(DirectoryErrorTranslator.InvalidCredentialsMessage)
+                        : new InvalidCredentialsException(DirectoryErrorTranslator.InvalidCredentialsMessage, detail);
                 }
 
                 // The cannot-change check runs strictly AFTER credential
@@ -215,12 +227,19 @@ namespace Unosquare.PassCore.PasswordProvider
         /// <param name="upn">The User Principal Name of the user.</param>
         /// <param name="currentPassword">The current password provided by the user.</param>
         /// <param name="principalContext">The PrincipalContext to use for validation.</param>
+        /// <param name="win32Code">Receives the Win32 code reported by the failed
+        /// logon, or <c>0</c> when the credentials validated without one. It exists
+        /// purely so the caller can attach the reason to the log; it takes no part
+        /// in the decision this method returns.</param>
         /// <returns>True if credentials are valid, or if the error code indicates password must be changed or is expired, otherwise false.</returns>
         private bool ValidateUserCredentials(
             string upn,
             string currentPassword,
-            PrincipalContext principalContext)
+            PrincipalContext principalContext,
+            out int win32Code)
         {
+            win32Code = 0;
+
             if (principalContext.ValidateCredentials(upn, currentPassword)) // First attempt: Validate credentials using PrincipalContext
             {
                 return true; // Credentials validated successfully
@@ -236,12 +255,12 @@ namespace Unosquare.PassCore.PasswordProvider
             }
 
             // Check for specific error codes indicating password expiration or must change scenarios
-            var errorCode = System.Runtime.InteropServices.Marshal.GetLastWin32Error(); // Get the last Win32 error code
+            win32Code = System.Runtime.InteropServices.Marshal.GetLastWin32Error(); // Get the last Win32 error code
 
             // Expired / must-change-at-next-logon still proves the user knows the current
             // password; the shared classification keeps this decision identical to the
             // LDAP provider's bind handling.
-            return DirectoryErrorTranslator.IsPasswordExpiredOrMustChange(errorCode);
+            return DirectoryErrorTranslator.IsPasswordExpiredOrMustChange(win32Code);
         }
 
         /// <summary>

--- a/src/Unosquare.PassCore.Web/appsettings.json
+++ b/src/Unosquare.PassCore.Web/appsettings.json
@@ -12,7 +12,7 @@
   },
   "AppSettings": {
     // The following options for AD Provider (remove if you don't use this Provider)
-    "UseAutomaticContext": true, // Set true to allow PassCore to reset password using the same credentials, or false if you will fill the credentials below
+    "UseAutomaticContext": true, // Set true to bind to the directory as the identity the PassCore process already runs as, or false to bind with the explicit LdapUsername/LdapPassword below. Unrelated to AllowAdministrativeReset: with true there is no service account to reset with, so that option is ignored.
     "IdTypeForUser": "UPN", // Possible values are "DN", "GUID", "Name", "SAM", "SID" and "UPN" (Default UPN)
     // The following options are for LDAP Provider (remove if you don't use this Provider)
     "LdapSearchBase": "ou=people,dc=example,dc=com",

--- a/tests/Unosquare.PassCore.Common.Tests/AdProviderDirectoryWriteAuditTests.cs
+++ b/tests/Unosquare.PassCore.Common.Tests/AdProviderDirectoryWriteAuditTests.cs
@@ -7,11 +7,11 @@ using System.Text.RegularExpressions;
 namespace Unosquare.PassCore.Common.Tests;
 
 /// <summary>
-/// Guards two properties of the Active Directory provider that cannot be
-/// asserted at runtime here: it performs no directory write before the
-/// caller's current password has been verified, and it never decides an
-/// <see cref="ApiErrorCode"/> itself (the one rule in
-/// <c>docs/error-routing-matrix.md</c>).
+/// Guards properties of the Active Directory provider that cannot be asserted
+/// at runtime here: it performs no directory write before the caller's current
+/// password has been verified, it never decides an <see cref="ApiErrorCode"/>
+/// itself (the one rule in <c>docs/error-routing-matrix.md</c>), and a failed
+/// credential verification still hands the reason to the log.
 ///
 /// <para><b>Why a source audit and not a behavioral test.</b> The AD provider
 /// targets <c>net8.0-windows</c>, its whole implementation is inside
@@ -103,6 +103,46 @@ public class AdProviderDirectoryWriteAuditTests
                 "call runs for a caller who supplied only a username, so a directory write there " +
                 "is an unauthenticated modification. See docs/UPGRADING-error-routing.md.");
         }
+    }
+
+    [Fact]
+    public void ChangePasswordCore_AttachesTheVerificationFailureReasonAsAnInnerException()
+    {
+        // The runtime behavior — that an operator can read the Win32 code back
+        // out of the logged chain — is covered by CredentialFailureDetailTests
+        // against the shared factory. What cannot be covered there is whether
+        // this provider actually calls it, so that wiring is asserted here.
+        var body = ExtractMethodBody(
+            CodeSkeleton(ReadRepoFile(ProviderRelativePath)),
+            "Task ChangePasswordCore(");
+
+        Assert.True(
+            body.Contains("CredentialFailureDetail.ForWin32Code(", StringComparison.Ordinal),
+            "ChangePasswordCore no longer builds a CredentialFailureDetail for a failed credential " +
+            "verification. Hardened mode collapses every credential and account-state condition " +
+            "into one response, so dropping this detail leaves the operator with no way to tell a " +
+            "lockout from a mistyped password. See docs/error-routing-matrix.md, 'Diagnostics'.");
+
+        // The detail must be an argument to the exception, never part of the
+        // message that ApiErrorMapper puts on the wire.
+        var throwAt = body.IndexOf("new InvalidCredentialsException(", StringComparison.Ordinal);
+        Assert.True(throwAt >= 0, "ChangePasswordCore no longer throws InvalidCredentialsException on verification failure.");
+    }
+
+    [Fact]
+    public void ValidateUserCredentials_StillDelegatesTheProceedDecisionToTheSharedPredicate()
+    {
+        // 0x532 / 0x773 must keep meaning "the user proved the current password,
+        // let the change proceed", and that decision must stay shared with the
+        // LDAP provider rather than being re-derived here.
+        var body = ExtractMethodBody(
+            CodeSkeleton(ReadRepoFile(ProviderRelativePath)),
+            "bool ValidateUserCredentials(");
+
+        Assert.Contains(
+            "DirectoryErrorTranslator.IsPasswordExpiredOrMustChange(",
+            body,
+            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Unosquare.PassCore.Common.Tests/CredentialFailureDetailTests.cs
+++ b/tests/Unosquare.PassCore.Common.Tests/CredentialFailureDetailTests.cs
@@ -1,0 +1,155 @@
+using System.ComponentModel;
+using System.Linq;
+using Unosquare.PassCore.Common.Exceptions;
+
+namespace Unosquare.PassCore.Common.Tests;
+
+/// <summary>
+/// Covers the diagnostic detail attached to a failed credential verification:
+/// it must make the underlying condition recoverable from the log, and it must
+/// stay out of everything the caller can see.
+/// </summary>
+public class CredentialFailureDetailTests
+{
+    /// <summary>
+    /// The codes an operator most needs to tell apart when hardened mode has
+    /// collapsed them all into one response.
+    /// </summary>
+    public static TheoryData<int, string> CataloguedCodes => new()
+    {
+        { 0x52B, "ERROR_WRONG_PASSWORD" },
+        { 0x52E, "ERROR_LOGON_FAILURE" },
+        { 0x52F, "ERROR_ACCOUNT_RESTRICTION" },
+        { 0x530, "ERROR_INVALID_LOGON_HOURS" },
+        { 0x533, "ERROR_ACCOUNT_DISABLED" },
+        { 0x701, "ERROR_ACCOUNT_EXPIRED" },
+        { 0x775, "ERROR_ACCOUNT_LOCKED_OUT" },
+    };
+
+    [Theory]
+    [MemberData(nameof(CataloguedCodes))]
+    public void ForWin32Code_MakesTheReasonRecoverable(int code, string codeName)
+    {
+        var detail = CredentialFailureDetail.ForWin32Code(code);
+        Assert.NotNull(detail);
+
+        // Recoverable by the same helper that reads the LDAP provider's
+        // transport exceptions, so both providers' logs answer the same
+        // question the same way.
+        Assert.True(DirectoryErrorTranslator.TryGetWin32Code(detail, out var recovered));
+        Assert.Equal(code, recovered);
+
+        // And readable without a lookup table in hand.
+        Assert.Contains(codeName, detail.Message, System.StringComparison.Ordinal);
+        Assert.Contains($"0x{code:X}", detail.Message, System.StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [MemberData(nameof(CataloguedCodes))]
+    public void ForWin32Code_SurvivesBeingWrappedAsAnInnerException(int code, string codeName)
+    {
+        // The shape the provider actually produces: the detail is reachable
+        // only through the chain, which is what the base class hands the logger.
+        var thrown = new InvalidCredentialsException(
+            DirectoryErrorTranslator.InvalidCredentialsMessage,
+            CredentialFailureDetail.ForWin32Code(code)!);
+
+        Assert.True(DirectoryErrorTranslator.TryGetWin32Code(thrown, out var recovered));
+        Assert.Equal(code, recovered);
+        Assert.Contains(codeName, thrown.ToString(), System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ForWin32Code_EveryCataloguedCode_IsNamedAndDescribed()
+    {
+        foreach (var entry in Win32ErrorCode.Codes)
+        {
+            var detail = CredentialFailureDetail.ForWin32Code(entry.Code);
+
+            Assert.NotNull(detail);
+            Assert.Contains(entry.CodeName, detail.Message, System.StringComparison.Ordinal);
+            Assert.Contains(entry.Description, detail.Message, System.StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void ForWin32Code_UncataloguedCode_StillCarriesTheCode()
+    {
+        const int uncatalogued = 0x1234;
+        Assert.Null(Win32ErrorCode.ByCode(uncatalogued));
+
+        var detail = CredentialFailureDetail.ForWin32Code(uncatalogued);
+
+        // The OS supplies the message here, so only the code is asserted — it
+        // is the part an operator can act on.
+        Assert.NotNull(detail);
+        Assert.Equal(uncatalogued, Assert.IsType<Win32Exception>(detail).NativeErrorCode);
+    }
+
+    [Fact]
+    public void ForWin32Code_Zero_YieldsNoDetail()
+    {
+        // "No code was reported" must not fabricate one; the failure stays
+        // exactly as detail-free as it was before.
+        Assert.Null(CredentialFailureDetail.ForWin32Code(0));
+    }
+
+    [Theory]
+    [InlineData(ErrorDisclosureMode.Hardened)]
+    [InlineData(ErrorDisclosureMode.Informative)]
+    public void Detail_NeverReachesTheWire_InEitherDisclosureMode(ErrorDisclosureMode mode)
+    {
+        // The disclosure mode is not an input to the mapping of an already-thrown
+        // InvalidCredentialsException; both modes are exercised to make the
+        // claim explicit rather than assumed.
+        Assert.True(mode is ErrorDisclosureMode.Hardened or ErrorDisclosureMode.Informative);
+
+        foreach (var entry in Win32ErrorCode.Codes)
+        {
+            var item = ApiErrorMapper.Map(new InvalidCredentialsException(
+                DirectoryErrorTranslator.InvalidCredentialsMessage,
+                CredentialFailureDetail.ForWin32Code(entry.Code)!));
+
+            Assert.Equal(ApiErrorCode.InvalidCredentials, item.ErrorCode);
+            Assert.Equal(DirectoryErrorTranslator.InvalidCredentialsMessage, item.Message);
+
+            // Nothing identifying the condition may survive into the payload.
+            Assert.DoesNotContain(entry.CodeName, item.Message, System.StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain($"0x{entry.Code:X}", item.Message, System.StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(entry.Description, item.Message, System.StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public void ApiErrorMapper_ReadsOnlyTheOuterMessage_NeverTheChain()
+    {
+        // The structural reason the assertion above holds: if Map ever started
+        // walking InnerException, this canary fails.
+        const string secret = "UNDERLYING-DETAIL-THAT-MUST-NOT-SHIP";
+
+        var item = ApiErrorMapper.Map(new InvalidCredentialsException(
+            DirectoryErrorTranslator.InvalidCredentialsMessage,
+            new Win32Exception(0x775, secret)));
+
+        Assert.Equal(DirectoryErrorTranslator.InvalidCredentialsMessage, item.Message);
+        Assert.DoesNotContain(secret, item.Message, System.StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(0x532)] // ERROR_PASSWORD_EXPIRED
+    [InlineData(0x773)] // ERROR_PASSWORD_MUST_CHANGE
+    public void ExpiredAndMustChange_StillProceed_AndAreNeverTurnedIntoAFailure(int code)
+    {
+        // The decision D-1 must not have disturbed: these two codes mean the
+        // user proved the current password, so verification returns "proceed"
+        // and no InvalidCredentialsException (and therefore no detail) is
+        // produced at all.
+        Assert.True(DirectoryErrorTranslator.IsPasswordExpiredOrMustChange(code));
+
+        var everyOtherCode = Win32ErrorCode.Codes
+            .Where(c => c.Code != 0x532 && c.Code != 0x773)
+            .Select(c => c.Code);
+
+        Assert.All(everyOtherCode, c => Assert.False(DirectoryErrorTranslator.IsPasswordExpiredOrMustChange(c)));
+    }
+}

--- a/tests/Unosquare.PassCore.Common.Tests/DirectoryErrorTranslatorTests.cs
+++ b/tests/Unosquare.PassCore.Common.Tests/DirectoryErrorTranslatorTests.cs
@@ -129,7 +129,25 @@ public class DirectoryErrorTranslatorTests
         var structuralNotFound = ApiErrorMapper.Map(
             DirectoryErrorTranslator.CreateUserNotFoundError(ErrorDisclosureMode.Hardened));
 
-        foreach (var item in new[] { unknownUser, lockedOut, disabled, structuralNotFound })
+        // Credential-verification failures do not go through the translator:
+        // both providers throw InvalidCredentialsException directly, with the
+        // underlying failure attached as a diagnostic inner exception. Those
+        // must land on the wire byte-identically too, or the inner exception
+        // would have reintroduced the oracle the rest of this test rules out.
+        var verificationLockedOut = ApiErrorMapper.Map(new InvalidCredentialsException(
+            DirectoryErrorTranslator.InvalidCredentialsMessage,
+            CredentialFailureDetail.ForWin32Code(0x775)!));
+        var verificationWrongPassword = ApiErrorMapper.Map(new InvalidCredentialsException(
+            DirectoryErrorTranslator.InvalidCredentialsMessage,
+            CredentialFailureDetail.ForWin32Code(0x52E)!));
+        var verificationNoDetail = ApiErrorMapper.Map(new InvalidCredentialsException(
+            DirectoryErrorTranslator.InvalidCredentialsMessage));
+
+        foreach (var item in new[]
+                 {
+                     unknownUser, lockedOut, disabled, structuralNotFound,
+                     verificationLockedOut, verificationWrongPassword, verificationNoDetail,
+                 })
         {
             Assert.Equal(wrongPassword.ErrorCode, item.ErrorCode);
             Assert.Equal(wrongPassword.Message, item.Message);


### PR DESCRIPTION
## Description

Four independently verifiable items. **Diagnostics and documentation only — nothing wire-visible changes.**

### D-1 — the AD provider discarded the credential-failure reason

`ValidateUserCredentials` read the Win32 code, used it only to answer `IsPasswordExpiredOrMustChange`, and returned `bool`. The caller then threw `InvalidCredentialsException` with **no inner exception**, so the base class's failure log (EventId 4) carried nothing. Since `Hardened` mode deliberately collapses wrong-password / unknown-user / locked / disabled into one wire response, the log *is* the compensating control — and on AD it was absent while LDAP already had it.

**Mechanism: the LDAP-parity route**, which the task suggested considering first and which turned out to be both the smallest change and the most symmetric. The code travels out via an `out` parameter, the new shared `CredentialFailureDetail.ForWin32Code` turns it into a `Win32Exception`, and the caller attaches it as the inner exception of the *unchanged* `InvalidCredentialsException`. The existing log event picks up the chain with the correlation ID — **no new event, no new log level**, so no new noise on top of an already-Warning-logged routine failure. `DirectoryErrorTranslator.TryGetWin32Code` recovers the code from it exactly as it does from LDAP's `LdapBindException`.

Cataloged codes get the symbolic name + curated `Win32ErrorCode.Description` (deterministic across platforms and locales); uncataloged codes fall back to the OS message and still carry the code.

Untouched: the decision logic (`0x532`/`0x773` still return "proceed" via the shared predicate), the thrown exception type, and the wire message. `CA1822` still fires on `ValidateUserCredentials` — left alone, not suppressed, as instructed.

### D-2 — `EventId` 104 used twice

AD's `LogGroupEnumerationFallback` moves to **105**; LDAP's `LogSdDetectionSkipped` keeps 104. The LDAP event has been emitted since `de8cb0e`, the AD one arrived later in `de186f2` — moving the newcomer avoids redefining an ID already in the wild. All **23** EventIds across the solution are now distinct (`1-9`, `100-105`, `110-112`, `300-304`), and the range scheme is recorded as a comment where the base class defines its own events, so the next addition doesn't repeat this.

### D-3 — stale `UseAutomaticContext` wording

"reset password" now collides with the specific meaning "administrative reset" carries in the adjacent `AllowAdministrativeReset` — the more so because `UseAutomaticContext: true` is exactly the mode where that option is ignored. Reworded to describe *binding identity*, and to say so explicitly.

### D-4 — `AccountState | Informative` reachability (documentation only)

Documented that an ordinary locked/disabled user does **not** get the "contact IT" guidance that row implies, because account state is discovered at credential-verification time where both providers hardcode `InvalidCredentialsException` regardless of mode; the row is reachable only from modify-time account-state errors. Written in the same spirit as the existing `PasswordExpiredOrMustChange` caveat. The two inputs to the pending decision are captured — existence *is* disclosed pre-verification in Informative mode while account state is not, and in Hardened mode the question is moot — **without advocating either way. No behavior changed.**

## Type of Change
- [x] Bug fix — a diagnostic gap, not a functional one
- [ ] New feature
- [ ] Refactoring
- [x] Documentation update
- [x] Testing/CI harness

## Checklist
- [x] All new code compiles under .NET 8. The Windows-only AD provider was compile-verified with `WINDOWS` defined against `net8.0-windows` (0 errors).
- [x] `dotnet test` passes locally — **469 tests**, no existing test weakened.
- [x] No external network calls are made in unit tests.
- [x] Documentation updated — `docs/error-routing-matrix.md`.
- [x] Debug provider gated by `#if DEBUG` — untouched.
- [ ] (Optional) e2e against the Docker Compose stack — not applicable; nothing wire-visible changed.

## Tests

**By test (cross-platform, real coverage):**
- The existing hardened-mode byte-identity test is **extended** (not duplicated) to include verification-time failures carrying a detail, plus the no-detail case — so an inner exception reintroducing the oracle would fail it.
- `CredentialFailureDetailTests`: code + catalog name recoverable via `TryGetWin32Code` both bare and wrapped; every cataloged code named and described; zero yields no detail; uncataloged still carries the code; **no detail reaches `ApiErrorItem.Message` for any cataloged code in either mode**; a canary that `ApiErrorMapper` only ever reads the outer message; and `0x532`/`0x773` still "proceed" while nothing else does.

**By inspection (source audit):** the AD provider is Windows-only, behind `#if WINDOWS`, and excluded from CI — it cannot be loaded or executed from the cross-platform suite, so whether *this provider actually calls* the factory cannot be covered at runtime. That wiring is asserted in the existing `AdProviderDirectoryWriteAuditTests`, extended with a detail-attachment check and a check that the proceed decision still delegates to the shared predicate. **Verified to fail when the attachment is removed** — it is not coverage that would pass either way.

Its existing anchor was checked, as asked: the ordering guard matches `ValidateUserCredentials(`, which the new `out` parameter does not disturb, and no write-capable call was added. `RoutingMatrixAuditTests`, `ProviderParityTests`, `DirectoryErrorTranslatorTests` all pass unmodified.

## Open question for review

`CredentialFailureDetail` is shared, but only the AD provider calls it — LDAP already attaches its native `LdapBindException`, which is richer. Deliberately left asymmetric rather than normalizing LDAP onto the same factory, which would have discarded detail for no gain.

---
_Generated by [Claude Code](https://claude.ai/code/session_011y6Xen4NEhD42xXpudKaGV)_