### PR TITLE
Escape or type-validate every value interpolated into an LDAP search filter

### DIFF
--- a/src/Unosquare.PassCore.Common/PasswordChangeProviderBase.cs
+++ b/src/Unosquare.PassCore.Common/PasswordChangeProviderBase.cs
@@ -38,7 +38,7 @@ public abstract class PasswordChangeProviderBase : IPasswordChangeProvider, IDis
     // everywhere. Ranges, and the next free number in each:
     //
     //   1-9      this base class (password-change and policy lifecycle)   next: 10
-    //   100-105  provider-specific events (LDAP 100-102, 104; AD 103)     next: 106
+    //   100-106  provider-specific events (LDAP 100-102, 104, 106; AD 103) next: 107
     //            105 is retired: it logged a group-enumeration failure as an
     //            expected Debug-level fallback, which no longer exists. Such a
     //            failure now leaves membership undetermined and is reported via

--- a/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeProvider.cs
+++ b/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeProvider.cs
@@ -30,7 +30,14 @@ namespace Zyborg.PassCore.PasswordProvider.LDAP;
 /// - User existence is checked before authorization
 /// - User must prove knowledge of current password (on Active Directory,
 ///   expired / must-change-at-next-logon passwords still count as proof)
-/// - User-supplied input cannot alter the structure of the LDAP search filter
+/// - No value interpolated into an LDAP search filter can alter that filter's
+///   structure. This covers more than the submitted username: values read back
+///   from the directory are not inert either, because RFC 4514 DN string form
+///   escapes none of '(', ')' or '*'. Every filter value is therefore either
+///   RFC 4515-escaped through <c>EscapeLdapSearchFilterValue</c> or validated to
+///   a type that has no metacharacters to escape. (Search bases and modify
+///   targets are deliberately not escaped this way — those are RFC 4514 DN
+///   syntax, not RFC 4515 filter syntax.)
 /// - Infrastructure failures never surface as auth or policy errors
 /// </summary>
 public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMembershipTester, IPasswordLengthRequirement
@@ -87,6 +94,16 @@ public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMemb
             "has no effect: the Replace change mechanism is already an administrative operation " +
             "performed by the service account. Remove AllowAdministrativeReset or switch to the " +
             "delete/add mechanism if a fallback from a user-style change is what you want.");
+
+    private static readonly Action<ILogger, string?, string, Exception?> LogNonNumericPrimaryGroupId =
+        LoggerMessage.Define<string?, string>(
+            LogLevel.Warning,
+            new EventId(106, nameof(LogNonNumericPrimaryGroupId)),
+            "primaryGroupID '{PrimaryGroupId}' on '{UserDn}' is not an integer RID, so the " +
+            "account's primary group cannot be resolved. Group membership is therefore treated " +
+            "as undetermined and the request is refused rather than being answered from an " +
+            "incomplete picture. This is a directory-data problem: check the account's " +
+            "primaryGroupID attribute.");
 
     private static readonly string[] RequiredAttributes =
     {
@@ -196,34 +213,57 @@ public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMemb
                 if (user.PrimaryGroupId == "519" && groupName.Equals("Enterprise Admins", StringComparison.OrdinalIgnoreCase))
                     return Task.FromResult(true);
 
-                try
+                // primaryGroupID is a RID, read back from the directory as a string.
+                // Validating it as an integer is what keeps it inert in the filter
+                // below: an integer has no RFC 4515 metacharacter to escape, so the
+                // filter's structure cannot depend on the attribute's contents.
+                if (int.TryParse(
+                        user.PrimaryGroupId, NumberStyles.None, CultureInfo.InvariantCulture,
+                        out var primaryGroupToken))
                 {
-                    using var ldap = BindAsServiceAccount();
-                    var primaryFilter = $"(primaryGroupToken={user.PrimaryGroupId})";
-                    var primarySearch = SearchLdap(
-                        ldap,
-                        _options.LdapSearchBase,
-                        LdapConnection.ScopeSub,
-                        primaryFilter,
-                        new[] { "distinguishedName" },
-                        false,
-                        _searchConstraints);
-
-                    if (primarySearch.HasMore())
+                    try
                     {
-                        var primaryDn = primarySearch.Next().Dn;
-                        if (DnMatchesGroup(primaryDn, groupName))
-                            return Task.FromResult(true);
+                        using var ldap = BindAsServiceAccount();
+                        var primaryFilter = FormattableString.Invariant(
+                            $"(primaryGroupToken={primaryGroupToken})");
+                        var primarySearch = SearchLdap(
+                            ldap,
+                            _options.LdapSearchBase,
+                            LdapConnection.ScopeSub,
+                            primaryFilter,
+                            new[] { "distinguishedName" },
+                            false,
+                            _searchConstraints);
+
+                        if (primarySearch.HasMore())
+                        {
+                            var primaryDn = primarySearch.Next().Dn;
+                            if (DnMatchesGroup(primaryDn, groupName))
+                                return Task.FromResult(true);
+                        }
+                    }
+                    catch (Exception ex) when (ex is LdapException || ex is DirectoryUnavailableException)
+                    {
+                        // Not a fallback: the user's primary group is now unknown, so a
+                        // "not a member" answer can no longer be justified.
+                        undetermined ??= ex;
+                        ServiceAccountFailure.Log(
+                            Logger, correlationId: null, "resolve primary group by primaryGroupToken",
+                            ServiceAccountHost(), ex);
                     }
                 }
-                catch (Exception ex) when (ex is LdapException || ex is DirectoryUnavailableException)
+                else
                 {
-                    // Not a fallback: the user's primary group is now unknown, so a
-                    // "not a member" answer can no longer be justified.
-                    undetermined ??= ex;
-                    ServiceAccountFailure.Log(
-                        Logger, correlationId: null, "resolve primary group by primaryGroupToken",
-                        ServiceAccountHost(), ex);
+                    // The RID is unusable, so the primary group cannot be resolved for
+                    // this account at all. That is the same outcome as a failed search —
+                    // membership through the primary group is unknown, not absent.
+                    // Treating it as absent would let a malformed attribute reopen the
+                    // deny-list hole that the undetermined handling exists to close.
+                    undetermined ??= new FormatException(
+                        FormattableString.Invariant(
+                            $"primaryGroupID '{user.PrimaryGroupId}' is not an integer RID."));
+                    LogNonNumericPrimaryGroupId(
+                        Logger, user.PrimaryGroupId, user.DistinguishedName, null);
                 }
             }
 
@@ -231,7 +271,13 @@ public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMemb
             try
             {
                 using var ldap = BindAsServiceAccount();
-                var chainFilter = $"(member:1.2.840.113556.1.4.1941:={user.DistinguishedName})";
+                // The DN comes back from the directory, but it is not inert: RFC 4514
+                // DN string form escapes none of '(', ')' or '*', so an account named
+                // e.g. "CN=Smith (Contractor),OU=..." would otherwise produce a
+                // malformed or structurally altered filter — and for a deny-list check
+                // that means a wrong answer rather than a clean error.
+                var chainFilter =
+                    $"(member:1.2.840.113556.1.4.1941:={EscapeLdapSearchFilterValue(user.DistinguishedName)})";
                 var chainSearch = SearchLdap(
                     ldap,
                     _options.LdapSearchBase,

--- a/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/LdapSearchFilterEscapingTests.cs
+++ b/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/LdapSearchFilterEscapingTests.cs
@@ -1,0 +1,278 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Novell.Directory.Ldap;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Unosquare.PassCore.Common;
+using Unosquare.PassCore.Common.Exceptions;
+using Unosquare.PassCore.Common.Models;
+using Xunit;
+
+namespace Zyborg.PassCore.PasswordProvider.LDAP.Tests;
+
+/// <summary>
+/// Every value interpolated into a search filter must be RFC 4515-escaped or
+/// validated to a type with no metacharacters.
+///
+/// <para>The values here are read back from the directory rather than submitted
+/// by the caller, which is why they were treated as inert. They are not. RFC
+/// 4514 DN string form escapes none of <c>(</c>, <c>)</c> or <c>*</c>, so an
+/// account under <c>CN=Smith (Contractor)</c> produces a malformed or
+/// structurally altered filter; and a DN that legitimately contains a backslash
+/// (RFC 4514 escaping of <c>,</c>, <c>+</c>, <c>"</c> and friends) is read by the
+/// server as the start of an RFC 4515 escape sequence. For a deny-list check
+/// that yields a <em>wrong answer</em> rather than a clean error.</para>
+/// </summary>
+public class LdapSearchFilterEscapingTests
+{
+    private const string ChainFilterPrefix = "(member:1.2.840.113556.1.4.1941:=";
+
+    /// <summary>
+    /// One row per metacharacter the task calls out, plus the realistic case that
+    /// motivated it. In every case the filter must stay well-formed and its
+    /// assertion value must denote exactly the user's DN — nothing wider.
+    /// </summary>
+    [Theory]
+    [InlineData("cn=a(b,ou=people,dc=example,dc=com")]
+    [InlineData("cn=a)b,ou=people,dc=example,dc=com")]
+    [InlineData("cn=a*b,ou=people,dc=example,dc=com")]
+    [InlineData(@"cn=a\,b,ou=people,dc=example,dc=com")]
+    [InlineData("cn=Smith (Contractor),ou=people,dc=example,dc=com")]
+    [InlineData("cn=plain,ou=people,dc=example,dc=com")]
+    public async Task ChainFilter_EscapesTheDistinguishedName_AndMatchesOnlyThatEntry(string userDn)
+    {
+        var filters = await CapturedFilters(userDn, primaryGroupId: "1234");
+
+        var chainFilter = Assert.Single(filters.Where(f => f.StartsWith(ChainFilterPrefix, StringComparison.Ordinal)));
+
+        Assert.EndsWith(")", chainFilter, StringComparison.Ordinal);
+
+        var assertionValue = chainFilter[ChainFilterPrefix.Length..^1];
+
+        AssertNoUnescapedMetacharacters(assertionValue);
+
+        // The escaped value must denote the DN exactly: unescaping it round-trips
+        // to the original. A filter that matched more than this entry (a stray '*'
+        // turning it into a substring match) or less than it (a mangled escape)
+        // would fail here.
+        Assert.Equal(userDn, UnescapeRfc4515(assertionValue));
+    }
+
+    /// <summary>
+    /// The <c>primaryGroupToken</c> filter carries a RID. It is validated as an
+    /// integer rather than escaped: an integer has nothing to escape, and the
+    /// attribute is meaningless if it is not one.
+    /// </summary>
+    [Theory]
+    [InlineData("1234")]
+    [InlineData("513")]
+    public async Task PrimaryGroupFilter_CarriesTheValidatedRid(string primaryGroupId)
+    {
+        var filters = await CapturedFilters("cn=u,ou=people,dc=example,dc=com", primaryGroupId);
+
+        var primaryFilter = Assert.Single(filters.Where(f => f.Contains("primaryGroupToken", StringComparison.Ordinal)));
+        Assert.Equal($"(primaryGroupToken={primaryGroupId})", primaryFilter);
+    }
+
+    /// <summary>
+    /// A <c>primaryGroupID</c> that is not an integer must never reach a filter.
+    /// Interpolating it would put attacker-influenced-or-corrupt directory data
+    /// straight into the filter's structure.
+    /// </summary>
+    [Theory]
+    [InlineData("not-a-number")]
+    [InlineData("1234)(objectClass=*")]
+    [InlineData("*")]
+    [InlineData("")]
+    [InlineData(" 513")]
+    [InlineData("0x200")]
+    [InlineData("-1")]
+    public async Task NonNumericPrimaryGroupId_NeverReachesAFilter(string primaryGroupId)
+    {
+        var logger = new CapturingLogger();
+        var provider = Provider("cn=u,ou=people,dc=example,dc=com", primaryGroupId, logger, out var filters);
+
+        // An unresolvable primary group leaves membership undetermined, so the
+        // call fails closed rather than answering from an incomplete picture.
+        // (An empty attribute is simply "no primary group" and is not a failure.)
+        if (primaryGroupId.Length == 0)
+        {
+            Assert.False(await provider.IsMemberOfGroupAsync("u", "RestrictedGroup"));
+        }
+        else
+        {
+            await Assert.ThrowsAsync<DirectoryUnavailableException>(
+                () => provider.IsMemberOfGroupAsync("u", "RestrictedGroup"));
+        }
+
+        Assert.DoesNotContain(filters, f => f.Contains("primaryGroupToken", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The malformed-RID path has to be visible to an operator: it is a
+    /// directory-data problem that starts refusing requests.
+    /// </summary>
+    [Fact]
+    public async Task NonNumericPrimaryGroupId_IsLoggedAtWarningNamingTheAccount()
+    {
+        var logger = new CapturingLogger();
+        var provider = Provider("cn=u,ou=people,dc=example,dc=com", "not-a-number", logger, out _);
+
+        await Assert.ThrowsAsync<DirectoryUnavailableException>(
+            () => provider.IsMemberOfGroupAsync("u", "RestrictedGroup"));
+
+        var entry = Assert.Single(logger.Entries.Where(e => e.EventId.Id == 106));
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("not-a-number", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("cn=u,ou=people,dc=example,dc=com", entry.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The user-lookup filter is the one that was already escaped, and it must
+    /// stay that way — including the domain component appended from configuration.
+    /// </summary>
+    [Theory]
+    [InlineData("jdoe", "ex(ample.com")]
+    [InlineData("jdoe", "ex*ample.com")]
+    [InlineData("jdoe", @"ex\ample.com")]
+    [InlineData("jdoe", "example.com")]
+    public void SanitizeUsername_WithAMetacharacterInTheConfiguredDomain_StillProducesAnInertValue(
+        string username, string defaultDomain)
+    {
+        AssertNoUnescapedMetacharacters(
+            LdapPasswordChangeProvider.SanitizeUsername(username, defaultDomain));
+    }
+
+    /// <summary>
+    /// Asserts the RFC 4515 §3 rule for an assertion value: no bare <c>*</c>,
+    /// <c>(</c>, <c>)</c> or NUL, and every backslash introducing a two-hex-digit
+    /// escape.
+    /// </summary>
+    private static void AssertNoUnescapedMetacharacters(string value)
+    {
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            Assert.True(
+                c is not ('(' or ')' or '*' or '\0'),
+                $"Unescaped metacharacter '{c}' at index {i} in \"{value}\"");
+
+            if (c != '\\') continue;
+
+            Assert.True(
+                i + 2 < value.Length && Uri.IsHexDigit(value[i + 1]) && Uri.IsHexDigit(value[i + 2]),
+                $"Backslash at index {i} in \"{value}\" does not introduce a valid \\XX escape");
+            i += 2;
+        }
+    }
+
+    /// <summary>Reverses <c>EscapeLdapSearchFilterValue</c>, so a filter value can be compared to what it denotes.</summary>
+    private static string UnescapeRfc4515(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (value[i] == '\\')
+            {
+                builder.Append((char)Convert.ToInt32(value.Substring(i + 1, 2), 16));
+                i += 2;
+                continue;
+            }
+
+            builder.Append(value[i]);
+        }
+
+        return builder.ToString();
+    }
+
+    private static async Task<List<string>> CapturedFilters(string userDn, string primaryGroupId)
+    {
+        var provider = Provider(userDn, primaryGroupId, NullLogger<LdapPasswordChangeProvider>.Instance, out var filters);
+
+        // No group matches; the point is which filters were issued along the way.
+        Assert.False(await provider.IsMemberOfGroupAsync("u", "NoSuchGroup"));
+
+        return filters;
+    }
+
+    private static TestLdapPasswordChangeProvider Provider(
+        string userDn,
+        string primaryGroupId,
+        ILogger<LdapPasswordChangeProvider> logger,
+        out List<string> filters)
+    {
+        var options = new LdapPasswordChangeOptions
+        {
+            LdapHostnames = new[] { "ldap.example.com" },
+            LdapPort = 389,
+            LdapUsername = "cn=admin,dc=example,dc=com",
+            LdapPassword = "secret",
+            LdapSearchBase = "dc=example,dc=com",
+            LdapSearchFilter = "(sAMAccountName={Username})",
+        };
+
+        var provider = new TestLdapPasswordChangeProvider(
+            logger,
+            Options.Create(options),
+            Options.Create(new ClientSettings()),
+            Array.Empty<IPasswordPolicy>());
+
+        var attributes = new LdapAttributeSet
+        {
+            new LdapAttribute("distinguishedName", userDn),
+            new LdapAttribute("sAMAccountName", "u"),
+        };
+
+        if (primaryGroupId.Length > 0)
+            attributes.Add(new LdapAttribute("primaryGroupID", primaryGroupId));
+
+        var userEntry = new LdapEntry(userDn, attributes);
+
+        var captured = new List<string>();
+        filters = captured;
+
+        provider.OnSearchLdap = (filter, _) =>
+        {
+            captured.Add(filter);
+
+            var results = new Mock<ILdapSearchResults>();
+            if (filter.Contains("sAMAccountName=", StringComparison.Ordinal))
+            {
+                var remaining = new Queue<LdapEntry>(new[] { userEntry });
+                results.Setup(r => r.HasMore()).Returns(() => remaining.Count > 0);
+                results.Setup(r => r.Next()).Returns(() => remaining.Dequeue());
+            }
+            else
+            {
+                results.Setup(r => r.HasMore()).Returns(false);
+            }
+
+            return results.Object;
+        };
+
+        return provider;
+    }
+
+    private sealed class CapturingLogger : ILogger<LdapPasswordChangeProvider>
+    {
+        public List<(LogLevel Level, EventId EventId, string Message, Exception? Exception)> Entries { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            Entries.Add((logLevel, eventId, formatter(state, exception), exception));
+    }
+}


### PR DESCRIPTION
## Description

**Task 3 of the post-merge remediation series.**

Phase 2 added two filters built by string interpolation, in a class whose summary claimed *"User-supplied input cannot alter the structure of the LDAP search filter"*. Neither value is submitted by the caller — both are read back from the directory — but neither is inert, and the summary's claim was guarding the wrong threat.

## The distinguished name

```csharp
var chainFilter = $"(member:1.2.840.113556.1.4.1941:={user.DistinguishedName})";
```

RFC 4514 DN string form escapes none of `(`, `)` or `*`, so an account under `CN=Smith (Contractor)` produced a malformed or structurally altered filter.

The backslash case is worse and was not in the original report: a DN that legitimately contains one — RFC 4514 escaping of `,`, `+`, `"` and friends, e.g. `CN=Smith\, Jr.,OU=…` — is read by the server as the start of an RFC 4515 escape sequence, so the assertion value silently denotes something *other than* the DN. No error, just a wrong match.

For a deny-list check, either one yields a wrong answer rather than a clean error.

Now escaped with the existing `EscapeLdapSearchFilterValue`. The test proves the property directly rather than pattern-matching the output: it unescapes the produced assertion value and asserts it round-trips to exactly the DN, so the filter matches that entry and nothing wider.

## The primary group RID

```csharp
var primaryFilter = $"(primaryGroupToken={user.PrimaryGroupId})";
```

`primaryGroupID` was read as a string and interpolated with no validation. It is a RID, so it is now parsed as an integer and the *parsed value* is what reaches the filter — an integer has no metacharacter to escape, which is a stronger guarantee than escaping. `NumberStyles.None` also rejects the near-misses that would otherwise slip through: signs, surrounding whitespace, and hex forms.

### One reconciliation with Task 2, worth review attention

Task 3 specifies that a value which does not parse means "primary-group resolution is unavailable for that user (log and skip)". Taken literally as *skip and carry on*, that would let a malformed attribute reopen the exact deny-list hole [#53](https://github.com/EastCentralRegionalLibrary/passcore/pull/53) just closed — an unresolvable primary group would read as "no primary group" and the negative answer would stand.

So the unparseable case is recorded as **undetermined** and the request fails closed, identically to a failed primary-group search. "Primary-group resolution is unavailable for that user" and Task 2's "could not complete" describe the same condition, so they get the same outcome.

An **absent** attribute is unchanged and still simply means "no primary group" — that is not a failure and still proceeds. The malformed case is logged at Warning (EventId 106, next free in the LDAP range, registry updated) naming both the attribute value and the account, since it is a directory-data problem that starts refusing that user's requests.

## Out of scope, deliberately

Search bases and modify targets are untouched. Those are RFC 4514 DN syntax, not RFC 4515 filter syntax — escaping them would corrupt them. Only filter *values* are in scope, per the task's DO-NOT. No new escaping helper was written.

## The `SanitizeUsername` third

Already landed in [#51](https://github.com/EastCentralRegionalLibrary/passcore/pull/51): accepting an unvalidated qualifier made the domain component user input, so it had to be escaped there or that PR would have introduced an injection vector of its own. The remaining criterion — a configured `DefaultDomain` containing a metacharacter — is covered here.

## Tests

- A DN containing each of `(`, `)`, `*`, `\`, plus the realistic `CN=Smith (Contractor)` case and a plain control. Each asserts the filter is well-formed, carries no unescaped metacharacter, and that its assertion value unescapes back to exactly the DN.
- Non-numeric, injection-shaped (`1234)(objectClass=*`), signed, whitespace-padded and hex `primaryGroupID` values never reach a filter.
- The absent-attribute case still returns a normal "not a member" and proceeds.
- The malformed-RID path is logged at Warning with EventId 106, naming the value and the account.
- `SanitizeUsername` output stays inert for a `DefaultDomain` containing `(`, `*` or `\`.

**Verified the new tests fail against the unescaped implementation** — reverting the DN escaping produces 5 failures rather than passing vacuously. Existing `LdapUsernameSanitizationTests` and `GroupMembershipParityTests` behavior is unchanged.

Suite: 567 tests across all four projects (was 547; +20).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Testing/CI harness

## Checklist
- [x] All new code compiles under .NET 8.
- [x] `dotnet test` passes locally — 567 tests, all four projects.
- [x] No external network calls are made in unit tests.
- [x] Documentation (if applicable) is updated — the class summary now states what is actually guaranteed, and why it extends to directory-sourced values; the EventId registry records 106.
- [x] Debug provider is gated by `#if DEBUG` and cannot be enabled in Production — untouched.
- [ ] (Optional) Example e2e test runs against the Docker Compose test stack — the smoke-test fixture DNs contain no metacharacters, so this is covered by unit tests instead.

Note: this PR touches only the LDAP provider and `PasswordChangeProviderBase`, so it needs no Windows compile (unlike #53). The AD-provider CI gap noted there still stands as separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsJRsb3rUAuacypogW9ZEN

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsJRsb3rUAuacypogW9ZEN)_