### PR TITLE
Add a Hardened-mode leg to the LDAP smoke test

### DIFF
--- a/.github/workflows/ldap-provider-smoke-test.yml
+++ b/.github/workflows/ldap-provider-smoke-test.yml
@@ -299,9 +299,20 @@ jobs:
         run: |
           set -uo pipefail
           echo "An authorized user with the correct password must NOT be refused."
+
+          # testuser, not alloweduser. Both are in AllowedGroup, but Test 1 of the
+          # Informative leg submits a change for alloweduser and deliberately
+          # tolerates either outcome (success, or a non-authorization error if
+          # MokAPI does not implement the modify). That leaves alloweduser's current
+          # password indeterminate from here: if the change succeeded it is now
+          # NewPassword123!, so submitting testpassword would be a genuinely wrong
+          # password and the 4 it earns would say nothing about Hardened mode.
+          # testuser is deterministic - every earlier request for it (Informative
+          # Test 2, and row 6 of Step B) uses a wrong password on purpose, so no
+          # earlier step can have rotated it.
           RESPONSE=$(curl -s -X POST http://localhost:5000/api/password \
             -H "Content-Type: application/json" \
-            -d '{"username": "alloweduser", "currentPassword": "testpassword", "newPassword": "NewPassword123!", "newPasswordVerify": "NewPassword123!"}')
+            -d '{"username": "testuser", "currentPassword": "testpassword", "newPassword": "NewPassword123!", "newPasswordVerify": "NewPassword123!"}')
           echo "Response: $RESPONSE"
 
           # Same tolerance as Test 1 in the Informative leg: MokAPI may not fully
@@ -311,7 +322,7 @@ jobs:
           ERROR_CODE=$(printf '%s' "$RESPONSE" | jq -r '.errors[0].errorCode // empty' 2>/dev/null || true)
           # 3: UserNotFound, 4: InvalidCredentials, 6: ChangeNotPermitted
           if [[ "$ERROR_CODE" == "3" || "$ERROR_CODE" == "4" || "$ERROR_CODE" == "6" ]]; then
-            echo "::error::alloweduser with the correct password returned '${ERROR_CODE}'. Hardened mode is refusing an authorized user, so Step B's uniform responses prove nothing."
+            echo "::error::testuser with the correct password returned '${ERROR_CODE}'. Hardened mode is refusing an authorized user, so Step B's uniform responses prove nothing."
             exit 1
           fi
           echo "Positive control passed."
@@ -321,6 +332,11 @@ jobs:
           echo "Stopping MokAPI..."
           docker stop mokapi
 
+          # testuser's password may have been rotated by the Hardened positive
+          # control just above, so testpassword is not necessarily current here.
+          # That does not matter: MokAPI is stopped, so this must fail on
+          # connectivity (8), and a wrong password (4) is accepted by this
+          # assertion anyway. Both outcomes are posture-independent.
           echo "Attempting password change during LDAP outage..."
           RESPONSE=$(curl -s -X POST http://localhost:5000/api/password \
             -H "Content-Type: application/json" \

--- a/.github/workflows/ldap-provider-smoke-test.yml
+++ b/.github/workflows/ldap-provider-smoke-test.yml
@@ -109,7 +109,9 @@ jobs:
             -H "Content-Type: application/json" \
             -d '{"username": "nonexistent", "currentPassword": "somepassword", "newPassword": "NewPassword123!", "newPasswordVerify": "NewPassword123!"}')
           echo "Response: $RESPONSE"
-          # With "ErrorDisclosureMode": "Hardened" (default), it returns InvalidCredentials (4)
+          # This leg runs with "ErrorDisclosureMode": "Informative", which discloses an
+          # unknown user as UserNotFound (3). The Hardened leg below asserts that the
+          # same request returns InvalidCredentials (4) instead.
           echo $RESPONSE | jq -e '.errors[] | select(.errorCode == 3)'
 
           echo "Test 4: User in restricted group"
@@ -129,6 +131,190 @@ jobs:
           echo "Response: $RESPONSE"
           # 6: ChangeNotPermitted
           echo $RESPONSE | jq -e '.errors[] | select(.errorCode == 6)'
+
+      # ---------------------------------------------------------------------
+      # Hardened leg.
+      #
+      # Hardened is the shipped default and the posture the indistinguishability
+      # work exists to provide, but appsettings.LdapTest.json pins Informative, so
+      # until now it had no end-to-end coverage at all. The same config file is
+      # reused unchanged; only the posture differs, overridden at runtime.
+      # ---------------------------------------------------------------------
+      - name: Restart Passcore in Hardened mode
+        shell: bash
+        env:
+          # Layered over the unchanged appsettings.LdapTest.json. ASP.NET Core's
+          # default configuration chain reads environment variables after the JSON
+          # files, so this wins. It has to be a process environment variable:
+          # configuration appended as arguments after the program path is what made
+          # the earlier Docker fix silently ineffective.
+          AppSettings__ErrorDisclosureMode: Hardened
+        run: |
+          set -uo pipefail
+
+          # `dotnet run` is a launcher: backend.pid holds the launcher, and killing
+          # it does not reliably kill the child holding port 5000. Terminate by
+          # listener instead. If the old instance survived, the new one would fail
+          # to bind and every assertion below would silently be measuring the old
+          # Informative process, so the port being free is verified before starting.
+          # Whichever of these the runner image provides. Not all are guaranteed,
+          # so the port being free is confirmed over HTTP below rather than by
+          # trusting any one of them to have found the process.
+          listeners() {
+            {
+              if command -v lsof >/dev/null 2>&1; then
+                lsof -t -iTCP:5000 -sTCP:LISTEN 2>/dev/null
+              elif command -v ss >/dev/null 2>&1; then
+                ss -H -ltnp 'sport = :5000' 2>/dev/null | grep -o 'pid=[0-9]*' | cut -d= -f2
+              elif command -v fuser >/dev/null 2>&1; then
+                fuser 5000/tcp 2>/dev/null | tr -s ' ' '\n'
+              fi
+            } | grep -E '^[0-9]+$' | sort -u || true
+          }
+
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+            pids="$(listeners)"
+            if [ -z "$pids" ]; then
+              break
+            fi
+            echo "Attempt ${attempt}: stopping PID(s) on port 5000: ${pids}"
+            # shellcheck disable=SC2086
+            kill ${pids} 2>/dev/null || true
+            sleep 2
+          done
+
+          pids="$(listeners)"
+          if [ -n "$pids" ]; then
+            echo "Escalating to SIGKILL for: ${pids}"
+            # shellcheck disable=SC2086
+            kill -9 ${pids} 2>/dev/null || true
+            sleep 2
+          fi
+
+          # The authoritative check: nothing may still answer on the port.
+          if ! timeout 30s bash -c 'while curl -fsS http://localhost:5000/api/password >/dev/null 2>&1; do sleep 1; done'; then
+            echo "::error::Port 5000 is still serving after the previous instance was terminated. The Hardened leg cannot start."
+            exit 1
+          fi
+          echo "Port 5000 is free."
+
+          dotnet run \
+            --no-launch-profile \
+            --project src/Unosquare.PassCore.Web/Unosquare.PassCore.Web.csproj \
+            --configuration Release \
+            --framework net8.0 \
+            --property:PASSCORE_PROVIDER=LDAP \
+            --no-build &
+          echo $! > backend.pid
+
+          echo "Waiting for Passcore (Hardened)..."
+          timeout 90s bash -c '
+            until curl -fsS http://localhost:5000/api/password >/dev/null; do
+              sleep 3
+            done
+          '
+          echo "Passcore restarted."
+
+      - name: Hardened Step A - restart verification
+        run: |
+          set -uo pipefail
+          echo "Unknown user must be indistinguishable from a wrong password in Hardened mode."
+          RESPONSE=$(curl -s -X POST http://localhost:5000/api/password \
+            -H "Content-Type: application/json" \
+            -d '{"username": "nonexistent", "currentPassword": "somepassword", "newPassword": "NewPassword123!", "newPasswordVerify": "NewPassword123!"}')
+          echo "Response: $RESPONSE"
+
+          CODE=$(printf '%s' "$RESPONSE" | jq -r '.errors[0].errorCode // empty' 2>/dev/null || true)
+          if [ "$CODE" != "4" ]; then
+            echo "::error::Expected InvalidCredentials (4) for an unknown user in Hardened mode, got '${CODE}'."
+            echo "This step runs first precisely to catch a failed restart. In Informative mode this same"
+            echo "request returns UserNotFound (3), so a '3' here almost certainly means the runtime"
+            echo "override did not take effect - most likely the previous Informative instance is still"
+            echo "bound to port 5000 and answering these requests."
+            exit 1
+          fi
+          echo "Restart confirmed: running in Hardened mode."
+
+      - name: Hardened Step B - indistinguishability
+        run: |
+          set -uo pipefail
+
+          # Every condition below must be masked behind one identical response.
+          # Rows 1 and 3 are the ones a well-meaning change is most likely to
+          # special-case: a correct password for an account refused on group
+          # grounds must not be distinguishable from anything else here.
+          declare -a labels=() bodies=() normalized=()
+          fail=0
+
+          probe() {
+            local label="$1" username="$2" password="$3"
+            local response errors code message
+
+            response=$(curl -s -X POST http://localhost:5000/api/password \
+              -H "Content-Type: application/json" \
+              -d "{\"username\": \"${username}\", \"currentPassword\": \"${password}\", \"newPassword\": \"NewPassword123!\", \"newPasswordVerify\": \"NewPassword123!\"}" || true)
+
+            errors=$(printf '%s' "$response" | jq -S -c '.errors' 2>/dev/null || true)
+            code=$(printf '%s' "$response" | jq -r '.errors[0].errorCode // empty' 2>/dev/null || true)
+            message=$(printf '%s' "$response" | jq -r '.errors[0].message // empty' 2>/dev/null || true)
+
+            labels+=("$label")
+            bodies+=("$response")
+            normalized+=("$errors")
+
+            if [ "$code" != "4" ] || [ "$message" != "Invalid username or password" ]; then
+              echo "::error::${label}: expected errorCode 4 with message 'Invalid username or password', got errorCode '${code}' with message '${message}'."
+              fail=1
+            fi
+          }
+
+          probe "1 restricteduser + correct password (in RestrictedGroup)" restricteduser testpassword
+          probe "2 restricteduser + wrong password"                       restricteduser wrongpassword
+          probe "3 unlisteduser + correct password (in no group)"         unlisteduser   testpassword
+          probe "4 unlisteduser + wrong password"                         unlisteduser   wrongpassword
+          probe "5 nonexistent account"                                   nonexistent    anything
+          probe "6 testuser + wrong password (exists, authorized)"        testuser       wrongpassword
+
+          # Byte-identical, not merely all code 4: the message has to match too.
+          for i in "${!normalized[@]}"; do
+            if [ "${normalized[$i]}" != "${normalized[0]}" ]; then
+              echo "::error::'${labels[$i]}' is distinguishable from '${labels[0]}'."
+              fail=1
+            fi
+          done
+
+          if [ "$fail" -ne 0 ]; then
+            echo "----- all six responses -----"
+            for i in "${!bodies[@]}"; do
+              echo "${labels[$i]}"
+              echo "  ${bodies[$i]}"
+            done
+            echo "-----------------------------"
+            echo "A failure here is a real finding in the Hardened implementation, not a stale assertion."
+            exit 1
+          fi
+          echo "All six conditions produced identical responses."
+
+      - name: Hardened Step C - positive control
+        run: |
+          set -uo pipefail
+          echo "An authorized user with the correct password must NOT be refused."
+          RESPONSE=$(curl -s -X POST http://localhost:5000/api/password \
+            -H "Content-Type: application/json" \
+            -d '{"username": "alloweduser", "currentPassword": "testpassword", "newPassword": "NewPassword123!", "newPasswordVerify": "NewPassword123!"}')
+          echo "Response: $RESPONSE"
+
+          # Same tolerance as Test 1 in the Informative leg: MokAPI may not fully
+          # implement the change operation, so success or a non-authorization error
+          # is acceptable - but never an authorization/existence error. Without this
+          # control, a server answering 4 unconditionally would satisfy Step B.
+          ERROR_CODE=$(printf '%s' "$RESPONSE" | jq -r '.errors[0].errorCode // empty' 2>/dev/null || true)
+          # 3: UserNotFound, 4: InvalidCredentials, 6: ChangeNotPermitted
+          if [[ "$ERROR_CODE" == "3" || "$ERROR_CODE" == "4" || "$ERROR_CODE" == "6" ]]; then
+            echo "::error::alloweduser with the correct password returned '${ERROR_CODE}'. Hardened mode is refusing an authorized user, so Step B's uniform responses prove nothing."
+            exit 1
+          fi
+          echo "Positive control passed."
 
       - name: LDAP Environment Failure Test
         run: |
@@ -154,8 +340,34 @@ jobs:
 
       - name: Stop Services
         if: always()
+        shell: bash
         run: |
-          if [ -f backend.pid ]; then
-            kill "$(cat backend.pid)" || true
+          set -uo pipefail
+
+          # Either leg's instance may be the one running, and backend.pid holds a
+          # `dotnet run` launcher rather than the process that owns the port, so
+          # terminate by listener and use the pid file only as a backstop.
+          pids="$(
+            {
+              if command -v lsof >/dev/null 2>&1; then
+                lsof -t -iTCP:5000 -sTCP:LISTEN 2>/dev/null
+              elif command -v ss >/dev/null 2>&1; then
+                ss -H -ltnp 'sport = :5000' 2>/dev/null | grep -o 'pid=[0-9]*' | cut -d= -f2
+              elif command -v fuser >/dev/null 2>&1; then
+                fuser 5000/tcp 2>/dev/null | tr -s ' ' '\n'
+              fi
+            } | grep -E '^[0-9]+$' | sort -u || true
+          )"
+          if [ -n "$pids" ]; then
+            # shellcheck disable=SC2086
+            kill ${pids} 2>/dev/null || true
+            sleep 2
+            # shellcheck disable=SC2086
+            kill -9 ${pids} 2>/dev/null || true
           fi
+
+          if [ -f backend.pid ]; then
+            kill "$(cat backend.pid)" 2>/dev/null || true
+          fi
+
           docker stop mokapi || true


### PR DESCRIPTION
## Description

**Task 4 of the post-merge remediation series.**

`appsettings.LdapTest.json` pins `ErrorDisclosureMode` to `Informative`, so the LDAP integration workflow only ever exercised that posture. Hardened is the shipped default and the posture the indistinguishability work exists to provide — and it had **no end-to-end coverage at all**.

The existing Informative leg is correct and stays. This **adds** a second leg against the same unchanged config file.

## Mechanism

The posture is overridden at runtime via the `AppSettings__ErrorDisclosureMode` **process environment variable**, set through the step's `env:` block. ASP.NET Core reads environment variables after the JSON files in its default configuration chain, so the override wins. It is not appended as an argument after the program path — that is how the earlier Docker fix was silently ineffective. `appsettings.LdapTest.json` is untouched and no new `appsettings.*.json` is added; the job-level `ASPNETCORE_ENVIRONMENT: LdapTest` stays as-is.

### Restarting is the delicate part

`dotnet run` is a launcher, so `backend.pid` holds a process that is **not** the one bound to port 5000 — killing it leaves the old instance serving. I confirmed this failure mode locally before relying on the fix.

The new leg terminates **by listener** instead, trying `lsof`, then `ss`, then `fuser` (no single one is guaranteed on the runner image — `ss` is absent from the container I developed in, which is exactly why the lookup does not depend on any one of them). It then **confirms over HTTP** that nothing answers on the port before starting the replacement. If the port cannot be freed, the step fails right there rather than letting every assertion below silently measure the old process.

`Stop Services` uses the same listener-based termination so it ends whichever leg's instance is running, keeping the pid file only as a backstop.

## The three assertion steps

**Step A — restart verification, runs first.** An unknown user must return `InvalidCredentials (4)`. The same request returns `UserNotFound (3)` in Informative, so a silently failed restart fails *here*, loudly and with the likely cause named, instead of passing the rest by accident.

**Step B — indistinguishability.** Six conditions must produce **byte-identical** responses — same code *and* same message, not merely all code 4:

| # | Username | Password | Condition being masked |
|---|---|---|---|
| 1 | `restricteduser` | correct | in `RestrictedGroup`, correct credentials |
| 2 | `restricteduser` | wrong | in `RestrictedGroup`, wrong credentials |
| 3 | `unlisteduser` | correct | in no group, fails `AllowedGroup` |
| 4 | `unlisteduser` | wrong | in no group, wrong credentials |
| 5 | `nonexistent` | anything | account does not exist |
| 6 | `testuser` | wrong | exists, authorized, wrong credentials |

Rows 1 and 3 are the ones a well-meaning change is most likely to special-case. On failure every response body is printed so the divergence is visible.

**Step C — positive control.** Without it, a server answering `4` unconditionally would satisfy Step B. `alloweduser` with the correct password must not produce `3`, `4` or `6`, using the same tolerance as Test 1 in the Informative leg (MokAPI may not fully implement the change operation).

## Placement

Between `LDAP Success and Authorization Tests` and `LDAP Environment Failure Test`. The latter's assertions (`4` or `8`) are posture-independent, so nothing is restored to Informative afterwards.

## Also fixed

Test 3's comment in the Informative leg described Hardened behavior while asserting the Informative result. Comment corrected; **assertion unchanged**.

## Verification

I did not want to push assertion logic I had only syntax-checked, particularly given the instruction that a Hardened failure must be reported rather than tuned away — that only holds if the harness itself is trustworthy. So I replayed the three steps against a stub PassCore in four postures, under GitHub's actual shell flags:

| Stub posture | Expected | Result |
|---|---|---|
| Correct Hardened | A, B, C pass | ✅ all pass |
| Special-cases row 1 (restricted + correct password → 6) | B fails | ✅ B fails, naming row 1 and each divergence |
| Restart silently failed, still Informative | A fails | ✅ A fails with "got '3'" and the likely cause |
| Answers `4` unconditionally | B passes, C fails | ✅ C catches it |

The termination logic was checked against a launcher whose child owns the port — reproducing the failure mode first (child survives the launcher kill), then confirming the port is freed — and against a case where the port cannot be freed, where the step fails after 30s with an explicit error rather than proceeding.

Fixture confirmed against `tests/mokapi/users.ldif`: `testuser` and `alloweduser` in `AllowedGroup`, `restricteduser` in `RestrictedGroup`, `unlisteduser` in no group, all four with `testpassword`.

## Diff scope

Only `.github/workflows/ldap-provider-smoke-test.yml` changes. Exactly two lines are removed — the stale comment, and the unreliable `kill "$(cat backend.pid)"` in `Stop Services` that the task requires replacing. Everything else is additive. No `ErrorDisclosureMode` default changed, nothing added to `ClientSettings`.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [x] Testing/CI harness

## Checklist
- [x] All new code compiles under .NET 8 — no application code changed.
- [x] `dotnet test` passes locally — unaffected; 567 tests still pass.
- [x] No external network calls are made in unit tests.
- [x] Documentation (if applicable) is updated — the rationale for each step lives in comments beside it.
- [x] Debug provider is gated by `#if DEBUG` and cannot be enabled in Production — untouched.
- [x] (Optional) Example e2e test runs against the Docker Compose test stack — this PR *is* the e2e coverage, extending the existing MokAPI-backed workflow.

## Note for reviewers

This is the first time Hardened mode is exercised end to end. If Step B fails on this run, that is a **real finding in the Hardened implementation**, not a stale assertion — per the task's instruction I would report it rather than adjust the assertion to match observed behavior. I'll follow up on the CI result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsJRsb3rUAuacypogW9ZEN

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsJRsb3rUAuacypogW9ZEN)_