### PR TITLE
Fix silently-empty test runs: dotnet test discovered zero tests, CI passed anyway

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -65,10 +65,27 @@ jobs:
             tests/PwnedPasswordsSearch.Tests/PwnedPasswordsSearch.Tests.csproj
           do
             echo "==> Testing $proj"
-            dotnet test "$proj" \
+            # `dotnet test` exits 0 when it discovers nothing -- it just prints
+            # "No test is available" -- so a project/SDK configuration slip can
+            # reduce this whole step to a green no-op. That is exactly what
+            # happened: the test projects set TargetFramework while
+            # Directory.Build.props set TargetFrameworks, the package .props
+            # imports were skipped, the xunit VSTest adapter never reached the
+            # output directory, and CI reported success while running zero
+            # assertions. Capture the output and fail loudly if it recurs.
+            output=$(dotnet test "$proj" \
               --configuration Debug \
               --logger "trx;LogFileName=test-results.trx" \
-              --logger "console;verbosity=normal"
+              --logger "console;verbosity=normal" 2>&1) || {
+                echo "$output"
+                exit 1
+              }
+            echo "$output"
+
+            if grep -qF 'No test is available' <<<"$output"; then
+              echo "::error file=$proj::No tests were discovered in $proj, so this run passed vacuously. Usually the xunit VSTest adapter did not reach the output directory: check that the project declares TargetFrameworks (plural), so that the package .props imports apply."
+              exit 1
+            fi
           done
 
       - name: Upload .NET Test Results

--- a/tests/PwnedPasswordsSearch.Tests/PwnedPasswordsSearch.Tests.csproj
+++ b/tests/PwnedPasswordsSearch.Tests/PwnedPasswordsSearch.Tests.csproj
@@ -1,6 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <!-- TargetFrameworks (plural), not TargetFramework. The root Directory.Build.props
+         sets TargetFrameworks, so NuGet restores this project as cross-targeting and
+         emits its package .props imports under a Condition of "'$(TargetFramework)' ==
+         'net8.0'". Those imports are evaluated at the top of the project, before the body
+         runs, so setting TargetFramework (singular) here leaves that condition false and
+         the imports skipped. That silently drops the None items which copy
+         xunit.runner.visualstudio.testadapter.dll to the output, and `dotnet test` then
+         reports "No test is available" instead of running anything. Declaring a
+         single-entry TargetFrameworks keeps the outer/inner build that passes
+         TargetFramework as a global property, so the imports apply. It also overrides the
+         Windows value from Directory.Build.props, keeping tests net8.0 only. -->
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/Unosquare.PassCore.Common.Tests/Unosquare.PassCore.Common.Tests.csproj
+++ b/tests/Unosquare.PassCore.Common.Tests/Unosquare.PassCore.Common.Tests.csproj
@@ -1,6 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <!-- TargetFrameworks (plural), not TargetFramework. The root Directory.Build.props
+         sets TargetFrameworks, so NuGet restores this project as cross-targeting and
+         emits its package .props imports under a Condition of "'$(TargetFramework)' ==
+         'net8.0'". Those imports are evaluated at the top of the project, before the body
+         runs, so setting TargetFramework (singular) here leaves that condition false and
+         the imports skipped. That silently drops the None items which copy
+         xunit.runner.visualstudio.testadapter.dll to the output, and `dotnet test` then
+         reports "No test is available" instead of running anything. Declaring a
+         single-entry TargetFrameworks keeps the outer/inner build that passes
+         TargetFramework as a global property, so the imports apply. It also overrides the
+         Windows value from Directory.Build.props, keeping tests net8.0 only. -->
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/Unosquare.PassCore.PasswordProvider.Debug.Tests/Unosquare.PassCore.PasswordProvider.Debug.Tests.csproj
+++ b/tests/Unosquare.PassCore.PasswordProvider.Debug.Tests/Unosquare.PassCore.PasswordProvider.Debug.Tests.csproj
@@ -1,6 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <!-- TargetFrameworks (plural), not TargetFramework. The root Directory.Build.props
+         sets TargetFrameworks, so NuGet restores this project as cross-targeting and
+         emits its package .props imports under a Condition of "'$(TargetFramework)' ==
+         'net8.0'". Those imports are evaluated at the top of the project, before the body
+         runs, so setting TargetFramework (singular) here leaves that condition false and
+         the imports skipped. That silently drops the None items which copy
+         xunit.runner.visualstudio.testadapter.dll to the output, and `dotnet test` then
+         reports "No test is available" instead of running anything. Declaring a
+         single-entry TargetFrameworks keeps the outer/inner build that passes
+         TargetFramework as a global property, so the imports apply. It also overrides the
+         Windows value from Directory.Build.props, keeping tests net8.0 only. -->
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests.csproj
+++ b/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests.csproj
@@ -1,6 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <!-- TargetFrameworks (plural), not TargetFramework. The root Directory.Build.props
+         sets TargetFrameworks, so NuGet restores this project as cross-targeting and
+         emits its package .props imports under a Condition of "'$(TargetFramework)' ==
+         'net8.0'". Those imports are evaluated at the top of the project, before the body
+         runs, so setting TargetFramework (singular) here leaves that condition false and
+         the imports skipped. That silently drops the None items which copy
+         xunit.runner.visualstudio.testadapter.dll to the output, and `dotnet test` then
+         reports "No test is available" instead of running anything. Declaring a
+         single-entry TargetFrameworks keeps the outer/inner build that passes
+         TargetFramework as a global property, so the imports apply. It also overrides the
+         Windows value from Directory.Build.props, keeping tests net8.0 only. -->
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Description

**The backend unit test step has been passing without executing a single assertion.**

On master at `a86c587`, the `Run Backend Unit Tests` step printed `No test is available` for all four test projects, and the job concluded **success**:

```
A total of 1 test files matched the specified pattern.
No test is available in .../Unosquare.PassCore.Common.Tests.dll. ...
No test is available in .../Unosquare.PassCore.PasswordProvider.Debug.Tests.dll. ...
No test is available in .../Zyborg.PassCore.PasswordProvider.LDAP.Tests.dll. ...
No test is available in .../PwnedPasswordsSearch.Tests.dll. ...
```

No `Passed!`, no `Failed!`, no counts — 538 tests, zero executed. This is why it matters now: every acceptance criterion in the remaining remediation tasks is expressed as a test, and none of them would have gated anything.

### Root cause

An interaction between the root `Directory.Build.props` and the test projects.

`Directory.Build.props` sets `TargetFrameworks` (plural). NuGet therefore restores each test project as **cross-targeting** and emits its package `.props` imports under a condition:

```xml
<ImportGroup Condition=" '$(TargetFramework)' == 'net8.0' AND ... ">
  <Import Project="...xunit.runner.visualstudio/2.5.7/build/net6.0/xunit.runner.visualstudio.props" ... />
```

Those imports are evaluated by `Microsoft.Common.props` at the *top* of the project, before the project body runs — so the `TargetFramework` (singular) set in each test csproj body is not yet visible and the condition is **false**. The project then builds as a single-TFM project, so no inner build supplies `TargetFramework` as a global property either, and the conditioned imports never apply at all.

The import that matters is `xunit.runner.visualstudio.props`, which delivers the VSTest adapter as `None` items with `CopyToOutputDirectory`. Without it, `xunit.runner.visualstudio.testadapter.dll` never reaches `bin`, VSTest finds no discoverer, and `dotnet test` reports `No test is available` — **and exits 0**, so the `set -euo pipefail` already in the workflow could not catch it.

Package `.targets` were unaffected the whole time, because `nuget.g.targets` is imported at the *bottom* of the project, after the body sets `TargetFramework`. That asymmetry is why everything compiled normally and only discovery broke — the failure was invisible.

### The fix

Each test project declares a single-entry `TargetFrameworks` instead of `TargetFramework`. That restores the outer/inner build which passes `TargetFramework` as a global property, so the conditioned imports apply. It also overrides the value inherited from `Directory.Build.props`, keeping the test projects `net8.0`-only on Windows where the shared value is `net8.0;net8.0-windows`. Each change carries a comment explaining the trap, since `TargetFrameworks` for a single framework looks like a typo otherwise.

### The guard

Because the failure mode is silent and exits 0, the workflow now captures the `dotnet test` output and fails the step if any project reports `No test is available`, with a GitHub error annotation naming the likely cause. Without this, the same slip in any future project would go straight back to passing vacuously.

## Verification

Run with the workflow's exact invocation, no local overrides:

| Project | Tests |
|---|---|
| `Unosquare.PassCore.Common.Tests` | 189 passed |
| `Unosquare.PassCore.PasswordProvider.Debug.Tests` | 20 passed |
| `Zyborg.PassCore.PasswordProvider.LDAP.Tests` | 325 passed |
| `PwnedPasswordsSearch.Tests` | 4 passed |
| **Total** | **538 passed, 0 failed** |

Every project now writes a `.trx` with a non-zero count (previously the uploaded artifacts recorded nothing). Reverting a single project to `TargetFramework` reproduces the empty run and trips the new guard with exit 1, confirming the guard works rather than just being present.

## Scope

The `src` projects that set `TargetFramework` (singular) carry the same latent pattern, but none of them consume a package that ships `.props` content, so nothing is broken there today. Left alone deliberately to keep this change to the defect.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [x] Testing/CI harness

## Checklist
- [x] All new code compiles under .NET 8.
- [x] `dotnet test` passes locally — and now actually runs: 538 tests across all four projects.
- [x] No external network calls are made in unit tests.
- [x] Documentation (if applicable) is updated — the rationale lives in a comment in each csproj and in the workflow step.
- [x] Debug provider is gated by `#if DEBUG` and cannot be enabled in Production — untouched.
- [ ] (Optional) Example e2e test runs against the Docker Compose test stack — not affected; no source or provider behavior changed.

## Note for reviewers

Expect the CI signal on this PR to differ from previous runs. Backend unit tests are executing for the first time in this configuration, so if any pre-existing test is actually broken, this is the PR where it will surface. Everything passes locally on Linux with .NET 8.0.423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsJRsb3rUAuacypogW9ZEN

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsJRsb3rUAuacypogW9ZEN)_