### PR TITLE
LDAP: accept qualified usernames when no default domain is configured

### DIFF
--- a/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeProvider.cs
+++ b/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeProvider.cs
@@ -57,6 +57,10 @@ public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMemb
     private static readonly Regex InvalidAccountNameCharsRegex =
         new(@"[""/\\\[\]:;|=,+*?<>]", RegexOptions.CultureInvariant);
 
+    // Single wording for every way SanitizeUsername can reject its input, so the
+    // rejections stay indistinguishable from one another on the wire.
+    private const string InvalidUsernameFormatMessage = "Invalid username format";
+
     private static readonly Action<ILogger, Exception?> LogNoTransportSecurity =
         LoggerMessage.Define(
             LogLevel.Warning,
@@ -428,18 +432,7 @@ public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMemb
 
     private LdapUser FindUser(string username, string? correlationId = null)
     {
-        var safeUsername = SanitizeUsername(username, _options.DefaultDomain);
-
-        var searchUsername = safeUsername;
-        if (_options.LdapSearchFilter.Contains("sAMAccountName", StringComparison.OrdinalIgnoreCase))
-        {
-            var atIdx = safeUsername.IndexOf('@', StringComparison.Ordinal);
-            if (atIdx >= 0)
-                searchUsername = safeUsername[..atIdx];
-        }
-
-        var filter = _options.LdapSearchFilter.Replace(
-            "{Username}", searchUsername, StringComparison.Ordinal);
+        var filter = BuildUserSearchFilter(username, _options.DefaultDomain, _options.LdapSearchFilter);
 
         using var ldap = BindAsServiceAccount(correlationId);
 
@@ -478,6 +471,33 @@ public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMemb
             : null;
 
         return new LdapUser(entry.Dn, groups, primaryGroupId);
+    }
+
+    /// <summary>
+    /// Sanitizes <paramref name="username"/> and substitutes the result into the
+    /// <c>{Username}</c> placeholder of <paramref name="searchFilterTemplate"/>.
+    /// </summary>
+    /// <remarks>
+    /// A <c>sAMAccountName</c>-shaped filter matches the bare account name, never a
+    /// qualified one, so a domain qualifier the sanitizer kept is dropped before
+    /// substitution; a <c>userPrincipalName</c>-shaped filter keeps it. Split out from
+    /// <see cref="FindUser"/> so the filter a given username and configuration produce
+    /// can be asserted without a directory.
+    /// </remarks>
+    internal static string BuildUserSearchFilter(
+        string username, string? defaultDomain, string searchFilterTemplate)
+    {
+        var safeUsername = SanitizeUsername(username, defaultDomain);
+
+        var searchUsername = safeUsername;
+        if (searchFilterTemplate.Contains("sAMAccountName", StringComparison.OrdinalIgnoreCase))
+        {
+            var atIdx = safeUsername.IndexOf('@', StringComparison.Ordinal);
+            if (atIdx >= 0)
+                searchUsername = safeUsername[..atIdx];
+        }
+
+        return searchFilterTemplate.Replace("{Username}", searchUsername, StringComparison.Ordinal);
     }
 
     // ---------------------------------------------------------------------
@@ -1109,41 +1129,86 @@ public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMemb
 
     /// <summary>
     /// Produces a value safe to substitute into <see cref="LdapPasswordChangeOptions.LdapSearchFilter"/>:
-    /// parses the domain and local parts explicitly, rejects invalid qualifiers and format/credentials,
-    /// and returns the escaped expanded/qualified username.
+    /// parses the domain and local parts explicitly, validates the qualifier against the configured
+    /// <see cref="LdapPasswordChangeOptions.DefaultDomain"/>, and returns the escaped, canonicalized
+    /// username.
     /// </summary>
+    /// <remarks>
+    /// <para>A configured <paramref name="defaultDomain"/> is authoritative: a bare name is qualified
+    /// with it, a qualifier that matches it (the domain itself or its NetBIOS prefix) is canonicalized
+    /// to it, and any other qualifier is rejected — a user of <c>other.com</c> must not be searched for
+    /// in the configured domain.</para>
+    /// <para>An empty <paramref name="defaultDomain"/> means there is no configured domain to validate a
+    /// qualifier <em>against</em>, so a qualified name is accepted rather than rejected. Rejecting it
+    /// makes the shipped configuration self-contradictory: it ships <c>DefaultDomain: ""</c> together
+    /// with <c>UseEmail: true</c> and a username help block asking for an email address, so the exact
+    /// input form the UI requests would come back as <c>InvalidCredentials</c> — indistinguishable from
+    /// a wrong password, with nothing pointing at configuration. It would also diverge from the AD
+    /// provider, whose <c>FixUsernameWithDomain</c> returns the supplied name unchanged when no default
+    /// domain is configured and lets <c>FindByIdentity</c> resolve the UPN.</para>
+    /// <para>In that unconfigured case a UPN suffix (<c>user@suffix</c>) is preserved, because it is
+    /// meaningful to a <c>userPrincipalName</c>-shaped filter; a NetBIOS qualifier
+    /// (<c>DOMAIN\user</c>) is dropped, because a NetBIOS name is not a UPN suffix and there is no
+    /// configured domain to map it onto. Either way the account name itself still carries the full
+    /// local-part validation below, and the returned value — including any preserved domain, which is
+    /// user-supplied in this case — is escaped, so it stays inert in the filter.</para>
+    /// <para>A backslash is a qualifier separator here, never part of an account name (the local-part
+    /// rules reject one, since a <c>sAMAccountName</c> cannot contain it). So with no configured domain
+    /// to check the qualifier against, any single-backslash input is read as <c>DOMAIN\account</c> —
+    /// <c>a\b</c> resolves to account <c>b</c>. That is the only available reading: nothing
+    /// distinguishes it from a genuine NetBIOS qualifier, and the account name it yields is still fully
+    /// validated. With a <c>DefaultDomain</c> configured the qualifier must match it, so the same input
+    /// is rejected.</para>
+    /// </remarks>
     internal static string SanitizeUsername(string username, string? defaultDomain = null)
     {
         string localPart = username;
         string? domainPart = null;
+        var netbiosQualified = false;
 
         var backslashIndex = username.IndexOf('\\', StringComparison.Ordinal);
+        var atIndex = username.IndexOf('@', StringComparison.Ordinal);
+
+        // A username is qualified in one syntax or the other. Something carrying
+        // both separators is well-formed in neither, and would otherwise be split
+        // on the backslash into two halves that are each meaningless — so it is
+        // rejected outright, as it was in every configuration state before an
+        // unvalidated qualifier could be accepted.
+        if (backslashIndex >= 0 && atIndex >= 0)
+            throw new InvalidCredentialsException(InvalidUsernameFormatMessage);
+
         if (backslashIndex >= 0)
         {
             domainPart = username[..backslashIndex];
             localPart = username[(backslashIndex + 1)..];
+            netbiosQualified = true;
+        }
+        else if (atIndex >= 0)
+        {
+            domainPart = username[(atIndex + 1)..];
+            localPart = username[..atIndex];
+        }
+
+        // The supplied qualifier is user input. Escaping (below) neutralizes the
+        // RFC 4515 metacharacters; control characters are rejected outright, as
+        // they are for the local part.
+        if (!string.IsNullOrEmpty(domainPart) && domainPart.Any(char.IsControl))
+            throw new InvalidCredentialsException(InvalidUsernameFormatMessage);
+
+        if (string.IsNullOrEmpty(defaultDomain))
+        {
+            // Nothing is configured to validate the qualifier against, so it is
+            // accepted: a UPN suffix is kept, a NetBIOS name is dropped.
+            if (netbiosQualified)
+                domainPart = null;
         }
         else
         {
-            var atIndex = username.IndexOf('@', StringComparison.Ordinal);
-            if (atIndex >= 0)
-            {
-                domainPart = username[(atIndex + 1)..];
-                localPart = username[..atIndex];
-            }
-        }
+            if (!string.IsNullOrEmpty(domainPart) && !IsDomainMatching(domainPart, defaultDomain))
+                throw new InvalidCredentialsException(InvalidUsernameFormatMessage);
 
-        if (string.IsNullOrEmpty(domainPart) && !string.IsNullOrEmpty(defaultDomain))
-        {
-            domainPart = defaultDomain;
-        }
-
-        if (!string.IsNullOrEmpty(domainPart))
-        {
-            if (string.IsNullOrEmpty(defaultDomain) || !IsDomainMatching(domainPart, defaultDomain))
-            {
-                throw new InvalidCredentialsException("Invalid username format");
-            }
+            // The configured domain is authoritative: it qualifies a bare name and
+            // canonicalizes a matching NetBIOS prefix to the full domain.
             domainPart = defaultDomain;
         }
 
@@ -1151,12 +1216,13 @@ public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMemb
             || localPart.Any(char.IsControl)
             || InvalidAccountNameCharsRegex.IsMatch(localPart))
         {
-            throw new InvalidCredentialsException(
-                "Invalid username format");
+            throw new InvalidCredentialsException(InvalidUsernameFormatMessage);
         }
 
         var escapedLocalPart = EscapeLdapSearchFilterValue(localPart);
-        return !string.IsNullOrEmpty(domainPart) ? $"{escapedLocalPart}@{domainPart}" : escapedLocalPart;
+        return !string.IsNullOrEmpty(domainPart)
+            ? $"{escapedLocalPart}@{EscapeLdapSearchFilterValue(domainPart)}"
+            : escapedLocalPart;
     }
 
     /// <summary>

--- a/tests/Unosquare.PassCore.Common.Tests/AdProviderDirectoryWriteAuditTests.cs
+++ b/tests/Unosquare.PassCore.Common.Tests/AdProviderDirectoryWriteAuditTests.cs
@@ -207,6 +207,40 @@ public class AdProviderDirectoryWriteAuditTests
         throw new InvalidOperationException($"Unbalanced braces while reading the body of '{signatureFragment}'.");
     }
 
+    /// <summary>
+    /// The AD half of the cross-provider claim that a stock deployment accepts the
+    /// username form its own UI asks for. <c>appsettings.json</c> ships
+    /// <c>DefaultDomain: ""</c> next to <c>UseEmail: true</c>, so an unmodified
+    /// install prompts for <c>user@domain</c>; the AD provider must hand that
+    /// straight to <c>FindByIdentity</c>, which resolves it as a UPN, rather than
+    /// rejecting it as malformed. The LDAP provider's matching behavior is asserted
+    /// for real in <c>ShippedConfigurationUsernameFormTests</c> — this side can only
+    /// be audited, for the reasons in the class summary above.
+    /// </summary>
+    [Fact]
+    public void AdProvider_AcceptsAQualifiedUsernameWhenNoDefaultDomainIsConfigured()
+    {
+        Assert.Contains(
+            "\"DefaultDomain\": \"\"",
+            ReadRepoFile(AppSettingsRelativePath),
+            StringComparison.Ordinal);
+
+        var body = ExtractMethodBody(
+            CodeSkeleton(ReadRepoFile(ProviderRelativePath)),
+            "string FixUsernameWithDomain(");
+
+        // Two branches return the supplied name untouched: it already carries a
+        // domain, or there is no configured domain to qualify it with.
+        Assert.Contains("parts.Length > 1", body, StringComparison.Ordinal);
+        Assert.Contains("string.IsNullOrWhiteSpace(_options.DefaultDomain)", body, StringComparison.Ordinal);
+
+        // And neither branch rejects. A format rejection here would surface as
+        // InvalidCredentials — indistinguishable from a wrong password, with nothing
+        // logged to point at configuration — which is exactly the divergence the LDAP
+        // provider carried until its qualifier handling was corrected.
+        Assert.DoesNotContain("throw", body, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void AdProvider_DefaultLdapPortIs389()
     {

--- a/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/LdapUsernameSanitizationTests.cs
+++ b/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/LdapUsernameSanitizationTests.cs
@@ -16,20 +16,147 @@ public class LdapUsernameSanitizationTests
         Assert.Equal(expected, LdapPasswordChangeProvider.SanitizeUsername(input, defaultDomain));
     }
 
+    /// <summary>
+    /// The complete qualifier-handling matrix, in one table, across both
+    /// configuration states. The unconfigured rows are the ones that regressed:
+    /// a qualified username used to be rejected outright when no
+    /// <c>DefaultDomain</c> was set, which is precisely the input form the
+    /// shipped UI asks for (<c>UseEmail: true</c>). "Accepted" here means the
+    /// call returns a value; what that value is, is asserted alongside so the
+    /// canonicalization rules are pinned too.
+    /// </summary>
     [Theory]
-    [InlineData("jdoe@wrongdomain.com", "example.com")]
-    [InlineData("WRONGDOMAIN\\jdoe", "example.com")]
-    [InlineData("jdoe@example.com", null)]
-    [InlineData("EXAMPLE\\jdoe", null)]
-    public void SanitizeUsername_InvalidDomain_Throws(string input, string? defaultDomain)
+    // No configured domain: nothing to validate a qualifier against, so every form is accepted.
+    [InlineData("", "jdoe", "jdoe")]
+    [InlineData("", "jdoe@example.com", "jdoe@example.com")]          // UPN suffix preserved
+    [InlineData("", "jdoe@other.com", "jdoe@other.com")]              // ... whatever the suffix is
+    [InlineData("", "EXAMPLE\\jdoe", "jdoe")]                         // NetBIOS name is not a UPN suffix; dropped
+    [InlineData(null, "jdoe@example.com", "jdoe@example.com")]        // null is the same state as empty
+    [InlineData(null, "EXAMPLE\\jdoe", "jdoe")]
+    // Configured domain: authoritative, and every accepted form canonicalizes onto it.
+    [InlineData("example.com", "jdoe", "jdoe@example.com")]
+    [InlineData("example.com", "jdoe@example.com", "jdoe@example.com")]
+    [InlineData("example.com", "EXAMPLE\\jdoe", "jdoe@example.com")]  // NetBIOS prefix match
+    public void SanitizeUsername_QualifierMatrix_Accepted(
+        string? defaultDomain, string input, string expected)
+    {
+        Assert.Equal(expected, LdapPasswordChangeProvider.SanitizeUsername(input, defaultDomain));
+    }
+
+    /// <summary>
+    /// The one rejection row of the matrix: a qualifier that contradicts a
+    /// configured <c>DefaultDomain</c>. A user of another domain must not be
+    /// searched for as if they belonged to the configured one.
+    /// </summary>
+    [Theory]
+    [InlineData("example.com", "jdoe@other.com")]
+    [InlineData("example.com", "OTHER\\jdoe")]
+    public void SanitizeUsername_QualifierMatrix_RejectedAgainstConfiguredDomain(
+        string defaultDomain, string input)
     {
         Assert.Throws<InvalidCredentialsException>(
             () => LdapPasswordChangeProvider.SanitizeUsername(input, defaultDomain));
     }
 
     [Theory]
+    [InlineData("jdoe@wrongdomain.com", "example.com")]
+    [InlineData("WRONGDOMAIN\\jdoe", "example.com")]
+    public void SanitizeUsername_InvalidDomain_Throws(string input, string? defaultDomain)
+    {
+        Assert.Throws<InvalidCredentialsException>(
+            () => LdapPasswordChangeProvider.SanitizeUsername(input, defaultDomain));
+    }
+
+    /// <summary>
+    /// Accepting an unvalidated qualifier makes the domain part user input, so
+    /// it carries the same rules the local part does: control characters are
+    /// rejected, filter metacharacters are escaped (see
+    /// <see cref="SanitizeUsername_OutputCannotAlterFilterStructure"/>).
+    /// </summary>
+    [Theory]
+    [InlineData("jdoe@exa\0mple.com")]
+    [InlineData("jdoe@exa\nmple.com")]
+    [InlineData("jdoe@exa\tmple.com")]
+    public void SanitizeUsername_ControlCharactersInUnvalidatedDomain_Throws(string input)
+    {
+        Assert.Throws<InvalidCredentialsException>(
+            () => LdapPasswordChangeProvider.SanitizeUsername(input));
+    }
+
+    /// <summary>
+    /// A backslash always separates a qualifier from an account name; it is never
+    /// a character within one, because a <c>sAMAccountName</c> cannot contain one.
+    ///
+    /// <para>This is the visible edge of accepting an unvalidated qualifier: with a
+    /// <c>DefaultDomain</c> configured, <c>a\b</c> is rejected because <c>a</c>
+    /// contradicts it — but with none configured there is nothing to contradict, and
+    /// nothing distinguishes <c>a\b</c> from a genuine <c>EXAMPLE\jdoe</c>, so it is
+    /// read the same way and resolves to account <c>b</c>. The account name it
+    /// produces still carries the full local-part rules, and a backslash surviving
+    /// into that account name is still rejected.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("example.com", @"a\b", null)]           // qualifier contradicts the configured domain
+    [InlineData("", @"a\b", "b")]                       // no configured domain: read as DOMAIN\account
+    [InlineData("", @"EXAMPLE\jdoe", "jdoe")]           // ... indistinguishable from this
+    [InlineData("", @"a\b\c", null)]                    // surviving backslash fails the local-part rules
+    [InlineData("", @"EXAMPLE\jd\e", null)]
+    public void SanitizeUsername_Backslash_IsAQualifierSeparatorNotAnAccountNameCharacter(
+        string defaultDomain, string input, string? expected)
+    {
+        if (expected is null)
+        {
+            Assert.Throws<InvalidCredentialsException>(
+                () => LdapPasswordChangeProvider.SanitizeUsername(input, defaultDomain));
+            return;
+        }
+
+        Assert.Equal(expected, LdapPasswordChangeProvider.SanitizeUsername(input, defaultDomain));
+    }
+
+    /// <summary>
+    /// A username carrying both separators is well-formed in neither syntax.
+    /// Splitting it on the backslash would leave two meaningless halves — and
+    /// <c>jdoe@exa\mple.com</c> would resolve to an account named
+    /// <c>mple.com</c> — so it is rejected outright, in either configuration
+    /// state, as it was before qualifiers could be accepted unvalidated.
+    /// </summary>
+    [Theory]
+    [InlineData("", @"jdoe@exa\mple.com")]
+    [InlineData("", @"EXAMPLE\jdoe@example.com")]
+    [InlineData("example.com", @"jdoe@exa\mple.com")]
+    [InlineData("example.com", @"EXAMPLE\jdoe@example.com")]
+    public void SanitizeUsername_MixedQualifierSyntax_Throws(string defaultDomain, string input)
+    {
+        Assert.Throws<InvalidCredentialsException>(
+            () => LdapPasswordChangeProvider.SanitizeUsername(input, defaultDomain));
+    }
+
+    /// <summary>
+    /// Local-part validation is unaffected by which configuration state the
+    /// qualifier rules are in: the account name is checked after the qualifier
+    /// is resolved, in every row of the matrix.
+    /// </summary>
+    [Theory]
+    [InlineData("", "jd*e@example.com")]
+    [InlineData("", "EXAMPLE\\jd,e")]
+    [InlineData("", "@example.com")]
+    [InlineData("example.com", "jd*e@example.com")]
+    [InlineData("example.com", "EXAMPLE\\jd,e")]
+    [InlineData("example.com", "@example.com")]
+    public void SanitizeUsername_LocalPartValidation_AppliesInEveryQualifierState(
+        string defaultDomain, string input)
+    {
+        Assert.Throws<InvalidCredentialsException>(
+            () => LdapPasswordChangeProvider.SanitizeUsername(input, defaultDomain));
+    }
+
+    // A backslash is not in this list: it is the DOMAIN\account separator, so it is
+    // consumed during qualifier parsing and never reaches the local-part rules —
+    // which is exactly why those rules reject one if it survives to the account name
+    // (see SanitizeUsername_Backslash_IsAQualifierSeparatorNotAnAccountNameCharacter).
+    [Theory]
     [InlineData("jd*e")]
-    [InlineData(@"jd\e")]
     [InlineData("jd=e")]
     [InlineData("jd,e")]
     [InlineData("jd;e")]
@@ -74,6 +201,12 @@ public class LdapUsernameSanitizationTests
     [InlineData("jd(e")]
     [InlineData("jd)e")]
     [InlineData("plainuser")]
+    // A qualifier is accepted unvalidated when no DefaultDomain is configured, so
+    // it reaches the filter as user input and must be escaped like the local part.
+    [InlineData("jdoe@example.com")]
+    [InlineData("jdoe@*")]
+    [InlineData("jdoe@x)(objectClass=*")]
+    [InlineData("jdoe@x\\y")]
     public void SanitizeUsername_OutputCannotAlterFilterStructure(string input)
     {
         string value;

--- a/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/ShippedConfigurationUsernameFormTests.cs
+++ b/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/ShippedConfigurationUsernameFormTests.cs
@@ -1,0 +1,252 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Novell.Directory.Ldap;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Unosquare.PassCore.Common;
+using Unosquare.PassCore.Common.Models;
+using Xunit;
+
+namespace Zyborg.PassCore.PasswordProvider.LDAP.Tests;
+
+/// <summary>
+/// A stock deployment must accept the username form its own UI asks for.
+/// <c>src/Unosquare.PassCore.Web/appsettings.json</c> ships
+/// <c>DefaultDomain: ""</c> alongside <c>UseEmail: true</c> and a username help
+/// block reading "Your organization's email address", so an unmodified install
+/// prompts for <c>user@domain</c> and must resolve it.
+///
+/// <para>These tests read the shipped file rather than constructing options in
+/// code: the failure being guarded against is a configuration/behavior
+/// contradiction, and a hand-built options object cannot express one. Only the
+/// values under test come from the file — <c>DefaultDomain</c>, the search
+/// filter, and the client-side username form. The connection settings are
+/// filled in here because the shipped file deliberately leaves them blank for
+/// the operator, and <c>ValidateOptions</c> rejects blanks at construction.</para>
+/// </summary>
+public class ShippedConfigurationUsernameFormTests
+{
+    private const string AppSettingsRelativePath = "src/Unosquare.PassCore.Web/appsettings.json";
+
+    private const string EmailFormUsername = "jdoe@example.com";
+
+    /// <summary>
+    /// The premise the rest of this class rests on. If the shipped defaults ever
+    /// change — a default domain is set, or the UI stops asking for an email
+    /// address — the tests below are guarding a situation that no longer exists
+    /// and should be revisited rather than silently kept passing.
+    /// </summary>
+    [Fact]
+    public void ShippedConfiguration_AsksForAnEmailAddressAndConfiguresNoDefaultDomain()
+    {
+        var settings = ShippedSettings();
+
+        Assert.True(
+            string.IsNullOrEmpty(settings.DefaultDomain),
+            $"appsettings.json now ships DefaultDomain='{settings.DefaultDomain}'. These tests exist " +
+            "because it ships empty while the UI asks for an email address; re-derive them against " +
+            "the new default.");
+
+        Assert.True(
+            settings.UseEmail,
+            "appsettings.json no longer ships UseEmail=true, so the shipped UI may no longer be " +
+            "asking for a qualified username. Re-derive these tests against the new default.");
+
+        Assert.Contains("email", settings.UsernameHelpblock, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The end-to-end path on the LDAP provider: an email-form username, the
+    /// shipped (empty) default domain, and the shipped search filter must
+    /// resolve the account rather than being rejected as a malformed username.
+    /// A rejection surfaces as <c>InvalidCredentials</c>, indistinguishable from
+    /// a wrong password, with nothing to point the operator at configuration.
+    /// </summary>
+    [Fact]
+    public async Task ShippedConfiguration_EmailFormUsername_ResolvesOnTheLdapProvider()
+    {
+        var settings = ShippedSettings();
+        var provider = ProviderWithShippedUsernameSettings(settings, out var filters);
+
+        // The user is found, so membership evaluation runs to a real answer; a
+        // sanitizer rejection would instead throw out of the call.
+        Assert.True(await provider.IsMemberOfGroupAsync(EmailFormUsername, "DirectGroup"));
+
+        // The shipped filter is sAMAccountName-shaped, which matches the bare
+        // account name — the qualifier is dropped for the search, not smuggled in.
+        Assert.Equal("(sAMAccountName=jdoe)", filters[0]);
+    }
+
+    /// <summary>
+    /// Same path, spelled <c>DOMAIN\user</c>. The shipped UI asks for an email
+    /// address, but a domain-qualified username is what a Windows-trained user
+    /// types, and it was accepted before the qualifier validation was added.
+    /// </summary>
+    [Fact]
+    public async Task ShippedConfiguration_NetbiosFormUsername_ResolvesOnTheLdapProvider()
+    {
+        var settings = ShippedSettings();
+        var provider = ProviderWithShippedUsernameSettings(settings, out var filters);
+
+        Assert.True(await provider.IsMemberOfGroupAsync("EXAMPLE\\jdoe", "DirectGroup"));
+        Assert.Equal("(sAMAccountName=jdoe)", filters[0]);
+    }
+
+    /// <summary>
+    /// The counterpart to the two above, and the behavior that must survive:
+    /// once an operator configures a default domain, a username qualified with a
+    /// different one is rejected.
+    /// </summary>
+    [Fact]
+    public async Task ConfiguredDefaultDomain_ForeignQualifier_IsStillRejected()
+    {
+        var settings = ShippedSettings() with { DefaultDomain = "example.com" };
+        var provider = ProviderWithShippedUsernameSettings(settings, out _);
+
+        var error = await Assert.ThrowsAsync<Unosquare.PassCore.Common.Exceptions.InvalidCredentialsException>(
+            () => provider.IsMemberOfGroupAsync("jdoe@other.com", "DirectGroup"));
+
+        Assert.Equal(ApiErrorCode.InvalidCredentials, ApiErrorMapper.Map(error).ErrorCode);
+    }
+
+    /// <summary>
+    /// Builds a provider whose username-relevant configuration is the shipped
+    /// one, backed by a directory that holds exactly one account: <c>jdoe</c>,
+    /// a member of <c>DirectGroup</c>. <paramref name="filters"/> collects every
+    /// search filter the provider issues, in order.
+    /// </summary>
+    private static TestLdapPasswordChangeProvider ProviderWithShippedUsernameSettings(
+        ShippedUsernameSettings settings, out List<string> filters)
+    {
+        var options = new LdapPasswordChangeOptions
+        {
+            // From the shipped file — the values under test.
+            DefaultDomain = settings.DefaultDomain,
+            LdapSearchFilter = settings.LdapSearchFilter,
+
+            // Deployment-specific; the shipped file leaves these blank on purpose.
+            LdapHostnames = new[] { "ldap.example.com" },
+            LdapPort = 389,
+            LdapUsername = "cn=admin,dc=example,dc=com",
+            LdapPassword = "secret",
+            LdapSearchBase = "dc=example,dc=com",
+        };
+
+        var provider = new TestLdapPasswordChangeProvider(
+            NullLogger<LdapPasswordChangeProvider>.Instance,
+            Options.Create(options),
+            Options.Create(new ClientSettings()),
+            Array.Empty<IPasswordPolicy>());
+
+        var userEntry = new LdapEntry(
+            "cn=jdoe,ou=people,dc=example,dc=com",
+            new LdapAttributeSet
+            {
+                new LdapAttribute("distinguishedName", "cn=jdoe,ou=people,dc=example,dc=com"),
+                new LdapAttribute("sAMAccountName", "jdoe"),
+                new LdapAttribute("memberOf", "cn=DirectGroup,ou=groups,dc=example,dc=com"),
+            });
+
+        var seen = new List<string>();
+        filters = seen;
+
+        provider.OnSearchLdap = (filter, _) =>
+        {
+            seen.Add(filter);
+
+            var results = new Mock<ILdapSearchResults>();
+            if (filter == "(sAMAccountName=jdoe)")
+            {
+                results.Setup(r => r.HasMore()).Returns(true);
+                results.Setup(r => r.Next()).Returns(userEntry);
+            }
+            else
+            {
+                results.Setup(r => r.HasMore()).Returns(false);
+            }
+
+            return results.Object;
+        };
+
+        return provider;
+    }
+
+    /// <summary>The username-relevant slice of the shipped configuration.</summary>
+    private sealed record ShippedUsernameSettings(
+        string DefaultDomain,
+        string LdapSearchFilter,
+        bool UseEmail,
+        string UsernameHelpblock);
+
+    private static ShippedUsernameSettings ShippedSettings()
+    {
+        // The shipped file carries // comments, which the ASP.NET Core JSON
+        // configuration provider tolerates and the strict parser does not.
+        using var document = JsonDocument.Parse(
+            ReadRepoFile(AppSettingsRelativePath),
+            new JsonDocumentOptions
+            {
+                CommentHandling = JsonCommentHandling.Skip,
+                AllowTrailingCommas = true,
+            });
+
+        var root = document.RootElement;
+        var appSettings = Section(root, "AppSettings");
+        var clientSettings = Section(root, "ClientSettings");
+        var changePasswordForm = Section(clientSettings, "ChangePasswordForm");
+
+        return new ShippedUsernameSettings(
+            DefaultDomain: String(appSettings, "DefaultDomain"),
+            LdapSearchFilter: String(appSettings, "LdapSearchFilter"),
+            // Shipped as the string "true", which the configuration binder parses.
+            UseEmail: bool.Parse(String(clientSettings, "UseEmail")),
+            UsernameHelpblock: String(changePasswordForm, "UsernameHelpblock"));
+    }
+
+    private static JsonElement Section(JsonElement parent, string name)
+    {
+        Assert.True(
+            parent.TryGetProperty(name, out var section),
+            $"'{name}' is missing from {AppSettingsRelativePath}.");
+
+        return section;
+    }
+
+    private static string String(JsonElement parent, string name) =>
+        Section(parent, name).GetString()
+        ?? throw new InvalidOperationException($"'{name}' in {AppSettingsRelativePath} is null.");
+
+    private static string ReadRepoFile(string relativePath)
+    {
+        // Path.Join, not Path.Combine: Join always concatenates, where Combine
+        // discards everything before a segment it considers rooted.
+        var path = Path.Join(RepositoryRoot(), relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Assert.True(File.Exists(path), $"Expected to find '{relativePath}' at '{path}'.");
+
+        return File.ReadAllText(path);
+    }
+
+    private static string RepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        var visited = new List<string>();
+
+        while (directory != null)
+        {
+            visited.Add(directory.FullName);
+            if (File.Exists(Path.Join(directory.FullName, "Unosquare.PassCore.sln")))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException(
+            "Could not locate the repository root (no Unosquare.PassCore.sln found above " +
+            $"'{AppContext.BaseDirectory}'). Searched: {string.Join(", ", visited)}. This test " +
+            "reads the shipped configuration, so it must run from a source checkout.");
+    }
+}


### PR DESCRIPTION
## Description

**Task 1 of the post-merge remediation series** (`2ef6a64` → `c7ae101`).

Phase 3 added domain parsing to `LdapPasswordChangeProvider.SanitizeUsername` and rejected any qualified username (`user@domain` or `DOMAIN\user`) when `DefaultDomain` was empty. `appsettings.json` ships `DefaultDomain: ""` alongside `UseEmail: true` and a username help block reading *"Your organization's email address"* — so a stock LDAP deployment refused the exact input form its own UI requested, surfacing as `InvalidCredentials` (4), indistinguishable from a wrong password, with nothing logged to point at configuration. The AD provider accepts the same input (`FixUsernameWithDomain` returns it unchanged and `FindByIdentity` resolves the UPN), making this a live AD/LDAP divergence.

### Semantics implemented

| `DefaultDomain` | Input | Outcome |
|---|---|---|
| empty | `jdoe` | accepted → `jdoe` |
| empty | `jdoe@example.com` | **accepted** → `jdoe@example.com` |
| empty | `EXAMPLE\jdoe` | **accepted** → `jdoe` |
| `example.com` | `jdoe` | accepted → `jdoe@example.com` |
| `example.com` | `jdoe@example.com` | accepted → `jdoe@example.com` |
| `example.com` | `EXAMPLE\jdoe` | accepted → `jdoe@example.com` (NetBIOS prefix match) |
| `example.com` | `jdoe@other.com` | **rejected** — the Phase 3 fix, preserved |

An empty `DefaultDomain` means there is nothing to validate a qualifier *against*, so it is accepted. A UPN suffix is preserved (it is meaningful to a `userPrincipalName`-shaped filter); a NetBIOS qualifier is dropped (a NetBIOS name is not a UPN suffix, and there is no configured domain to map it onto). A configured `DefaultDomain` stays authoritative and still rejects a contradicting qualifier. Local-part validation (empty, control characters, `InvalidAccountNameCharsRegex`) is unchanged in every row.

### Two consequences handled in the same change

Both follow directly from letting an unvalidated qualifier through, and leaving either out would be a defect introduced by this PR:

- **The domain part becomes user input**, so it is now RFC 4515-escaped on the way into the filter (via the existing `EscapeLdapSearchFilterValue`) and rejected if it carries control characters. Without this the method's stated contract — that its return value is safe to substitute into a search filter — would no longer hold. This overlaps with one bullet of Task 3; the DN-escaping and `primaryGroupID` parsing bullets are untouched and remain for that PR.
- **Mixed-syntax usernames are rejected.** `jdoe@exa\mple.com` carries both separators, is well-formed in neither syntax, and would otherwise split on the backslash into an account named `mple.com`. It was rejected in every configuration state before this change, and still is.

### One behavior change worth review attention

A backslash is a qualifier separator, never an account-name character (a `sAMAccountName` cannot contain one). With no configured domain to check the qualifier against, **any** single-backslash input reads as `DOMAIN\account` — `a\b` resolves to account `b`. Nothing distinguishes it from a genuine `EXAMPLE\jdoe`, which the semantics table requires be accepted, so this is the only available reading. The account name it yields still carries the full local-part rules, which continue to reject a backslash surviving into the account name itself (`EXAMPLE\jd\e` is rejected).

The `@"jd\e"` row therefore moves out of `SanitizeUsername_InvalidAccountNameCharacters_Throws` into explicit coverage of the separator rule (`SanitizeUsername_Backslash_IsAQualifierSeparatorNotAnAccountNameCharacter`), which pins both configuration states. That theory's remaining rows and every other existing test are unchanged.

### Refactor

Filter construction is split out of `FindUser` as `BuildUserSearchFilter(username, defaultDomain, searchFilterTemplate)` so the filter a given username and configuration produce can be asserted without a directory. No behavior change.

### Tests

- The full qualifier matrix above, table-driven, in both configuration states, plus the rejection path.
- `ShippedConfigurationUsernameFormTests` drives the provider end to end with `DefaultDomain` and `LdapSearchFilter` read from the real `src/Unosquare.PassCore.Web/appsettings.json`: an email-form username resolves and produces `(sAMAccountName=jdoe)`. It also pins the premise (`DefaultDomain` empty, `UseEmail` true, help block asks for an email address) so the test fails loudly rather than silently if the shipped defaults change. Connection settings are supplied in the test because the shipped file leaves them blank for the operator and `ValidateOptions` rejects blanks at construction.
- The AD side is a source-skeleton audit in `AdProviderDirectoryWriteAuditTests`, following the existing pattern — that provider is `net8.0-windows` inside `#if WINDOWS` and cannot be loaded by the cross-platform suite.

`appsettings*.json` is unchanged, no `ApiErrorCode` decision moved outside `DirectoryErrorTranslator`, and the AD provider source is untouched.

### Note on running the tests locally

`dotnet test` reports *"No test is available"* for every test project in this repo on Linux. Root `Directory.Build.props` sets `TargetFrameworks` while each test csproj sets `TargetFramework`, so the project is never dispatched as an inner build with `TargetFramework` as a global property — the NuGet-generated `ImportGroup` conditioned on `'$(TargetFramework)' == 'net8.0'` never applies, and `xunit.runner.visualstudio.testadapter.dll` is never copied to the output. Passing `-p:TargetFramework=net8.0` works around it. This is pre-existing and unrelated to this change; I have not touched it, but it likely means the CI test steps are not running assertions either and is worth a separate look.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation update
- [ ] Testing/CI harness

## Checklist
- [x] All new code compiles under .NET 8.
- [x] `dotnet test` passes locally — 538 tests across all four projects (see note above on the required `-p:TargetFramework=net8.0`).
- [x] No external network calls are made in unit tests.
- [x] Documentation (if applicable) is updated — the routing matrix is unaffected; no `ApiErrorCode` routing changed. `SanitizeUsername`'s XML docs now state the qualifier rules and their rationale.
- [x] Debug provider is gated by `#if DEBUG` and cannot be enabled in Production — untouched by this change.
- [ ] (Optional) Example e2e test runs against the Docker Compose test stack — the LDAP smoke test uses bare usernames and is unaffected; `appsettings.LdapTest.json` sets no `DefaultDomain`, so qualified forms now work there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsJRsb3rUAuacypogW9ZEN

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsJRsb3rUAuacypogW9ZEN)_