### PR TITLE
Fail closed when group membership cannot be determined (restricted-group deny list was failing open)

### DIFF
--- a/docs/error-routing-matrix.md
+++ b/docs/error-routing-matrix.md
@@ -195,6 +195,40 @@ gets the diagnosis while the wire response stays curated. `0x532`
 password is correct but expired"; as the **service account** it must never
 proceed — the actor coercion makes it `Infrastructure`.
 
+### Undetermined group membership
+
+`IsMemberOfGroupAsync` answers `true`/`false` only when the answer is known. A
+lookup that **could not complete** is a third outcome, and it is not reported as
+"not a member": the provider throws, the failure routes as
+`DirectoryActor.ServiceAccount` → `Infrastructure`, and the caller gets
+`LdapProblem (8)` / `DirectoryFailureMessage` in both modes — the `Infrastructure`
+row above, not the `Group Rejection` row.
+
+This is why the distinction is load-bearing rather than pedantic.
+`GroupMembershipPolicy` reads the result as a `bool`, so conflating the two makes
+`RestrictedAdGroups` **fail open**: during a partial directory failure, a
+service-account permissions problem, or a cross-domain timeout, a member of a
+restricted group would be handed a password change. (`AllowedAdGroups` fails the
+other way — every user refused, with no operator signal.) Failing closed is the
+point of a deny list, so an unknown answer blocks the request.
+
+A match is definitive the moment it is found, so a later lookup failing never
+turns a confirmed membership into code 8 — a restricted-group member still gets
+the `Group Rejection` row. Only a *negative* answer requires that every lookup
+which could still have matched actually ran:
+
+- **LDAP** — direct `memberOf`, the `primaryGroupToken` search, and the
+  `LDAP_MATCHING_RULE_IN_CHAIN` search. `memberOf` succeeding does not cover
+  nesting or the primary group, so it cannot rescue either search's failure.
+- **AD** — `GetAuthorizationGroups` (transitive plus primary security groups) and
+  `GetGroups` (direct, including distribution groups). They cover different
+  ground, so neither rescues the other's failure.
+
+An empty result set is a completed lookup, not a failure: ordinary
+non-membership stays an ordinary `false` and the request proceeds. Each failed
+lookup is logged at Warning through `ServiceAccountFailure` with the operation
+that failed, so the operator can see why requests started being refused.
+
 ## Terminal catch
 
 Both providers end `ChangePasswordCore` with the same last-resort

--- a/src/Unosquare.PassCore.Common/PasswordChangeProviderBase.cs
+++ b/src/Unosquare.PassCore.Common/PasswordChangeProviderBase.cs
@@ -38,7 +38,11 @@ public abstract class PasswordChangeProviderBase : IPasswordChangeProvider, IDis
     // everywhere. Ranges, and the next free number in each:
     //
     //   1-9      this base class (password-change and policy lifecycle)   next: 10
-    //   100-105  provider-specific events (LDAP 100-102, 104; AD 103, 105) next: 106
+    //   100-105  provider-specific events (LDAP 100-102, 104; AD 103)     next: 106
+    //            105 is retired: it logged a group-enumeration failure as an
+    //            expected Debug-level fallback, which no longer exists. Such a
+    //            failure now leaves membership undetermined and is reported via
+    //            ServiceAccountFailure (111). Retired, not free -- do not reuse.
     //   110-112  shared helpers (AdministrativeReset, ServiceAccountFailure,
     //            DomainPasswordPolicy)                                     next: 113
     //   300-304  PwnedPasswordsSearch                                      next: 305

--- a/src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs
+++ b/src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs
@@ -43,13 +43,13 @@ namespace Unosquare.PassCore.PasswordProvider
                 "administrative reset with. Configure explicit LdapUsername/LdapPassword bind " +
                 "credentials (UseAutomaticContext=false) if the fallback is wanted.");
 
-        private static readonly Action<ILogger, Exception?> LogGroupEnumerationFallback =
-            LoggerMessage.Define(
-                LogLevel.Debug,
-                new EventId(105, nameof(LogGroupEnumerationFallback)),
-                "GetGroups() failed; falling back to GetAuthorizationGroups(). The two behave " +
-                "differently across environments so the fallback is expected, but a persistent " +
-                "GetGroups failure indicates a misconfiguration worth investigating.");
+        // EventId 105 (LogGroupEnumerationFallback) is retired, not reused. It
+        // described a group-enumeration failure as an expected fallback logged at
+        // Debug, which is no longer true in either direction: a failed enumeration
+        // now leaves membership undetermined and fails the request closed, and it is
+        // reported through ServiceAccountFailure (EventId 111) at Warning, like every
+        // other service-account directory failure. Its message had also inverted
+        // during an earlier refactor, naming the wrong call as the one that failed.
 
         public PasswordChangeProvider(
             ILogger<PasswordChangeProvider> logger,
@@ -192,7 +192,29 @@ namespace Unosquare.PassCore.PasswordProvider
             return Task.FromResult(AcquireDomainPasswordLength());
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Reports whether <paramref name="username"/> is a member of
+        /// <paramref name="groupName"/>, directly, by primary group, or transitively.
+        /// </summary>
+        /// <remarks>
+        /// <para><b>A negative answer means "determined not to be a member", never
+        /// "could not tell".</b> A positive match is definitive the moment it is found,
+        /// so each enumeration returns immediately on a hit and no later failure can
+        /// affect it. A negative answer is only trustworthy if every enumeration that
+        /// could still have produced a match completed, so a failed enumeration is
+        /// recorded and the method throws the shared infrastructure failure instead of
+        /// returning <see langword="false"/>.</para>
+        /// <para>The two enumerations do not cover the same ground, which is why
+        /// neither one succeeding rescues the other's failure:
+        /// <c>GetAuthorizationGroups</c> resolves transitive and primary security
+        /// groups, while <c>GetGroups</c> covers direct groups including distribution
+        /// groups. A match found by either is real; a miss is only conclusive when both
+        /// ran.</para>
+        /// <para>Reporting "not a member" for a membership that could not be determined
+        /// makes <c>RestrictedAdGroups</c> <em>fail open</em>, letting a member of
+        /// <c>Domain Admins</c> through during a partial directory failure. This keeps
+        /// it failing closed, matching the LDAP provider for the same condition.</para>
+        /// </remarks>
         public Task<bool> IsMemberOfGroupAsync(string username, string groupName)
         {
             // Every operation in this method is a service-account directory read
@@ -209,6 +231,11 @@ namespace Unosquare.PassCore.PasswordProvider
                     () => UserPrincipal.FindByIdentity(principalContext, _idType, FixUsernameWithDomain(username)));
                 if (userPrincipal == null) return Task.FromResult(false);
 
+                // Records the first enumeration that could not complete. Both match
+                // paths return before the end of the method, so a value here always
+                // means "could not determine", never "determined not to be a member".
+                Exception? undetermined = null;
+
                 // Deterministically check GetAuthorizationGroups first to resolve transitive/recursive and primary security groups.
                 try
                 {
@@ -218,7 +245,12 @@ namespace Unosquare.PassCore.PasswordProvider
                 }
                 catch (Exception ex)
                 {
-                    LogGroupEnumerationFallback(Logger, ex);
+                    // Transitive and primary membership are now unknown; GetGroups
+                    // below covers neither, so it cannot stand in for this.
+                    undetermined ??= ex;
+                    ServiceAccountFailure.Log(
+                        Logger, correlationId: null, "enumerate authorization groups",
+                        ServiceAccountHost(), ex);
                 }
 
                 // Complement with GetGroups to cover distribution or direct groups that might not be in authorization groups.
@@ -230,7 +262,18 @@ namespace Unosquare.PassCore.PasswordProvider
                 }
                 catch (Exception ex)
                 {
-                    Logger.LogWarning(ex, "Failed to retrieve direct groups via GetGroups().");
+                    // Direct and distribution-group membership are now unknown.
+                    undetermined ??= ex;
+                    ServiceAccountFailure.Log(
+                        Logger, correlationId: null, "enumerate direct groups",
+                        ServiceAccountHost(), ex);
+                }
+
+                // Nothing matched. That is only an answer if both enumerations ran.
+                if (undetermined is not null)
+                {
+                    throw DirectoryErrorTranslator.TranslateException(
+                        undetermined, _options.ErrorDisclosureMode, DirectoryActor.ServiceAccount);
                 }
 
                 return Task.FromResult(false);

--- a/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeProvider.cs
+++ b/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeProvider.cs
@@ -137,6 +137,30 @@ public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMemb
     // Group membership lookup
     // ---------------------------------------------------------------------
 
+    /// <summary>
+    /// Reports whether <paramref name="username"/> is a member of
+    /// <paramref name="groupName"/>, directly, by primary group, or transitively.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>A negative answer means "determined not to be a member", never "could
+    /// not tell".</b> A positive match is definitive the moment it is found, so every
+    /// lookup below returns immediately on a hit and no later failure can affect it. A
+    /// negative answer is only trustworthy if every lookup that could still have
+    /// produced a match actually completed, so any lookup that fails is recorded and
+    /// the method ends by throwing the shared infrastructure failure instead of
+    /// returning <see langword="false"/>.</para>
+    /// <para>This matters because the caller cannot distinguish the two outcomes from a
+    /// <see langword="bool"/>. <c>GroupMembershipPolicy</c> evaluates
+    /// <c>RestrictedAdGroups</c> as a deny list, so reporting "not a member" for a
+    /// membership that could not be determined makes the deny list <em>fail open</em>:
+    /// during a partial directory failure, a service-account permissions problem, or a
+    /// cross-domain timeout, a member of <c>Domain Admins</c> would be allowed to change
+    /// their password through this utility. Failing closed is the whole point of the
+    /// deny list.</para>
+    /// <para>Ordinary non-membership is unaffected and stays a plain
+    /// <see langword="false"/>: a lookup that ran and matched nothing is a completed
+    /// determination, and an empty result set is not a failure.</para>
+    /// </remarks>
     public Task<bool> IsMemberOfGroupAsync(string username, string groupName)
     {
         ArgumentNullException.ThrowIfNull(username);
@@ -145,6 +169,11 @@ public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMemb
         try
         {
             var user = FindUser(username);
+
+            // Records the first lookup that could not complete. Every match path
+            // returns before reaching the end of the method, so a value here always
+            // means "could not determine", never "determined not to be a member".
+            Exception? undetermined = null;
 
             // 1. Direct membership check
             // `memberOf` returns full DNs (e.g. "cn=Admins,ou=groups,dc=example,dc=com").
@@ -189,7 +218,12 @@ public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMemb
                 }
                 catch (Exception ex) when (ex is LdapException || ex is DirectoryUnavailableException)
                 {
-                    Logger.LogDebug(ex, "Failed to resolve primary group DN via primaryGroupToken search. Falling back to default evaluation.");
+                    // Not a fallback: the user's primary group is now unknown, so a
+                    // "not a member" answer can no longer be justified.
+                    undetermined ??= ex;
+                    ServiceAccountFailure.Log(
+                        Logger, correlationId: null, "resolve primary group by primaryGroupToken",
+                        ServiceAccountHost(), ex);
                 }
             }
 
@@ -216,7 +250,23 @@ public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMemb
             }
             catch (Exception ex) when (ex is LdapException || ex is DirectoryUnavailableException)
             {
-                Logger.LogDebug(ex, "Failed to resolve transitive groups using LDAP_MATCHING_RULE_IN_CHAIN. Falling back to default evaluation.");
+                // Nested membership is now unknown. Direct `memberOf` having
+                // succeeded is not enough: it does not cover nesting, so it cannot
+                // rule out a match this search would have found.
+                undetermined ??= ex;
+                ServiceAccountFailure.Log(
+                    Logger, correlationId: null, "resolve transitive groups via LDAP_MATCHING_RULE_IN_CHAIN",
+                    ServiceAccountHost(), ex);
+            }
+
+            // Nothing matched. That is only an answer if everything that could have
+            // matched actually ran; otherwise this is "could not determine", and the
+            // shared translator turns it into the infrastructure response rather than
+            // letting it read as "not a member".
+            if (undetermined is not null)
+            {
+                throw DirectoryErrorTranslator.TranslateException(
+                    undetermined, _options.ErrorDisclosureMode, DirectoryActor.ServiceAccount);
             }
 
             return Task.FromResult(false);

--- a/tests/Unosquare.PassCore.Common.Tests/AdProviderDirectoryWriteAuditTests.cs
+++ b/tests/Unosquare.PassCore.Common.Tests/AdProviderDirectoryWriteAuditTests.cs
@@ -208,6 +208,85 @@ public class AdProviderDirectoryWriteAuditTests
     }
 
     /// <summary>
+    /// The AD half of "could not determine membership is not the same as not a
+    /// member". The LDAP provider's behavior is exercised for real in
+    /// <c>GroupMembershipUndeterminedTests</c>; this provider cannot be loaded here
+    /// (see the class summary), so its shape is audited instead.
+    ///
+    /// <para>What must hold: both group enumerations record their failure rather
+    /// than swallowing it, and a negative result is only returned when neither
+    /// recorded anything. Swallowing either one makes <c>RestrictedAdGroups</c> fail
+    /// open — a <c>Domain Admins</c> member gets a password change during a partial
+    /// directory failure.</para>
+    /// </summary>
+    [Fact]
+    public void IsMemberOfGroupAsync_FailsClosedWhenMembershipCannotBeDetermined()
+    {
+        var body = ExtractMethodBody(
+            CodeSkeleton(ReadRepoFile(ProviderRelativePath)),
+            "Task<bool> IsMemberOfGroupAsync(");
+
+        // Both enumerations (GetAuthorizationGroups and GetGroups) must record a
+        // failure. They cover different ground — transitive plus primary security
+        // groups versus direct and distribution groups — so neither succeeding
+        // rescues the other's failure.
+        Assert.Equal(2, CountOccurrences(body, "undetermined ??= ex;"));
+
+        // A recorded failure must block the negative answer, not merely be logged.
+        var guardAt = body.IndexOf("if (undetermined is not null)", StringComparison.Ordinal);
+        var notAMemberAt = body.LastIndexOf("return Task.FromResult(false);", StringComparison.Ordinal);
+
+        Assert.True(
+            guardAt >= 0,
+            "IsMemberOfGroupAsync no longer guards its negative answer on whether every enumeration " +
+            "completed. Without that guard a failed enumeration reads as 'not a member' and the " +
+            "restricted-group deny list fails open. See docs/error-routing-matrix.md.");
+        Assert.True(
+            guardAt < notAMemberAt,
+            "The 'could not determine' guard no longer precedes the final 'not a member' return, so a " +
+            "failed enumeration can still reach it.");
+
+        // The outcome is the shared infrastructure response, decided by the
+        // translator rather than by this provider.
+        Assert.Contains("DirectoryErrorTranslator.TranslateException(", body, StringComparison.Ordinal);
+        Assert.Contains("DirectoryActor.ServiceAccount", body, StringComparison.Ordinal);
+
+        // ... and it is reported to the operator, not swallowed.
+        Assert.Contains("ServiceAccountFailure.Log(", body, StringComparison.Ordinal);
+
+        // A match stays definitive: both enumerations return true on a hit before
+        // any of the undetermined handling can affect the result.
+        Assert.Equal(2, CountOccurrences(body, "return Task.FromResult(true);"));
+    }
+
+    /// <summary>
+    /// EventId 105 described a group-enumeration failure as an expected fallback,
+    /// logged at Debug. That is no longer what happens, so the delegate is gone —
+    /// and the ID must stay retired rather than being recycled for something else.
+    /// </summary>
+    [Fact]
+    public void RetiredGroupEnumerationFallbackEvent_IsNotReintroducedOrReused()
+    {
+        var code = CodeSkeleton(ReadRepoFile(ProviderRelativePath));
+
+        Assert.DoesNotContain("LogGroupEnumerationFallback", code, StringComparison.Ordinal);
+        Assert.DoesNotContain("EventId(105", code, StringComparison.Ordinal);
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        for (var i = haystack.IndexOf(needle, StringComparison.Ordinal);
+             i >= 0;
+             i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    /// <summary>
     /// The AD half of the cross-provider claim that a stock deployment accepts the
     /// username form its own UI asks for. <c>appsettings.json</c> ships
     /// <c>DefaultDomain: ""</c> next to <c>UseEmail: true</c>, so an unmodified

--- a/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/GroupMembershipUndeterminedTests.cs
+++ b/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/GroupMembershipUndeterminedTests.cs
@@ -1,0 +1,258 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Novell.Directory.Ldap;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Unosquare.PassCore.Common;
+using Unosquare.PassCore.Common.Exceptions;
+using Unosquare.PassCore.Common.Models;
+using Unosquare.PassCore.Common.Policies;
+using Xunit;
+
+namespace Zyborg.PassCore.PasswordProvider.LDAP.Tests;
+
+/// <summary>
+/// "Could not determine membership" must never be reported as "not a member".
+///
+/// <para><c>GroupMembershipPolicy</c> reads <c>IsMemberOfGroupAsync</c> as a
+/// <see langword="bool"/>, so the two outcomes are indistinguishable to it. When
+/// they are conflated, <c>RestrictedAdGroups</c> — a deny list whose shipped
+/// default is <c>Administrators</c>, <c>Domain Admins</c>,
+/// <c>Enterprise Admins</c> — <b>fails open</b>: during a partial directory
+/// failure, a service-account permissions problem, or a cross-domain timeout,
+/// a member of a restricted group is handed a password change. These tests pin
+/// the failing-closed behavior, and equally pin that ordinary non-membership is
+/// still an ordinary <see langword="false"/>.</para>
+/// </summary>
+public class GroupMembershipUndeterminedTests
+{
+    private const string UserDn = "cn=testuser,ou=people,dc=example,dc=com";
+    private const string RestrictedGroup = "RestrictedGroup";
+
+    /// <summary>
+    /// The core case. The user <b>is</b> a member of the restricted group, nested
+    /// beneath a group they hold directly — the directory holds that fact, and the
+    /// in-chain search is what would reveal it. That search fails, so membership is
+    /// unknown. Reporting "not a member" here is what lets a Domain Admin through.
+    /// </summary>
+    [Theory]
+    [InlineData(ErrorDisclosureMode.Hardened)]
+    [InlineData(ErrorDisclosureMode.Informative)]
+    public async Task RestrictedMember_WhoseMembershipCannotBeDetermined_DoesNotGetASuccessfulOrNonInfrastructureResponse(
+        ErrorDisclosureMode mode)
+    {
+        var provider = Provider(mode, Directory.WhereNestedLookupFails());
+
+        var error = await Assert.ThrowsAnyAsync<Exception>(
+            () => RunRestrictedPolicy(provider));
+
+        // Not "not a member" (which would have let the request proceed), and not a
+        // group rejection either — the request is refused as an infrastructure
+        // failure, which is what a service-account read failure actually is.
+        var wire = ApiErrorMapper.Map(error);
+        Assert.Equal(ApiErrorCode.LdapProblem, wire.ErrorCode);
+        Assert.Equal(DirectoryErrorTranslator.DirectoryFailureMessage, wire.Message);
+    }
+
+    /// <summary>
+    /// The same undetermined condition, asserted directly on the provider rather
+    /// than through the policy: it must not quietly answer <see langword="false"/>.
+    /// </summary>
+    [Fact]
+    public async Task UndeterminedMembership_ThrowsRatherThanReturningNotAMember()
+    {
+        var provider = Provider(ErrorDisclosureMode.Hardened, Directory.WhereNestedLookupFails());
+
+        await Assert.ThrowsAsync<DirectoryUnavailableException>(
+            () => provider.IsMemberOfGroupAsync("testuser", RestrictedGroup));
+    }
+
+    /// <summary>
+    /// A failed primary-group lookup leaves membership just as unknown as a failed
+    /// nested lookup: <c>primaryGroupToken</c> is the authority for the user's
+    /// primary group, and <c>memberOf</c> does not list it.
+    /// </summary>
+    [Fact]
+    public async Task PrimaryGroupLookupFailure_IsAlsoUndetermined()
+    {
+        var provider = Provider(ErrorDisclosureMode.Hardened, Directory.WherePrimaryLookupFails());
+
+        await Assert.ThrowsAsync<DirectoryUnavailableException>(
+            () => provider.IsMemberOfGroupAsync("testuser", RestrictedGroup));
+    }
+
+    /// <summary>
+    /// The other half of the contract, and the one a fail-closed change is most
+    /// likely to break: a user who is simply not in the group must still get a
+    /// plain "not a member", and the request must proceed. An empty result set is
+    /// a completed lookup, not a failure.
+    /// </summary>
+    [Fact]
+    public async Task OrdinaryNonMembership_StillReturnsNotAMemberAndTheRequestProceeds()
+    {
+        var provider = Provider(ErrorDisclosureMode.Hardened, Directory.WhereEverythingSucceeds());
+
+        Assert.False(await provider.IsMemberOfGroupAsync("testuser", RestrictedGroup));
+
+        // And the deny-list policy lets it through.
+        await RunRestrictedPolicy(provider);
+    }
+
+    /// <summary>
+    /// A match is definitive the moment it is found, so a later lookup failing
+    /// cannot turn a confirmed membership into an infrastructure error. Without
+    /// this, every restricted-group member during a degraded window would get code
+    /// 8 instead of the group rejection.
+    /// </summary>
+    [Fact]
+    public async Task ConfirmedMembership_IsNotDisturbedByALaterLookupFailure()
+    {
+        // Direct memberOf holds the restricted group; the nested search still fails.
+        var provider = Provider(
+            ErrorDisclosureMode.Hardened,
+            Directory.WhereNestedLookupFails(directGroup: $"cn={RestrictedGroup},ou=groups,dc=example,dc=com"));
+
+        Assert.True(await provider.IsMemberOfGroupAsync("testuser", RestrictedGroup));
+    }
+
+    /// <summary>
+    /// The operator has to be able to see why requests started failing, so the
+    /// undetermined path reports through the shared service-account channel at
+    /// Warning rather than being swallowed at Debug.
+    /// </summary>
+    [Fact]
+    public async Task UndeterminedMembership_IsLoggedViaServiceAccountFailureAtWarning()
+    {
+        var logger = new CapturingLogger();
+        var provider = Provider(ErrorDisclosureMode.Hardened, Directory.WhereNestedLookupFails(), logger);
+
+        await Assert.ThrowsAsync<DirectoryUnavailableException>(
+            () => provider.IsMemberOfGroupAsync("testuser", RestrictedGroup));
+
+        var entry = Assert.Single(logger.Entries.Where(e => e.EventId.Id == ServiceAccountFailureEventId));
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("LDAP_MATCHING_RULE_IN_CHAIN", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("ldap.example.com", entry.Message, StringComparison.Ordinal);
+        Assert.NotNull(entry.Exception);
+    }
+
+    /// <summary>EventId of <see cref="ServiceAccountFailure"/>, per the registry in <c>PasswordChangeProviderBase</c>.</summary>
+    private const int ServiceAccountFailureEventId = 111;
+
+    private static Task RunRestrictedPolicy(IPasswordChangeProvider provider)
+    {
+        var settings = new ClientSettings
+        {
+            PasswordProviderOptions = new PasswordProviderOptions
+            {
+                RestrictedAdGroups = new List<string> { RestrictedGroup },
+            },
+        };
+
+        return new GroupMembershipPolicy()
+            .ValidateAsync(new PasswordChangeContext("testuser", "old", "new", settings), provider);
+    }
+
+    /// <summary>
+    /// Search behaviors for the three lookups the provider issues, keyed by filter.
+    /// Each variant models one directory condition.
+    /// </summary>
+    private sealed record Directory(string? DirectGroup, bool PrimaryFails, bool NestedFails)
+    {
+        public static Directory WhereEverythingSucceeds() => new(null, false, false);
+
+        public static Directory WhereNestedLookupFails(string? directGroup = null) =>
+            new(directGroup, false, true);
+
+        public static Directory WherePrimaryLookupFails() => new(null, true, false);
+    }
+
+    private static TestLdapPasswordChangeProvider Provider(
+        ErrorDisclosureMode mode, Directory directory, ILogger<LdapPasswordChangeProvider>? logger = null)
+    {
+        var options = new LdapPasswordChangeOptions
+        {
+            LdapHostnames = new[] { "ldap.example.com" },
+            LdapPort = 389,
+            LdapUsername = "cn=admin,dc=example,dc=com",
+            LdapPassword = "secret",
+            LdapSearchBase = "dc=example,dc=com",
+            LdapSearchFilter = "(sAMAccountName={Username})",
+            ErrorDisclosureMode = mode,
+        };
+
+        var provider = new TestLdapPasswordChangeProvider(
+            logger ?? new CapturingLogger(),
+            Options.Create(options),
+            Options.Create(new ClientSettings()),
+            Array.Empty<IPasswordPolicy>());
+
+        var attributes = new LdapAttributeSet
+        {
+            new LdapAttribute("distinguishedName", UserDn),
+            new LdapAttribute("sAMAccountName", "testuser"),
+            new LdapAttribute("primaryGroupID", "1234"),
+        };
+
+        if (directory.DirectGroup != null)
+            attributes.Add(new LdapAttribute("memberOf", directory.DirectGroup));
+
+        var userEntry = new LdapEntry(UserDn, attributes);
+
+        provider.OnSearchLdap = (filter, _) =>
+        {
+            if (filter.Contains("sAMAccountName=", StringComparison.Ordinal))
+                return Results(userEntry);
+
+            if (filter.Contains("primaryGroupToken=", StringComparison.Ordinal))
+            {
+                return directory.PrimaryFails
+                    ? throw new LdapException("primary group search failed", LdapException.Busy, null)
+                    : Results();
+            }
+
+            if (filter.Contains("1.2.840.113556.1.4.1941", StringComparison.Ordinal))
+            {
+                // The nested membership genuinely exists in this directory; this
+                // search is simply unable to report it.
+                return directory.NestedFails
+                    ? throw new LdapException("in-chain search failed", LdapException.Busy, null)
+                    : Results();
+            }
+
+            return Results();
+        };
+
+        return provider;
+    }
+
+    private static ILdapSearchResults Results(params LdapEntry[] entries)
+    {
+        var mock = new Mock<ILdapSearchResults>();
+        var remaining = new Queue<LdapEntry>(entries);
+
+        mock.Setup(r => r.HasMore()).Returns(() => remaining.Count > 0);
+        mock.Setup(r => r.Next()).Returns(() => remaining.Dequeue());
+        return mock.Object;
+    }
+
+    private sealed class CapturingLogger : ILogger<LdapPasswordChangeProvider>
+    {
+        public List<(LogLevel Level, EventId EventId, string Message, Exception? Exception)> Entries { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            Entries.Add((logLevel, eventId, formatter(state, exception), exception));
+    }
+}


### PR DESCRIPTION
## Description

**Task 2 of the post-merge remediation series.** This is the highest-severity item in the review: the restricted-group deny list currently **fails open**.

Phase 2 restructured `IsMemberOfGroupAsync` on both providers so a failed group lookup was caught, logged, and folded into a plain `false`. `GroupMembershipPolicy` reads the result as a `bool`, so it cannot distinguish *"confirmed not a member"* from *"could not tell"* — and `RestrictedAdGroups` is a deny list.

During a partial directory failure, a service-account permissions problem, or a `GetAuthorizationGroups` cross-domain timeout, a member of `Domain Admins` was handed a password change. The shipped default deny list is `Administrators`, `Domain Admins`, `Enterprise Admins`. `AllowedAdGroups` failed the other way — every user refused, with no operator signal.

## The rule, identical on both providers

- **A match is definitive the moment it is found.** Every lookup returns immediately on a hit, so no later failure can disturb a confirmed membership. A restricted-group member still gets the group rejection, not an infrastructure error.
- **A negative answer is only returned when every lookup that could still have matched completed.** Otherwise the first recorded failure goes to `DirectoryErrorTranslator` as `DirectoryActor.ServiceAccount` — which is what it is — and the caller gets the shared infrastructure response: `LdapProblem (8)` with `DirectoryFailureMessage`, identical in both disclosure modes.
- **Ordinary non-membership is unchanged.** An empty result set is a completed lookup, not a failure, so it stays a plain `false` and the request proceeds.

The lookups are not interchangeable, which is why neither rescues the other's failure:

| Provider | Lookups | Why one cannot cover for the other |
|---|---|---|
| LDAP | direct `memberOf`, `primaryGroupToken` search, `LDAP_MATCHING_RULE_IN_CHAIN` search | `memberOf` covers neither nesting nor the primary group |
| AD | `GetAuthorizationGroups`, `GetGroups` | transitive + primary security groups vs. direct + distribution groups |

## Mechanism

Expressed as an **exception**, not a tri-state. `IGroupMembershipTester` is public, and its contract becomes "returns a `bool` only when the answer is known; throws when the directory could not answer" — which callers already had to tolerate from the user lookup on the same code path. No signature change, so no implementer churn (the Debug provider does not implement this interface). `GroupMembershipPolicy` needs no change: the exception propagates through `Task.WhenAll` and refuses the request.

No `ApiErrorCode` is decided outside `DirectoryErrorTranslator`. The group check keeps its position before credential verification, restricted-before-allowed ordering is untouched, and no supplementary lookup was removed.

## Logging

Each failed lookup is now reported through `ServiceAccountFailure` at **Warning** — with the operation that failed, the host, and a correlation ID where one exists — instead of being swallowed at Debug. Without this the operator has no signal at all for a condition that starts refusing every request.

## Scope note for Task 5

This absorbs part of the logging-cleanup task, because Task 2's semantics explicitly required routing these through `ServiceAccountFailure` at Warning:

- **Three of the four ad-hoc logging calls** are gone (`PasswordChangeProvider.cs:233`, `LdapPasswordChangeProvider.cs:188`, `:215`). Only the rootDSE fallback log remains — verified: CA1848 now fires exactly once in the LDAP provider, at that line.
- **EventId 105 is retired.** It described a group-enumeration failure as an expected Debug-level fallback, which no longer exists, and its message had inverted during an earlier refactor so it named the wrong call as the one that failed. It is marked **retired, not free** in the `PasswordChangeProviderBase` registry — a test asserts it is neither reintroduced nor reused.

Task 5 keeps the remaining ad-hoc call and the registry housekeeping. Per its own note ("if Task 2 lands first, keep its levels"), the Warning levels set here stand.

## Tests

Exercised end-to-end on the LDAP provider through the real `GroupMembershipPolicy`:

- A genuine restricted-group member whose membership **cannot be read** is refused — not let through, and not with a group rejection either, but with the infrastructure response. Asserted in **both** disclosure modes.
- A confirmed membership **survives** a later lookup failure and still returns `true` (guards against over-eager failing).
- Ordinary non-membership still returns `false` **and the policy lets the request proceed**.
- A failed primary-group lookup is undetermined too, not just the nested one.
- `ServiceAccountFailure` fires at Warning with EventId 111, naming the failed operation and host.

The AD provider cannot be loaded by the cross-platform suite, so its shape is covered by source-skeleton audit: both catches record the failure, the guard precedes the negative return, the translator decides the code, and both match paths still return early.

`docs/error-routing-matrix.md` gains a section explaining why a deny-list check can produce code 8 rather than the Group Rejection row. The matrix table itself is unchanged — the outcome routes through the existing `Infrastructure` row — so `RoutingMatrixAuditTests` needed no corresponding change.

## How the AD provider was compile-verified, and a CI gap worth fixing separately

**No workflow in PR CI compiles the AD provider.** I assumed `build_windows.yml` covered it; it does not:

- `build_windows.yml` triggers only on `workflow_dispatch` and `v*.*.*` tags — not on pull requests or pushes to `master`.
- `build-sonar.yml` *would* cover it (windows-latest, `dotnet build` on every PR), but it has **never executed** — the API reports 0 runs for that workflow.
- `ci-testing.yml` and CodeQL run on ubuntu, where `net8.0-windows` cannot build and `#if WINDOWS` is undefined regardless.

So AD provider changes normally reach `master` without a compiler ever seeing them, until someone cuts a release tag. That is pre-existing and out of scope here, but it is worth its own fix — adding the AD provider to a Windows PR job, or enabling `build-sonar`.

For this PR I compiled it locally instead, forcing the Windows target and the guarded code:

```
dotnet restore src/Unosquare.PassCore.PasswordProvider/... -p:TargetFrameworks=net8.0-windows
dotnet build   src/Unosquare.PassCore.PasswordProvider/... -p:TargetFrameworks=net8.0-windows -p:DefineConstants=WINDOWS
→ Build succeeded. 0 Error(s)
```

and confirmed the guarded body really was compiled rather than skipped, by finding the new operation labels in the emitted assembly's string heap (`enumerate authorization groups`, `enumerate direct groups` present; the retired `GroupEnumerationFallback` and its old message absent).

## Behavior change worth noting

If one deny-list group's check is undetermined while another would have returned a definite match, `Task.WhenAll` surfaces the failure and the caller sees code 8 rather than the group rejection. Both refuse the request; only the code differs, and the infrastructure signal is the more actionable one for the operator.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation update
- [ ] Testing/CI harness

## Checklist
- [x] All new code compiles under .NET 8 — LDAP and Common normally; the AD provider verified with the forced Windows build described above.
- [x] `dotnet test` passes locally — 547 tests across all four projects (was 538; +9).
- [x] No external network calls are made in unit tests.
- [x] Documentation (if applicable) is updated — `docs/error-routing-matrix.md`, plus provider XML docs on both `IsMemberOfGroupAsync` implementations.
- [x] Debug provider is gated by `#if DEBUG` and cannot be enabled in Production — untouched; it does not implement `IGroupMembershipTester`.
- [ ] (Optional) Example e2e test runs against the Docker Compose test stack — the LDAP smoke test covers the healthy-directory paths, which are unchanged; the undetermined path needs an induced directory failure and is covered by unit tests instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsJRsb3rUAuacypogW9ZEN