### PR TITLE
Route the last ad-hoc log call through a delegate and guard the EventId registry

### DIFF
--- a/src/Unosquare.PassCore.Common/PasswordChangeProviderBase.cs
+++ b/src/Unosquare.PassCore.Common/PasswordChangeProviderBase.cs
@@ -38,7 +38,8 @@ public abstract class PasswordChangeProviderBase : IPasswordChangeProvider, IDis
     // everywhere. Ranges, and the next free number in each:
     //
     //   1-9      this base class (password-change and policy lifecycle)   next: 10
-    //   100-106  provider-specific events (LDAP 100-102, 104, 106; AD 103) next: 107
+    //   100-107  provider-specific events                                  next: 108
+    //            LDAP: 100, 101, 102, 104, 106, 107.  AD: 103.
     //            105 is retired: it logged a group-enumeration failure as an
     //            expected Debug-level fallback, which no longer exists. Such a
     //            failure now leaves membership undetermined and is reported via

--- a/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeProvider.cs
+++ b/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeProvider.cs
@@ -95,6 +95,20 @@ public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMemb
             "performed by the service account. Remove AllowAdministrativeReset or switch to the " +
             "delete/add mechanism if a fallback from a user-style change is what you want.");
 
+    // Debug, deliberately, and unlike the group-enumeration failures that were
+    // raised to Warning: this one really is a fallback. GetDomainNcRootFallback
+    // derives the domain NC from the configured search base, the minimum-length
+    // lookup continues, and a wrong answer here is still caught downstream by
+    // DomainPasswordPolicy's own Warning (EventId 112) when the lookup as a whole
+    // fails. Nothing is degraded silently, so this stays diagnostic detail.
+    private static readonly Action<ILogger, Exception?> LogRootDseQueryFailed =
+        LoggerMessage.Define(
+            LogLevel.Debug,
+            new EventId(107, nameof(LogRootDseQueryFailed)),
+            "Failed to query defaultNamingContext from the rootDSE; falling back to deriving the " +
+            "domain naming context from the configured LdapSearchBase. The minimum-length lookup " +
+            "continues, and reports its own failure separately if the fallback does not resolve.");
+
     private static readonly Action<ILogger, string?, string, Exception?> LogNonNumericPrimaryGroupId =
         LoggerMessage.Define<string?, string>(
             LogLevel.Warning,
@@ -372,7 +386,7 @@ public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMemb
         }
         catch (Exception ex) when (ex is LdapException || ex is DirectoryUnavailableException)
         {
-            Logger.LogDebug(ex, "Failed to query defaultNamingContext from rootDSE. Falling back to search base extraction.");
+            LogRootDseQueryFailed(Logger, ex);
         }
 
         if (string.IsNullOrEmpty(domainNcRootDn))

--- a/tests/Unosquare.PassCore.Common.Tests/LoggingConventionAuditTests.cs
+++ b/tests/Unosquare.PassCore.Common.Tests/LoggingConventionAuditTests.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Unosquare.PassCore.Common.Tests;
+
+/// <summary>
+/// Guards the two logging rules the providers are built around: every log
+/// statement goes through a <c>LoggerMessage.Define</c> delegate with an
+/// allocated EventId, and an EventId means exactly one thing everywhere.
+///
+/// <para>The second rule is the one that needs a test. Provider selection is
+/// build-time, so an AD-built and an LDAP-built instance never share a process
+/// — but their logs are routinely aggregated together, so a number reused
+/// across providers silently merges two unrelated conditions in whatever the
+/// operator greps. Nothing in the compiler notices; only the registry comment in
+/// <see cref="PasswordChangeProviderBase"/> records the allocation, and a
+/// comment cannot enforce itself.</para>
+///
+/// <para>Scanning source rather than reflecting over the assemblies is
+/// deliberate: the AD provider is <c>net8.0-windows</c> inside
+/// <c>#if WINDOWS</c> and cannot be loaded here at all, so half the allocation
+/// would be invisible to a runtime check.</para>
+/// </summary>
+public class LoggingConventionAuditTests
+{
+    private const string RegistryRelativePath =
+        "src/Unosquare.PassCore.Common/PasswordChangeProviderBase.cs";
+
+    private static readonly string[] ProviderPaths =
+    [
+        "src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeProvider.cs",
+        "src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs",
+    ];
+
+    private static readonly Regex EventIdDeclaration =
+        new(@"new EventId\(\s*(?<id>\d+)", RegexOptions.CultureInvariant);
+
+    /// <summary>Ad-hoc <c>ILogger</c> extension calls, which bypass the delegate convention (and trip CA1848).</summary>
+    private static readonly Regex AdHocLoggerCall =
+        new(@"Logger\.Log(Trace|Debug|Information|Warning|Error|Critical)\s*\(", RegexOptions.CultureInvariant);
+
+    [Fact]
+    public void EveryEventId_IsAllocatedExactlyOnce()
+    {
+        var byId = new Dictionary<int, List<string>>();
+
+        foreach (var (relativePath, source) in SolutionSources())
+        {
+            foreach (Match match in EventIdDeclaration.Matches(source))
+            {
+                var id = int.Parse(match.Groups["id"].Value, System.Globalization.CultureInfo.InvariantCulture);
+                if (!byId.TryGetValue(id, out var sites))
+                    byId[id] = sites = new List<string>();
+
+                sites.Add(relativePath);
+            }
+        }
+
+        var duplicates = byId
+            .Where(entry => entry.Value.Count > 1)
+            .Select(entry => $"EventId {entry.Key} declared in: {string.Join(", ", entry.Value)}")
+            .ToList();
+
+        Assert.True(
+            duplicates.Count == 0,
+            "An EventId is declared more than once. Provider logs are aggregated together, so a reused " +
+            "number merges two unrelated conditions for whoever is reading them:\n  " +
+            string.Join("\n  ", duplicates));
+    }
+
+    /// <summary>
+    /// 105 logged a group-enumeration failure as an expected Debug-level
+    /// fallback. That fallback no longer exists — such a failure now leaves
+    /// membership undetermined and is reported via <c>ServiceAccountFailure</c>
+    /// (111) — and the ID stays retired rather than being recycled, so a
+    /// historical log search for it cannot turn up something unrelated.
+    /// </summary>
+    [Fact]
+    public void RetiredEventId105_IsNotAllocatedAnywhere()
+    {
+        var offenders = SolutionSources()
+            .Where(file => EventIdDeclaration.Matches(file.Source)
+                .Any(m => m.Groups["id"].Value == "105"))
+            .Select(file => file.RelativePath)
+            .ToList();
+
+        Assert.True(
+            offenders.Count == 0,
+            $"EventId 105 is retired but was allocated in: {string.Join(", ", offenders)}.");
+    }
+
+    /// <summary>
+    /// Every allocated ID has to sit inside a range the registry declares, and
+    /// each range's "next free" has to be one past its end. Adding a delegate
+    /// without updating the registry fails here rather than quietly drifting.
+    /// </summary>
+    [Fact]
+    public void RegistryRanges_CoverEveryAllocatedEventId_AndDeclareTheCorrectNextFree()
+    {
+        var ranges = DeclaredRanges();
+        Assert.NotEmpty(ranges);
+
+        foreach (var (low, high, next) in ranges)
+        {
+            Assert.True(
+                next == high + 1,
+                $"Registry range {low}-{high} declares 'next: {next}', but the next free number after " +
+                $"{high} is {high + 1}. Update the range or the next-free value in {RegistryRelativePath}.");
+        }
+
+        foreach (var (relativePath, source) in SolutionSources())
+        {
+            foreach (Match match in EventIdDeclaration.Matches(source))
+            {
+                var id = int.Parse(match.Groups["id"].Value, System.Globalization.CultureInfo.InvariantCulture);
+
+                Assert.True(
+                    ranges.Any(r => id >= r.Low && id <= r.High),
+                    $"EventId {id} in {relativePath} falls outside every range declared in the allocation " +
+                    $"registry in {RegistryRelativePath}. Extend the appropriate range and its next-free " +
+                    "value, or take a number from within one.");
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void Providers_UseLoggerMessageDelegatesRatherThanAdHocLoggerCalls(int providerIndex)
+    {
+        var relativePath = ProviderPaths[providerIndex];
+        var source = ReadRepoFile(relativePath);
+
+        var offenders = AdHocLoggerCall.Matches(source)
+            .Select(m => $"{m.Value.TrimEnd('(', ' ')} at offset {m.Index}")
+            .ToList();
+
+        Assert.True(
+            offenders.Count == 0,
+            $"{relativePath} calls ILogger extension methods directly instead of going through a " +
+            "LoggerMessage.Define delegate with an allocated EventId. These allocate on every call " +
+            "(CA1848) and, more importantly, carry no EventId, so they cannot be filtered or traced:\n  " +
+            string.Join("\n  ", offenders));
+    }
+
+    /// <summary>Parses the <c>low-high … next: n</c> rows out of the registry comment block.</summary>
+    private static List<(int Low, int High, int Next)> DeclaredRanges()
+    {
+        var registry = ReadRepoFile(RegistryRelativePath);
+
+        var start = registry.IndexOf("EventId allocation across the solution", StringComparison.Ordinal);
+        Assert.True(start >= 0, $"Could not find the EventId allocation registry in {RegistryRelativePath}.");
+
+        var end = registry.IndexOf("never reuse or", start, StringComparison.Ordinal);
+        Assert.True(end > start, "Could not find the end of the EventId allocation registry comment.");
+
+        var block = registry[start..end];
+
+        // Ranges and their next-free values appear in matching order, but not
+        // always on the same line (a long description wraps).
+        var lows = Regex.Matches(block, @"(?<low>\d+)-(?<high>\d+)\s").Select(
+            m => (Low: int.Parse(m.Groups["low"].Value, System.Globalization.CultureInfo.InvariantCulture),
+                  High: int.Parse(m.Groups["high"].Value, System.Globalization.CultureInfo.InvariantCulture))).ToList();
+
+        var nexts = Regex.Matches(block, @"next:\s*(?<next>\d+)").Select(
+            m => int.Parse(m.Groups["next"].Value, System.Globalization.CultureInfo.InvariantCulture)).ToList();
+
+        Assert.True(
+            lows.Count == nexts.Count,
+            $"The registry declares {lows.Count} ranges but {nexts.Count} next-free values; they must pair up.");
+
+        return lows.Zip(nexts, (r, next) => (r.Low, r.High, next)).ToList();
+    }
+
+    private static IEnumerable<(string RelativePath, string Source)> SolutionSources()
+    {
+        var root = Path.Join(RepositoryRoot(), "src");
+
+        foreach (var path in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories)
+                     .Where(p => !p.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                              && !p.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                     .OrderBy(p => p, StringComparer.Ordinal))
+        {
+            yield return (Path.GetRelativePath(RepositoryRoot(), path), File.ReadAllText(path));
+        }
+    }
+
+    private static string ReadRepoFile(string relativePath)
+    {
+        var path = Path.Join(RepositoryRoot(), relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Assert.True(File.Exists(path), $"Expected to find '{relativePath}' at '{path}'.");
+
+        return File.ReadAllText(path);
+    }
+
+    private static string RepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory != null)
+        {
+            if (File.Exists(Path.Join(directory.FullName, "Unosquare.PassCore.sln")))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException(
+            "Could not locate the repository root (no Unosquare.PassCore.sln found above " +
+            $"'{AppContext.BaseDirectory}'). This audit reads provider source, so it must run from a checkout.");
+    }
+}


### PR DESCRIPTION
## Description

**Task 5 of the post-merge remediation series** — completing the logging cleanup.

Most of this task landed with [#53](https://github.com/EastCentralRegionalLibrary/passcore/pull/53), which had to move three of the four ad-hoc calls onto `ServiceAccountFailure` at Warning as part of its own semantics, and retired **EventId 105** — whose message had inverted during an earlier refactor, naming `GetGroups()` as the call that failed when it actually fired for `GetAuthorizationGroups()`.

### What remained

The rootDSE lookup in the LDAP provider, now a `LoggerMessage.Define` delegate with **EventId 107** (next free in the provider range).

**Its level stays Debug, deliberately** — and unlike the group enumerations, it is not being raised. This one genuinely *is* a fallback: `GetDomainNcRootFallback` derives the domain naming context from the configured search base, the minimum-length lookup continues, and if the fallback does not resolve either, `DomainPasswordPolicy` reports that separately at Warning (EventId 112). Nothing degrades silently, so it stays diagnostic detail. The message is reworded to describe the actual fallback rather than naming an internal method.

**CA1848 now reports zero occurrences in both providers.** The AD provider cannot be built on Linux, so it was verified by forcing the Windows target with the guarded code compiled in — the same approach used to verify #53's AD changes.

I also reviewed every remaining delegate message against its trigger and delegate name; 105 was the only inaccurate one, and it is gone.

## The registry audit

The allocation comment in `PasswordChangeProviderBase` is the only record of which number means what, and a comment cannot enforce itself. This adds `LoggingConventionAuditTests` covering four properties:

| Check | Why it matters |
|---|---|
| Every EventId in `src/` is declared exactly once | Provider selection is build-time, but AD and LDAP logs are routinely aggregated — a reused number silently merges two unrelated conditions in whatever the operator greps |
| 105 stays retired, never recycled | A historical log search for it must not turn up something unrelated |
| Every allocated ID sits in a declared range, and each range's next-free is one past its end | Adding a delegate without updating the registry fails, rather than drifting |
| Neither provider calls an `ILogger` extension directly | The convention itself; also what CA1848 flags |

The audit reads **source** rather than reflecting over assemblies, because the AD provider is `net8.0-windows` inside `#if WINDOWS` and cannot be loaded by this suite — half the allocation would otherwise be invisible to a runtime check.

**Each of the four checks was confirmed to fail against a deliberately introduced violation** — a duplicated ID, an out-of-range ID, a reintroduced 105, and an ad-hoc `Logger.LogDebug` — rather than passing vacuously.

## Current allocation

```
1-9      base class (password-change and policy lifecycle)      next: 10
100-107  provider-specific                                      next: 108
         LDAP: 100, 101, 102, 104, 106, 107.  AD: 103.
         105 retired — not free, do not reuse.
110-112  shared helpers                                         next: 113
300-304  PwnedPasswordsSearch                                   next: 305
```

No shipped EventId is reused or renumbered.

Suite: 572 tests across all four projects (was 567; +5).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation update
- [x] Testing/CI harness

## Checklist
- [x] All new code compiles under .NET 8 — LDAP and Common normally; AD via the forced Windows build.
- [x] `dotnet test` passes locally — 572 tests, all four projects.
- [x] No external network calls are made in unit tests.
- [x] Documentation (if applicable) is updated — the EventId registry comment now records 106 and 107 and the corrected next-free values.
- [x] Debug provider is gated by `#if DEBUG` and cannot be enabled in Production — untouched.
- [ ] (Optional) Example e2e test runs against the Docker Compose test stack — logging only, no behavioral change to exercise.

## Note

The one red check to expect is `AD Provider Smoke Test on Windows Latest`, which fails on `master` independently of this branch (that workflow has never passed). Flagged on #55; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsJRsb3rUAuacypogW9ZEN

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsJRsb3rUAuacypogW9ZEN)_