### PR TITLE
Reduce the directory work an unauthenticated request performs

### DIFF
--- a/src/Unosquare.PassCore.Common/CachedDomainMinimumLength.cs
+++ b/src/Unosquare.PassCore.Common/CachedDomainMinimumLength.cs
@@ -1,0 +1,96 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Unosquare.PassCore.Common;
+
+/// <summary>
+/// A short-lived cache over the domain's minimum password length.
+/// </summary>
+/// <remarks>
+/// <para>The lookup behind this runs on <b>every</b> POST to the password endpoint,
+/// before the caller has proved anything, and costs a bind plus two searches. The
+/// value it fetches is domain-wide and changes about as often as a group policy
+/// edit, so re-reading it per request buys nothing and hands an unauthenticated
+/// caller a cheap way to generate directory load.</para>
+/// <para>Only a value that actually came from the directory is cached. The logged
+/// fallback is not: caching it would suppress the operator-actionable warning for
+/// the whole TTL, which is precisely the signal that something is wrong. A failing
+/// lookup therefore keeps re-attempting and keeps logging, exactly as before.</para>
+/// <para>Nothing account-specific belongs here. This caches one domain-wide policy
+/// number and nothing else — no membership, no credentials, no distinguished
+/// names.</para>
+/// </remarks>
+public sealed class CachedDomainMinimumLength
+{
+    /// <summary>
+    /// How long a directory-sourced value is reused. Long enough to collapse a burst
+    /// of requests onto one lookup, short enough that a policy change is picked up
+    /// without a restart. A stale value for a few minutes only affects the advertised
+    /// client-side minimum; the directory still enforces the real one on submit.
+    /// </summary>
+    public static readonly TimeSpan DefaultTimeToLive = TimeSpan.FromMinutes(5);
+
+    private readonly TimeSpan _timeToLive;
+    private readonly Func<DateTimeOffset> _clock;
+    private readonly object _gate = new();
+
+    private int? _cachedValue;
+    private DateTimeOffset _expiresAt;
+
+    /// <summary>Creates a cache with the default time-to-live and the system clock.</summary>
+    public CachedDomainMinimumLength()
+        : this(DefaultTimeToLive)
+    {
+    }
+
+    /// <summary>Creates a cache with an explicit time-to-live, and optionally an injected clock for tests.</summary>
+    /// <param name="timeToLive">How long a directory-sourced value is reused.</param>
+    /// <param name="clock">Supplies the current time; defaults to <see cref="DateTimeOffset.UtcNow"/>.</param>
+    public CachedDomainMinimumLength(TimeSpan timeToLive, Func<DateTimeOffset>? clock = null)
+    {
+        if (timeToLive < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(timeToLive), timeToLive, "Time-to-live cannot be negative.");
+
+        _timeToLive = timeToLive;
+        _clock = clock ?? (() => DateTimeOffset.UtcNow);
+    }
+
+    /// <summary>
+    /// Returns the cached minimum length when one is still fresh, otherwise performs
+    /// the lookup through <see cref="DomainPasswordPolicy.ResolveMinimumLength(ILogger, Func{int?}, int, out bool)"/>
+    /// and caches it if it came from the directory.
+    /// </summary>
+    /// <param name="logger">The provider's logger.</param>
+    /// <param name="lookup">The directory-specific lookup.</param>
+    /// <param name="fallback">The value to advertise when the lookup yields nothing.</param>
+    /// <returns>The resolved minimum length.</returns>
+    public int Resolve(
+        ILogger logger,
+        Func<int?> lookup,
+        int fallback = DomainPasswordPolicy.DefaultMinimumLength)
+    {
+        lock (_gate)
+        {
+            if (_cachedValue is { } cached && _clock() < _expiresAt)
+                return cached;
+        }
+
+        // Deliberately outside the lock: the lookup is a network round trip, and
+        // holding a lock across it would serialize every concurrent request behind
+        // the slowest one. A few racing requests may each perform a lookup; they
+        // resolve to the same domain-wide value, so the only cost is a duplicated
+        // read that the next request will not repeat.
+        var resolved = DomainPasswordPolicy.ResolveMinimumLength(logger, lookup, fallback, out var fromDirectory);
+
+        if (!fromDirectory)
+            return resolved;
+
+        lock (_gate)
+        {
+            _cachedValue = resolved;
+            _expiresAt = _clock().Add(_timeToLive);
+        }
+
+        return resolved;
+    }
+}

--- a/src/Unosquare.PassCore.Common/DomainPasswordPolicy.cs
+++ b/src/Unosquare.PassCore.Common/DomainPasswordPolicy.cs
@@ -53,7 +53,23 @@ public static class DomainPasswordPolicy
     public static int ResolveMinimumLength(
         ILogger logger,
         Func<int?> lookup,
-        int fallback = DefaultMinimumLength)
+        int fallback = DefaultMinimumLength) =>
+        ResolveMinimumLength(logger, lookup, fallback, out _);
+
+    /// <summary>
+    /// As <see cref="ResolveMinimumLength(ILogger, Func{int?}, int)"/>, and additionally
+    /// reports whether the value actually came from the directory.
+    /// </summary>
+    /// <param name="fromDirectory"><see langword="true"/> when the lookup returned a
+    /// value; <see langword="false"/> when the logged fallback was used. Callers that
+    /// cache the result use this to cache only real answers, so that a failing lookup
+    /// keeps re-attempting and keeps logging instead of having its warning suppressed
+    /// for the lifetime of a cache entry.</param>
+    public static int ResolveMinimumLength(
+        ILogger logger,
+        Func<int?> lookup,
+        int fallback,
+        out bool fromDirectory)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(lookup);
@@ -61,14 +77,19 @@ public static class DomainPasswordPolicy
         try
         {
             if (lookup() is { } minLength)
+            {
+                fromDirectory = true;
                 return minLength;
+            }
 
             LogLookupFailed(logger, fallback, null);
+            fromDirectory = false;
             return fallback;
         }
         catch (Exception ex)
         {
             LogLookupFailed(logger, fallback, ex);
+            fromDirectory = false;
             return fallback;
         }
     }

--- a/src/Unosquare.PassCore.Common/IGroupMembershipTester.cs
+++ b/src/Unosquare.PassCore.Common/IGroupMembershipTester.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Unosquare.PassCore.Common;
@@ -13,5 +14,88 @@ public interface IGroupMembershipTester
     /// <param name="username">The username to check.</param>
     /// <param name="groupName">The name of the group.</param>
     /// <returns>A task representing the asynchronous operation, containing true if the user is a member, otherwise false.</returns>
+    /// <remarks>
+    /// A negative answer means "determined not to be a member". A membership that
+    /// could not be determined throws rather than answering <see langword="false"/>,
+    /// so that a deny list fails closed.
+    /// </remarks>
     Task<bool> IsMemberOfGroupAsync(string username, string groupName);
+}
+
+/// <summary>
+/// An optional companion to <see cref="IGroupMembershipTester"/> for providers that
+/// can resolve a user's membership once and then answer any number of group names
+/// from that single resolution.
+/// </summary>
+/// <remarks>
+/// <para>This exists because every configured group name used to cost a full
+/// resolution: <c>GroupMembershipPolicy</c> called
+/// <see cref="IGroupMembershipTester.IsMemberOfGroupAsync"/> once per name, and each
+/// call re-resolved the user from scratch. With the shipped three restricted groups
+/// that is three resolutions per request, all before the caller has proved anything,
+/// on an endpoint with no rate limiting.</para>
+/// <para>It is deliberately a separate interface rather than a member of
+/// <see cref="IGroupMembershipTester"/>. Adding a member there — even one with a
+/// default implementation — would change what every existing implementer and test
+/// double presents, and a mocking framework auto-implements interface members
+/// regardless of whether they have a default body. Keeping it separate means a
+/// provider opts in and everything else is untouched: callers fall back to the
+/// per-group path exactly as before.</para>
+/// </remarks>
+public interface IGroupMembershipResolver
+{
+    /// <summary>Resolves the user's group membership once.</summary>
+    /// <param name="username">The username whose membership to resolve.</param>
+    Task<IResolvedGroupMembership> ResolveMembershipAsync(string username);
+}
+
+/// <summary>
+/// A single user's group membership, already resolved, so that testing further
+/// group names costs no additional directory work.
+/// </summary>
+public interface IResolvedGroupMembership
+{
+    /// <summary>
+    /// Reports whether the user belongs to any of <paramref name="groupNames"/>.
+    /// </summary>
+    /// <remarks>
+    /// Carries the same contract as <see cref="IGroupMembershipTester.IsMemberOfGroupAsync"/>:
+    /// a match is definitive, and <see langword="false"/> means "determined to belong to
+    /// none of them". If none matched and the membership could not be fully determined,
+    /// this throws rather than answering <see langword="false"/>.
+    /// </remarks>
+    /// <param name="groupNames">The group names to test. An empty collection is
+    /// <see langword="false"/> and performs no work.</param>
+    Task<bool> IsMemberOfAnyAsync(IReadOnlyCollection<string> groupNames);
+}
+
+/// <summary>
+/// The fallback used when a provider does not implement
+/// <see cref="IGroupMembershipResolver"/>: resolves nothing up front and asks the
+/// per-group method for each name, which is what every caller did before.
+/// </summary>
+internal sealed class PerGroupResolvedMembership : IResolvedGroupMembership
+{
+    private readonly IGroupMembershipTester _tester;
+    private readonly string _username;
+
+    public PerGroupResolvedMembership(IGroupMembershipTester tester, string username)
+    {
+        _tester = tester;
+        _username = username;
+    }
+
+    public async Task<bool> IsMemberOfAnyAsync(IReadOnlyCollection<string> groupNames)
+    {
+        if (groupNames is null || groupNames.Count == 0)
+            return false;
+
+        foreach (var groupName in groupNames)
+        {
+            if (await _tester.IsMemberOfGroupAsync(_username, groupName).ConfigureAwait(false))
+                return true;
+        }
+
+        return false;
+    }
 }

--- a/src/Unosquare.PassCore.Common/Policies/GroupMembershipPolicy.cs
+++ b/src/Unosquare.PassCore.Common/Policies/GroupMembershipPolicy.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Unosquare.PassCore.Common.Policies;
@@ -13,37 +13,33 @@ public class GroupMembershipPolicy : IPasswordPolicy
         var disclosureMode = provider is IDisclosurePosture posture ? posture.ErrorDisclosureMode : ErrorDisclosureMode.Hardened;
 
         var restrictedGroups = context.ClientSettings.PasswordProviderOptions?.RestrictedAdGroups;
-        if (restrictedGroups != null && restrictedGroups.Count != 0)
-        {
-            var restrictedMembershipResults = await Task.WhenAll(
-                restrictedGroups.Select(async group => new
-                {
-                    Group = group,
-                    IsMember = await tester.IsMemberOfGroupAsync(context.Username, group)
-                }));
-
-            if (restrictedMembershipResults.Any(x => x.IsMember))
-            {
-                throw DirectoryErrorTranslator.CreateGroupRejectionError(disclosureMode);
-            }
-        }
-
         var allowedGroups = context.ClientSettings.PasswordProviderOptions?.AllowedAdGroups;
-        if (allowedGroups != null && allowedGroups.Count != 0)
-        {
-            var allowedMembershipResults = await Task.WhenAll(
-                allowedGroups.Select(async group => new
-                {
-                    Group = group,
-                    IsMember = await tester.IsMemberOfGroupAsync(context.Username, group)
-                }));
 
-            var isMemberOfAnyAllowed = allowedMembershipResults.Any(x => x.IsMember);
+        var hasRestricted = restrictedGroups is { Count: > 0 };
+        var hasAllowed = allowedGroups is { Count: > 0 };
 
-            if (!isMemberOfAnyAllowed)
-            {
-                throw DirectoryErrorTranslator.CreateGroupRejectionError(disclosureMode);
-            }
-        }
+        // Nothing configured means nothing to ask the directory. This runs before
+        // the caller has proved anything, so a deployment that configures neither
+        // list must not pay for a lookup at all.
+        if (!hasRestricted && !hasAllowed)
+            return;
+
+        // Resolved once, then tested against both lists. Previously each configured
+        // group name cost its own full resolution of the user. A provider that does
+        // not opt into IGroupMembershipResolver keeps the old per-group path.
+        var membership = provider is IGroupMembershipResolver resolver
+            ? await resolver.ResolveMembershipAsync(context.Username).ConfigureAwait(false)
+            : new PerGroupResolvedMembership(tester, context.Username);
+
+        // Restricted before allowed, unchanged: a member of a restricted group is
+        // rejected regardless of what the allowed list says.
+        if (hasRestricted && await membership.IsMemberOfAnyAsync(AsCollection(restrictedGroups)).ConfigureAwait(false))
+            throw DirectoryErrorTranslator.CreateGroupRejectionError(disclosureMode);
+
+        if (hasAllowed && !await membership.IsMemberOfAnyAsync(AsCollection(allowedGroups)).ConfigureAwait(false))
+            throw DirectoryErrorTranslator.CreateGroupRejectionError(disclosureMode);
     }
+
+    private static IReadOnlyCollection<string> AsCollection(List<string>? groups) =>
+        groups ?? (IReadOnlyCollection<string>)System.Array.Empty<string>();
 }

--- a/src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs
+++ b/src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs
@@ -26,12 +26,16 @@ namespace Unosquare.PassCore.PasswordProvider
     /// <seealso cref="IPasswordChangeProvider" />
     /// https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1416#how-to-fix-violations
     [SupportedOSPlatform("windows")]
-    public class PasswordChangeProvider : PasswordChangeProviderBase, IPasswordLengthRequirement, IGroupMembershipTester
+    public class PasswordChangeProvider : PasswordChangeProviderBase, IPasswordLengthRequirement, IGroupMembershipTester, IGroupMembershipResolver
     {
         /// <inheritdoc />
         public override ErrorDisclosureMode ErrorDisclosureMode => _options.ErrorDisclosureMode;
 
         private readonly PasswordChangeOptions _options;
+
+        // The provider is registered as a singleton, so this is shared across
+        // requests -- which is the point: the value it holds is domain-wide.
+        private readonly CachedDomainMinimumLength _minimumLength = new();
         private IdentityType _idType = IdentityType.UserPrincipalName;
 
         private static readonly Action<ILogger, Exception?> LogAdminResetIgnoredInAutomaticContext =
@@ -215,13 +219,36 @@ namespace Unosquare.PassCore.PasswordProvider
         /// <c>Domain Admins</c> through during a partial directory failure. This keeps
         /// it failing closed, matching the LDAP provider for the same condition.</para>
         /// </remarks>
-        public Task<bool> IsMemberOfGroupAsync(string username, string groupName)
+        public async Task<bool> IsMemberOfGroupAsync(string username, string groupName)
         {
-            // Every operation in this method is a service-account directory read
-            // (context, resolve, group enumeration); a failure is infrastructure,
-            // never an end-user credential signal. There is no request context
-            // here, so the correlation ID is unavailable — the base class logs the
-            // propagated failure with the correlation ID as a backstop.
+            var membership = await ResolveMembershipAsync(username).ConfigureAwait(false);
+            return await membership.IsMemberOfAnyAsync(new[] { groupName }).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Resolves this user's group names once so that every configured group name
+        /// can be tested against the same resolution.
+        /// </summary>
+        /// <remarks>
+        /// <para>The per-group entry point above previously re-ran the whole sequence —
+        /// a fresh <c>PrincipalContext</c>, a <c>FindByIdentity</c>, and
+        /// <c>GetAuthorizationGroups</c> (the expensive one) — for every name the policy
+        /// asked about. With the shipped three restricted groups that is three of each,
+        /// per unauthenticated request, before the caller has proved anything.</para>
+        /// <para>Both enumerations are materialized into plain names in a single pass so
+        /// that the <c>PrincipalContext</c> and <c>UserPrincipal</c> can be disposed
+        /// immediately rather than held open across the policy's evaluation. That costs
+        /// one <c>GetGroups</c> in the case where a match in the authorization groups
+        /// would previously have short-circuited it — once per request, against N-fold
+        /// savings on everything else.</para>
+        /// </remarks>
+        public Task<IResolvedGroupMembership> ResolveMembershipAsync(string username)
+        {
+            // Every operation here is a service-account directory read (context,
+            // resolve, group enumeration); a failure is infrastructure, never an
+            // end-user credential signal. There is no request context here, so the
+            // correlation ID is unavailable — the base class logs the propagated
+            // failure with the correlation ID as a backstop.
             try
             {
                 using var principalContext = RunAsServiceAccount(
@@ -229,19 +256,21 @@ namespace Unosquare.PassCore.PasswordProvider
                 var userPrincipal = RunAsServiceAccount(
                     "resolve user by identity", correlationId: null,
                     () => UserPrincipal.FindByIdentity(principalContext, _idType, FixUsernameWithDomain(username)));
-                if (userPrincipal == null) return Task.FromResult(false);
 
-                // Records the first enumeration that could not complete. Both match
-                // paths return before the end of the method, so a value here always
-                // means "could not determine", never "determined not to be a member".
+                if (userPrincipal == null)
+                    return Task.FromResult<IResolvedGroupMembership>(AdResolvedMembership.NoSuchUser);
+
+                // Records the first enumeration that could not complete. A match is
+                // still definitive, so this only decides what a *negative* answer
+                // means: "determined not to be a member", or "could not determine".
                 Exception? undetermined = null;
+                var groupNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-                // Deterministically check GetAuthorizationGroups first to resolve transitive/recursive and primary security groups.
+                // GetAuthorizationGroups resolves transitive/recursive and primary security groups.
                 try
                 {
                     using var authGroups = userPrincipal.GetAuthorizationGroups();
-                    if (authGroups.Any(group => group.Name.Equals(groupName, StringComparison.OrdinalIgnoreCase)))
-                        return Task.FromResult(true);
+                    CollectNames(authGroups, groupNames);
                 }
                 catch (Exception ex)
                 {
@@ -253,12 +282,11 @@ namespace Unosquare.PassCore.PasswordProvider
                         ServiceAccountHost(), ex);
                 }
 
-                // Complement with GetGroups to cover distribution or direct groups that might not be in authorization groups.
+                // GetGroups covers distribution or direct groups that might not be in authorization groups.
                 try
                 {
                     using var directGroups = userPrincipal.GetGroups();
-                    if (directGroups.Any(group => group.Name.Equals(groupName, StringComparison.OrdinalIgnoreCase)))
-                        return Task.FromResult(true);
+                    CollectNames(directGroups, groupNames);
                 }
                 catch (Exception ex)
                 {
@@ -269,14 +297,8 @@ namespace Unosquare.PassCore.PasswordProvider
                         ServiceAccountHost(), ex);
                 }
 
-                // Nothing matched. That is only an answer if both enumerations ran.
-                if (undetermined is not null)
-                {
-                    throw DirectoryErrorTranslator.TranslateException(
-                        undetermined, _options.ErrorDisclosureMode, DirectoryActor.ServiceAccount);
-                }
-
-                return Task.FromResult(false);
+                return Task.FromResult<IResolvedGroupMembership>(
+                    new AdResolvedMembership(groupNames, undetermined, _options.ErrorDisclosureMode));
             }
             catch (PasswordChangeException)
             {
@@ -289,6 +311,63 @@ namespace Unosquare.PassCore.PasswordProvider
                 ServiceAccountFailure.Log(Logger, correlationId: null, "read group membership", ServiceAccountHost(), ex);
                 throw DirectoryErrorTranslator.TranslateException(
                     ex, _options.ErrorDisclosureMode, DirectoryActor.ServiceAccount);
+            }
+        }
+
+        /// <summary>
+        /// Copies a principal collection's names into <paramref name="into"/>. A group
+        /// with no name means the enumeration cannot be trusted to rule anything out,
+        /// so it throws and is recorded as undetermined by the caller rather than
+        /// being silently skipped — dropping it could turn a deny-list match into a
+        /// miss.
+        /// </summary>
+        private static void CollectNames(IEnumerable<Principal> principals, HashSet<string> into)
+        {
+            foreach (var principal in principals)
+            {
+                into.Add(principal.Name ?? throw new InvalidOperationException(
+                    "A group principal has no Name, so this enumeration cannot rule out membership."));
+            }
+        }
+
+        /// <summary>
+        /// A single resolution of one user's group names, queried in memory.
+        /// </summary>
+        private sealed class AdResolvedMembership : IResolvedGroupMembership
+        {
+            /// <summary>An unresolvable user belongs to nothing, matching the previous <c>false</c> for a null principal.</summary>
+            internal static readonly AdResolvedMembership NoSuchUser =
+                new(new HashSet<string>(StringComparer.OrdinalIgnoreCase), null, ErrorDisclosureMode.Hardened);
+
+            private readonly HashSet<string> _groupNames;
+            private readonly Exception? _undetermined;
+            private readonly ErrorDisclosureMode _disclosureMode;
+
+            internal AdResolvedMembership(
+                HashSet<string> groupNames, Exception? undetermined, ErrorDisclosureMode disclosureMode)
+            {
+                _groupNames = groupNames;
+                _undetermined = undetermined;
+                _disclosureMode = disclosureMode;
+            }
+
+            public Task<bool> IsMemberOfAnyAsync(IReadOnlyCollection<string> groupNames)
+            {
+                if (groupNames is null || groupNames.Count == 0)
+                    return Task.FromResult(false);
+
+                // A match is definitive regardless of what else failed.
+                if (groupNames.Any(_groupNames.Contains))
+                    return Task.FromResult(true);
+
+                // Nothing matched. That is only an answer if both enumerations ran.
+                if (_undetermined is not null)
+                {
+                    throw DirectoryErrorTranslator.TranslateException(
+                        _undetermined, _disclosureMode, DirectoryActor.ServiceAccount);
+                }
+
+                return Task.FromResult(false);
             }
         }
 
@@ -565,8 +644,12 @@ namespace Unosquare.PassCore.PasswordProvider
         /// method supplies only the AccountManagement-specific lookup.
         /// </summary>
         /// <returns>The minimum password length as an integer.</returns>
+        // Cached with a short time-to-live: this runs on every POST, before the
+        // caller has proved anything, and the value is domain-wide. Only a
+        // directory-sourced value is cached, so a failing lookup keeps
+        // re-attempting and keeps logging its warning.
         private int AcquireDomainPasswordLength() =>
-            DomainPasswordPolicy.ResolveMinimumLength(Logger, ReadMinPwdLength);
+            _minimumLength.Resolve(Logger, ReadMinPwdLength);
 
         /// <summary>
         /// Reads <c>minPwdLength</c> from the domain. Returns <see langword="null"/>

--- a/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeProvider.cs
+++ b/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeProvider.cs
@@ -40,7 +40,7 @@ namespace Zyborg.PassCore.PasswordProvider.LDAP;
 ///   syntax, not RFC 4515 filter syntax.)
 /// - Infrastructure failures never surface as auth or policy errors
 /// </summary>
-public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMembershipTester, IPasswordLengthRequirement
+public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMembershipTester, IGroupMembershipResolver, IPasswordLengthRequirement
 {
     /// <inheritdoc />
     public override ErrorDisclosureMode ErrorDisclosureMode => _options.ErrorDisclosureMode;
@@ -48,6 +48,10 @@ public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMemb
     private readonly LdapPasswordChangeOptions _options;
     private readonly LdapSearchConstraints _searchConstraints;
     private readonly LdapRemoteCertificateValidationCallback? _certValidator;
+
+    // The provider is registered as a singleton, so this is shared across requests —
+    // which is the point: the value it holds is domain-wide, not per-account.
+    private readonly CachedDomainMinimumLength _minimumLength = new();
 
     // AD operation errors lead with the Win32 code, e.g.
     // "0000052D: SvcErr: DSID-031A12D2, problem 5003 (WILL_NOT_PERFORM), data 0".
@@ -197,9 +201,48 @@ public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMemb
         ArgumentNullException.ThrowIfNull(username);
         ArgumentNullException.ThrowIfNull(groupName);
 
+        return IsMemberOfAnyGroup(username, new[] { groupName });
+    }
+
+    /// <summary>
+    /// Resolves this user once so that every configured group name can be tested
+    /// against the same resolution.
+    /// </summary>
+    /// <remarks>
+    /// The per-group entry point above previously re-resolved the user for every
+    /// name the policy asked about — with the shipped three restricted groups, three
+    /// binds and three searches per unauthenticated request, before the caller had
+    /// proved anything. The resolution is still lazy about the supplementary
+    /// lookups: a name matched by direct <c>memberOf</c> never triggers them, which
+    /// is the same short-circuit the per-group path always had.
+    /// </remarks>
+    public Task<IResolvedGroupMembership> ResolveMembershipAsync(string username)
+    {
+        ArgumentNullException.ThrowIfNull(username);
+
+        return Task.FromResult<IResolvedGroupMembership>(new LdapResolvedMembership(this, username));
+    }
+
+    /// <summary>
+    /// The membership evaluation itself, shared by the per-group and resolve-once
+    /// entry points. Semantics are unchanged from the per-group version: a match is
+    /// definitive, and a negative answer requires every lookup that could still have
+    /// matched to have completed.
+    /// </summary>
+    private Task<bool> IsMemberOfAnyGroup(
+        string username, IReadOnlyCollection<string> groupNames, LdapResolvedMembership? resolution = null)
+    {
+        if (groupNames.Count == 0)
+            return Task.FromResult(false);
+
         try
         {
-            var user = FindUser(username);
+            // Resolved inside the try so that a failure here is translated exactly as
+            // it always was, and cached on the resolution so a second evaluation of
+            // the same request does not repeat it.
+            var user = resolution?.User ?? FindUser(username);
+            if (resolution is not null)
+                resolution.User = user;
 
             // Records the first lookup that could not complete. Every match path
             // returns before reaching the end of the method, so a value here always
@@ -211,7 +254,7 @@ public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMemb
             // Compare against the group's RDN value or its full DN, never as a substring,
             // so that "Admins" cannot accidentally match "AdminsExtra".
             var isMember = user.Groups.Any(dn =>
-                DnMatchesGroup(dn, groupName));
+                groupNames.Any(groupName => DnMatchesGroup(dn, groupName)));
 
             if (isMember)
                 return Task.FromResult(true);
@@ -220,11 +263,11 @@ public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMemb
             if (!string.IsNullOrEmpty(user.PrimaryGroupId))
             {
                 // Robust check for well-known RIDs:
-                if (user.PrimaryGroupId == "513" && groupName.Equals("Domain Users", StringComparison.OrdinalIgnoreCase))
+                if (user.PrimaryGroupId == "513" && groupNames.Any(g => g.Equals("Domain Users", StringComparison.OrdinalIgnoreCase)))
                     return Task.FromResult(true);
-                if (user.PrimaryGroupId == "512" && groupName.Equals("Domain Admins", StringComparison.OrdinalIgnoreCase))
+                if (user.PrimaryGroupId == "512" && groupNames.Any(g => g.Equals("Domain Admins", StringComparison.OrdinalIgnoreCase)))
                     return Task.FromResult(true);
-                if (user.PrimaryGroupId == "519" && groupName.Equals("Enterprise Admins", StringComparison.OrdinalIgnoreCase))
+                if (user.PrimaryGroupId == "519" && groupNames.Any(g => g.Equals("Enterprise Admins", StringComparison.OrdinalIgnoreCase)))
                     return Task.FromResult(true);
 
                 // primaryGroupID is a RID, read back from the directory as a string.
@@ -252,7 +295,7 @@ public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMemb
                         if (primarySearch.HasMore())
                         {
                             var primaryDn = primarySearch.Next().Dn;
-                            if (DnMatchesGroup(primaryDn, groupName))
+                            if (groupNames.Any(groupName => DnMatchesGroup(primaryDn, groupName)))
                                 return Task.FromResult(true);
                         }
                     }
@@ -304,7 +347,7 @@ public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMemb
                 while (chainSearch.HasMore())
                 {
                     var entry = chainSearch.Next();
-                    if (DnMatchesGroup(entry.Dn, groupName))
+                    if (groupNames.Any(groupName => DnMatchesGroup(entry.Dn, groupName)))
                         return Task.FromResult(true);
                 }
             }
@@ -351,9 +394,16 @@ public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMemb
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Cached with a short time-to-live. This runs on every POST, before the caller
+    /// has proved anything, and costs a bind plus two searches; the value is
+    /// domain-wide and changes about as often as a group policy edit. Only a
+    /// directory-sourced value is cached, so a failing lookup keeps re-attempting and
+    /// keeps logging its warning.
+    /// </remarks>
     public Task<int> GetMinimumLengthAsync()
     {
-        return Task.FromResult(DomainPasswordPolicy.ResolveMinimumLength(Logger, ReadMinPwdLength));
+        return Task.FromResult(_minimumLength.Resolve(Logger, ReadMinPwdLength));
     }
 
     private int? ReadMinPwdLength()
@@ -1401,4 +1451,39 @@ public class LdapPasswordChangeProvider : PasswordChangeProviderBase, IGroupMemb
         string DistinguishedName,
         IReadOnlyCollection<string> Groups,
         string? PrimaryGroupId);
+
+    /// <summary>
+    /// Holds one resolution of a user so that several group names can be tested
+    /// against it without re-resolving. The user lookup happens once, on first use;
+    /// each evaluation then reuses it.
+    /// </summary>
+    /// <remarks>
+    /// Evaluation itself is deliberately not memoized. The supplementary lookups are
+    /// skipped entirely whenever a name matches direct <c>memberOf</c>, which is the
+    /// common case for a configured deny list, and preserving that short-circuit is
+    /// worth more than collapsing the two calls the policy makes (restricted, then
+    /// allowed) when a deployment configures both lists.
+    /// </remarks>
+    private sealed class LdapResolvedMembership : IResolvedGroupMembership
+    {
+        private readonly LdapPasswordChangeProvider _provider;
+        private readonly string _username;
+
+        public LdapResolvedMembership(LdapPasswordChangeProvider provider, string username)
+        {
+            _provider = provider;
+            _username = username;
+        }
+
+        /// <summary>The resolved user, populated on first evaluation and reused after.</summary>
+        internal LdapUser? User { get; set; }
+
+        public Task<bool> IsMemberOfAnyAsync(IReadOnlyCollection<string> groupNames)
+        {
+            if (groupNames is null || groupNames.Count == 0)
+                return Task.FromResult(false);
+
+            return _provider.IsMemberOfAnyGroup(_username, groupNames, this);
+        }
+    }
 }

--- a/tests/Unosquare.PassCore.Common.Tests/AdProviderDirectoryWriteAuditTests.cs
+++ b/tests/Unosquare.PassCore.Common.Tests/AdProviderDirectoryWriteAuditTests.cs
@@ -220,25 +220,29 @@ public class AdProviderDirectoryWriteAuditTests
     /// directory failure.</para>
     /// </summary>
     [Fact]
-    public void IsMemberOfGroupAsync_FailsClosedWhenMembershipCannotBeDetermined()
+    public void GroupMembership_FailsClosedWhenMembershipCannotBeDetermined()
     {
-        var body = ExtractMethodBody(
-            CodeSkeleton(ReadRepoFile(ProviderRelativePath)),
-            "Task<bool> IsMemberOfGroupAsync(");
+        var code = CodeSkeleton(ReadRepoFile(ProviderRelativePath));
+
+        // Resolution and evaluation are now separate: the two enumerations happen
+        // once per request in ResolveMembershipAsync, and the answer is given from
+        // that resolution. The fail-closed property spans both.
+        var resolveBody = ExtractMethodBody(code, "Task<IResolvedGroupMembership> ResolveMembershipAsync(");
+        var answerBody = ExtractMethodBody(code, "Task<bool> IsMemberOfAnyAsync(");
 
         // Both enumerations (GetAuthorizationGroups and GetGroups) must record a
         // failure. They cover different ground — transitive plus primary security
         // groups versus direct and distribution groups — so neither succeeding
         // rescues the other's failure.
-        Assert.Equal(2, CountOccurrences(body, "undetermined ??= ex;"));
+        Assert.Equal(2, CountOccurrences(resolveBody, "undetermined ??= ex;"));
 
         // A recorded failure must block the negative answer, not merely be logged.
-        var guardAt = body.IndexOf("if (undetermined is not null)", StringComparison.Ordinal);
-        var notAMemberAt = body.LastIndexOf("return Task.FromResult(false);", StringComparison.Ordinal);
+        var guardAt = answerBody.IndexOf("if (_undetermined is not null)", StringComparison.Ordinal);
+        var notAMemberAt = answerBody.LastIndexOf("return Task.FromResult(false);", StringComparison.Ordinal);
 
         Assert.True(
             guardAt >= 0,
-            "IsMemberOfGroupAsync no longer guards its negative answer on whether every enumeration " +
+            "The resolved membership no longer guards its negative answer on whether every enumeration " +
             "completed. Without that guard a failed enumeration reads as 'not a member' and the " +
             "restricted-group deny list fails open. See docs/error-routing-matrix.md.");
         Assert.True(
@@ -246,17 +250,50 @@ public class AdProviderDirectoryWriteAuditTests
             "The 'could not determine' guard no longer precedes the final 'not a member' return, so a " +
             "failed enumeration can still reach it.");
 
+        // A match stays definitive: it is answered before the undetermined guard.
+        var matchAt = answerBody.IndexOf("return Task.FromResult(true);", StringComparison.Ordinal);
+        Assert.True(
+            matchAt >= 0 && matchAt < guardAt,
+            "A positive match must be answered before the undetermined guard, so that a confirmed " +
+            "membership is never turned into an infrastructure error by an unrelated lookup failure.");
+
         // The outcome is the shared infrastructure response, decided by the
         // translator rather than by this provider.
-        Assert.Contains("DirectoryErrorTranslator.TranslateException(", body, StringComparison.Ordinal);
-        Assert.Contains("DirectoryActor.ServiceAccount", body, StringComparison.Ordinal);
+        Assert.Contains("DirectoryErrorTranslator.TranslateException(", answerBody, StringComparison.Ordinal);
+        Assert.Contains("DirectoryActor.ServiceAccount", answerBody, StringComparison.Ordinal);
 
-        // ... and it is reported to the operator, not swallowed.
-        Assert.Contains("ServiceAccountFailure.Log(", body, StringComparison.Ordinal);
+        // ... and each failed enumeration is reported to the operator, not swallowed:
+        // one per enumeration, plus the terminal catch that covers resolving the user.
+        Assert.Equal(3, CountOccurrences(resolveBody, "ServiceAccountFailure.Log("));
+    }
 
-        // A match stays definitive: both enumerations return true on a hit before
-        // any of the undetermined handling can affect the result.
-        Assert.Equal(2, CountOccurrences(body, "return Task.FromResult(true);"));
+    /// <summary>
+    /// The resolution must happen once per request, not once per configured group
+    /// name. The LDAP side of this is exercised for real in
+    /// <c>PreAuthenticationDirectoryLoadTests</c>; this provider can only be audited.
+    /// </summary>
+    [Fact]
+    public void GroupMembership_ResolvesTheUserOncePerRequestRatherThanPerGroup()
+    {
+        var code = CodeSkeleton(ReadRepoFile(ProviderRelativePath));
+
+        // The expensive calls belong to the once-per-request resolution...
+        var resolveBody = ExtractMethodBody(code, "Task<IResolvedGroupMembership> ResolveMembershipAsync(");
+        Assert.Contains("GetAuthorizationGroups()", resolveBody, StringComparison.Ordinal);
+        Assert.Contains("GetGroups()", resolveBody, StringComparison.Ordinal);
+        Assert.Contains("FindByIdentity(", resolveBody, StringComparison.Ordinal);
+
+        // ... and none of them may reappear in the per-name answer, which must be
+        // pure in-memory work.
+        var answerBody = ExtractMethodBody(code, "Task<bool> IsMemberOfAnyAsync(");
+        Assert.DoesNotContain("GetAuthorizationGroups", answerBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("GetGroups", answerBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("FindByIdentity", answerBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("AcquirePrincipalContext", answerBody, StringComparison.Ordinal);
+
+        // The per-group entry point delegates rather than carrying its own copy.
+        var perGroupBody = ExtractMethodBody(code, "Task<bool> IsMemberOfGroupAsync(");
+        Assert.Contains("ResolveMembershipAsync(", perGroupBody, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/tests/Unosquare.PassCore.Common.Tests/CachedDomainMinimumLengthTests.cs
+++ b/tests/Unosquare.PassCore.Common.Tests/CachedDomainMinimumLengthTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Unosquare.PassCore.Common.Tests;
+
+/// <summary>
+/// The minimum-length lookup runs on every POST to the password endpoint, before
+/// the caller has proved anything, and costs a bind plus two searches. The value
+/// is domain-wide, so re-reading it per request buys nothing and hands an
+/// unauthenticated caller a cheap way to generate directory load.
+/// </summary>
+public class CachedDomainMinimumLengthTests
+{
+    [Fact]
+    public void WithinTheTimeToLive_TheValueIsNotFetchedAgain()
+    {
+        var now = DateTimeOffset.UnixEpoch;
+        var cache = new CachedDomainMinimumLength(TimeSpan.FromMinutes(5), () => now);
+        var lookups = 0;
+
+        int? Lookup()
+        {
+            lookups++;
+            return 14;
+        }
+
+        Assert.Equal(14, cache.Resolve(NullLogger.Instance, Lookup));
+
+        now = now.AddMinutes(4);
+        Assert.Equal(14, cache.Resolve(NullLogger.Instance, Lookup));
+        Assert.Equal(14, cache.Resolve(NullLogger.Instance, Lookup));
+
+        Assert.Equal(1, lookups);
+    }
+
+    [Fact]
+    public void OnceTheTimeToLiveExpires_TheValueIsFetchedAgain()
+    {
+        var now = DateTimeOffset.UnixEpoch;
+        var cache = new CachedDomainMinimumLength(TimeSpan.FromMinutes(5), () => now);
+        var lookups = 0;
+
+        int? Lookup()
+        {
+            lookups++;
+            return 8 + lookups;
+        }
+
+        Assert.Equal(9, cache.Resolve(NullLogger.Instance, Lookup));
+
+        now = now.AddMinutes(5).AddSeconds(1);
+        Assert.Equal(10, cache.Resolve(NullLogger.Instance, Lookup));
+        Assert.Equal(2, lookups);
+    }
+
+    /// <summary>
+    /// The fallback must never be cached. Caching it would suppress the
+    /// operator-actionable warning for the whole TTL — and that warning is the only
+    /// signal that PassCore is advertising a weaker minimum than the domain
+    /// enforces.
+    /// </summary>
+    [Fact]
+    public void AFailedLookup_StillLogsAndFallsBack_EveryTime()
+    {
+        var now = DateTimeOffset.UnixEpoch;
+        var cache = new CachedDomainMinimumLength(TimeSpan.FromMinutes(5), () => now);
+        var logger = new CapturingLogger();
+        var lookups = 0;
+
+        int? Failing()
+        {
+            lookups++;
+            throw new InvalidOperationException("directory unreachable");
+        }
+
+        Assert.Equal(DomainPasswordPolicy.DefaultMinimumLength, cache.Resolve(logger, Failing));
+        Assert.Equal(DomainPasswordPolicy.DefaultMinimumLength, cache.Resolve(logger, Failing));
+
+        Assert.Equal(2, lookups);
+        Assert.Equal(2, logger.Entries.Count);
+        Assert.All(logger.Entries, e => Assert.Equal(LogLevel.Warning, e.Level));
+    }
+
+    /// <summary>A lookup that returns nothing is the same case: logged fallback, not cached.</summary>
+    [Fact]
+    public void AnAbsentValue_IsAlsoNotCached()
+    {
+        var cache = new CachedDomainMinimumLength(TimeSpan.FromMinutes(5), () => DateTimeOffset.UnixEpoch);
+        var logger = new CapturingLogger();
+        var lookups = 0;
+
+        int? Absent()
+        {
+            lookups++;
+            return null;
+        }
+
+        cache.Resolve(logger, Absent);
+        cache.Resolve(logger, Absent);
+
+        Assert.Equal(2, lookups);
+        Assert.Equal(2, logger.Entries.Count);
+    }
+
+    /// <summary>A failure after a success keeps serving the cached value; it does not poison it.</summary>
+    [Fact]
+    public void AFailureAfterASuccess_DoesNotDiscardTheCachedValue()
+    {
+        var now = DateTimeOffset.UnixEpoch;
+        var cache = new CachedDomainMinimumLength(TimeSpan.FromMinutes(5), () => now);
+
+        Assert.Equal(12, cache.Resolve(NullLogger.Instance, () => 12));
+        Assert.Equal(12, cache.Resolve(NullLogger.Instance, () => throw new InvalidOperationException("down")));
+    }
+
+    private sealed class NullLogger : ILogger
+    {
+        public static readonly NullLogger Instance = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+        }
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<(LogLevel Level, string Message, Exception? Exception)> Entries { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            Entries.Add((logLevel, formatter(state, exception), exception));
+    }
+}

--- a/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/PreAuthenticationDirectoryLoadTests.cs
+++ b/tests/Zyborg.PassCore.PasswordProvider.LDAP.Tests/PreAuthenticationDirectoryLoadTests.cs
@@ -1,0 +1,297 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Novell.Directory.Ldap;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Unosquare.PassCore.Common;
+using Unosquare.PassCore.Common.Models;
+using Unosquare.PassCore.Common.Policies;
+using Xunit;
+
+namespace Zyborg.PassCore.PasswordProvider.LDAP.Tests;
+
+/// <summary>
+/// Group evaluation runs before credential verification, on any POST with any
+/// username, on an endpoint with no rate limiting. It used to re-resolve the user
+/// from scratch for every configured group name — with the shipped three
+/// restricted groups, three binds and three searches per unauthenticated request.
+///
+/// <para>These tests count the directory work a single request performs. They are
+/// about load, not correctness: the membership outcomes themselves are pinned by
+/// <c>GroupMembershipParityTests</c> and <c>GroupMembershipUndeterminedTests</c>,
+/// which are unchanged.</para>
+/// </summary>
+public class PreAuthenticationDirectoryLoadTests
+{
+    private const string UserDn = "cn=testuser,ou=people,dc=example,dc=com";
+
+    /// <summary>The shipped default deny list.</summary>
+    private static readonly List<string> ShippedRestrictedGroups =
+        new() { "Administrators", "Domain Admins", "Enterprise Admins" };
+
+    [Fact]
+    public async Task TheUserIsResolvedOncePerRequest_NotOncePerConfiguredGroup()
+    {
+        var provider = Provider(out var filters);
+
+        await new GroupMembershipPolicy().ValidateAsync(Context(ShippedRestrictedGroups), provider);
+
+        var userLookups = filters.Count(f => f.Contains("sAMAccountName=", StringComparison.Ordinal));
+
+        Assert.Equal(1, userLookups);
+
+        // Sanity check that the configuration under test would previously have cost
+        // one resolution per name, so the assertion above is not trivially true.
+        Assert.Equal(3, ShippedRestrictedGroups.Count);
+
+        // And the supplementary lookups are likewise not repeated per group name.
+        Assert.Equal(1, filters.Count(f => f.Contains("1.2.840.113556.1.4.1941", StringComparison.Ordinal)));
+
+        // Two binds: one for the user lookup, one for the in-chain search. Each
+        // search opens its own connection, so the floor for this configuration is
+        // two -- the point is that it no longer scales with the number of names.
+        Assert.Equal(2, provider.Binds);
+    }
+
+    /// <summary>
+    /// With both lists configured the policy asks twice — restricted, then allowed —
+    /// but the user is still resolved only once for the request.
+    /// </summary>
+    [Fact]
+    public async Task WithBothListsConfigured_TheUserIsStillResolvedOnce()
+    {
+        var provider = Provider(out var filters);
+
+        var settings = new ClientSettings
+        {
+            PasswordProviderOptions = new PasswordProviderOptions
+            {
+                RestrictedAdGroups = ShippedRestrictedGroups,
+                AllowedAdGroups = new List<string> { "PasswordResetUsers", "Staff" },
+            },
+        };
+
+        // testuser is in DirectGroup only: not restricted, and not allowed either,
+        // so this refuses — after a single resolution.
+        await Assert.ThrowsAnyAsync<Exception>(
+            () => new GroupMembershipPolicy().ValidateAsync(
+                new PasswordChangeContext("testuser", "old", "new", settings), provider));
+
+        Assert.Equal(1, filters.Count(f => f.Contains("sAMAccountName=", StringComparison.Ordinal)));
+    }
+
+    /// <summary>
+    /// Nothing configured must cost nothing. This check runs before the caller has
+    /// proved anything, so a deployment that configures neither list must not hand
+    /// an unauthenticated request any directory work at all.
+    /// </summary>
+    [Fact]
+    public async Task WithNoGroupsConfigured_TheDirectoryIsNotQueriedAtAll()
+    {
+        var provider = Provider(out var filters);
+
+        var settings = new ClientSettings { PasswordProviderOptions = new PasswordProviderOptions() };
+        await new GroupMembershipPolicy().ValidateAsync(
+            new PasswordChangeContext("testuser", "old", "new", settings), provider);
+
+        Assert.Empty(filters);
+        Assert.Equal(0, provider.Binds);
+    }
+
+    /// <summary>
+    /// A direct match must still skip the supplementary searches. Resolving once per
+    /// request must not turn into "always run everything".
+    /// </summary>
+    [Fact]
+    public async Task ADirectMatch_StillSkipsTheSupplementaryLookups()
+    {
+        var provider = Provider(out var filters);
+
+        var settings = new ClientSettings
+        {
+            PasswordProviderOptions = new PasswordProviderOptions
+            {
+                RestrictedAdGroups = new List<string> { "DirectGroup" },
+            },
+        };
+
+        await Assert.ThrowsAnyAsync<Exception>(
+            () => new GroupMembershipPolicy().ValidateAsync(
+                new PasswordChangeContext("testuser", "old", "new", settings), provider));
+
+        Assert.Equal(1, filters.Count(f => f.Contains("sAMAccountName=", StringComparison.Ordinal)));
+        Assert.DoesNotContain(filters, f => f.Contains("1.2.840.113556.1.4.1941", StringComparison.Ordinal));
+        Assert.DoesNotContain(filters, f => f.Contains("primaryGroupToken", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The minimum-length lookup is domain-wide, so a burst of unauthenticated
+    /// requests collapses onto one directory read rather than one per request.
+    /// </summary>
+    [Fact]
+    public async Task TheMinimumLengthLookupIsNotRepeatedForEveryRequest()
+    {
+        var provider = ProviderWithDomainPolicy(out var filters, minPwdLength: 14);
+
+        for (var i = 0; i < 5; i++)
+            Assert.Equal(14, await provider.GetMinimumLengthAsync());
+
+        // The rootDSE probe runs once for five requests rather than once each.
+        Assert.Equal(1, filters.Count(f => f.Contains("defaultNamingContext", StringComparison.Ordinal)));
+    }
+
+    /// <summary>
+    /// A lookup that cannot produce a value is deliberately not cached: caching it
+    /// would suppress the operator-actionable warning for the whole TTL.
+    /// </summary>
+    [Fact]
+    public async Task AFailingMinimumLengthLookupIsRetriedRatherThanCached()
+    {
+        var provider = Provider(out var filters);
+
+        for (var i = 0; i < 3; i++)
+            await provider.GetMinimumLengthAsync();
+
+        Assert.Equal(3, filters.Count(f => f.Contains("defaultNamingContext", StringComparison.Ordinal)));
+    }
+
+    /// <summary>
+    /// As <see cref="Provider"/>, but the directory answers the rootDSE and domain
+    /// naming context probes, so the minimum length actually resolves.
+    /// </summary>
+    private static CountingLdapProvider ProviderWithDomainPolicy(out List<string> filters, int minPwdLength)
+    {
+        var provider = Provider(out var seen);
+        filters = seen;
+
+        var rootDse = new LdapEntry(
+            string.Empty,
+            new LdapAttributeSet { new LdapAttribute("defaultNamingContext", "dc=example,dc=com") });
+
+        var domainNc = new LdapEntry(
+            "dc=example,dc=com",
+            new LdapAttributeSet
+            {
+                new LdapAttribute("minPwdLength", minPwdLength.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+            });
+
+        provider.OnSearchLdap = (filter, attrs) =>
+        {
+            seen.Add(Record(filter, attrs));
+
+            var entry = attrs.Contains("defaultNamingContext") ? rootDse
+                : attrs.Contains("minPwdLength") ? domainNc
+                : null;
+
+            var results = new Mock<ILdapSearchResults>();
+            if (entry is null)
+            {
+                results.Setup(r => r.HasMore()).Returns(false);
+            }
+            else
+            {
+                var remaining = new Queue<LdapEntry>(new[] { entry });
+                results.Setup(r => r.HasMore()).Returns(() => remaining.Count > 0);
+                results.Setup(r => r.Next()).Returns(() => remaining.Dequeue());
+            }
+
+            return results.Object;
+        };
+
+        return provider;
+    }
+
+    /// <summary>Filter plus requested attributes, so two probes sharing a filter stay distinguishable.</summary>
+    private static string Record(string filter, IEnumerable<string> attributes) =>
+        $"{filter} [{string.Join(",", attributes)}]";
+
+    private static PasswordChangeContext Context(List<string> restrictedGroups) =>
+        new(
+            "testuser", "old", "new",
+            new ClientSettings
+            {
+                PasswordProviderOptions = new PasswordProviderOptions { RestrictedAdGroups = restrictedGroups },
+            });
+
+    /// <summary>
+    /// A provider over a directory holding one account, <c>testuser</c>, a member of
+    /// <c>DirectGroup</c> and nothing else. <paramref name="filters"/> collects every
+    /// search filter issued and <paramref name="bindCount"/> counts service-account
+    /// binds, in issue order.
+    /// </summary>
+    private static CountingLdapProvider Provider(out List<string> filters)
+    {
+        var options = new LdapPasswordChangeOptions
+        {
+            LdapHostnames = new[] { "ldap.example.com" },
+            LdapPort = 389,
+            LdapUsername = "cn=admin,dc=example,dc=com",
+            LdapPassword = "secret",
+            LdapSearchBase = "dc=example,dc=com",
+            LdapSearchFilter = "(sAMAccountName={Username})",
+        };
+
+        var provider = new CountingLdapProvider(
+            NullLogger<LdapPasswordChangeProvider>.Instance,
+            Options.Create(options),
+            Options.Create(new ClientSettings()),
+            Array.Empty<IPasswordPolicy>());
+
+        var userEntry = new LdapEntry(
+            UserDn,
+            new LdapAttributeSet
+            {
+                new LdapAttribute("distinguishedName", UserDn),
+                new LdapAttribute("sAMAccountName", "testuser"),
+                new LdapAttribute("memberOf", "cn=DirectGroup,ou=groups,dc=example,dc=com"),
+            });
+
+        var seen = new List<string>();
+        filters = seen;
+
+        provider.OnSearchLdap = (filter, attrs) =>
+        {
+            seen.Add(Record(filter, attrs));
+
+            var results = new Mock<ILdapSearchResults>();
+            if (filter.Contains("sAMAccountName=testuser", StringComparison.Ordinal))
+            {
+                var remaining = new Queue<LdapEntry>(new[] { userEntry });
+                results.Setup(r => r.HasMore()).Returns(() => remaining.Count > 0);
+                results.Setup(r => r.Next()).Returns(() => remaining.Dequeue());
+            }
+            else
+            {
+                results.Setup(r => r.HasMore()).Returns(false);
+            }
+
+            return results.Object;
+        };
+
+        return provider;
+    }
+
+    /// <summary>Adds bind counting on top of the shared test provider.</summary>
+    private sealed class CountingLdapProvider : TestLdapPasswordChangeProvider
+    {
+        public CountingLdapProvider(
+            Microsoft.Extensions.Logging.ILogger<LdapPasswordChangeProvider> logger,
+            IOptions<LdapPasswordChangeOptions> options,
+            IOptions<ClientSettings> clientSettings,
+            IEnumerable<IPasswordPolicy> policies)
+            : base(logger, options, clientSettings, policies)
+        {
+        }
+
+        public int Binds { get; private set; }
+
+        internal override LdapConnection BindAsServiceAccount(string? correlationId = null)
+        {
+            Binds++;
+            return base.BindAsServiceAccount(correlationId);
+        }
+    }
+}


### PR DESCRIPTION
## Description

**Task 6 of the post-merge remediation series — the last one.**

Group evaluation and the minimum-length lookup both run **before credential verification**, on any POST with any username, on an endpoint with no rate limiting. Between them they were roughly ten binds and eleven searches per request against the shipped configuration — a cheap amplification primitive pointed at the domain controller.

Two changes, neither of which alters an observable result.

## The minimum-length lookup is cached

Five-minute TTL. The value is domain-wide and changes about as often as a group policy edit, so re-reading it per request bought nothing.

**Only a value that actually came from the directory is cached.** Caching the fallback would suppress the operator-actionable warning for the whole TTL — and that warning is the only signal that PassCore is advertising a weaker minimum than the domain enforces. A failing lookup keeps re-attempting and keeps logging, exactly as before.

Nothing account-specific is cached: one domain-wide number, no membership, no credentials, no distinguished names.

## Group membership is resolved once per request

`GroupMembershipPolicy` called `IsMemberOfGroupAsync` per configured name, and each call re-resolved the user from scratch — the shipped three restricted groups cost three full resolutions. The policy now resolves once and tests both lists against that resolution.

Ordering is unchanged: restricted before allowed, and a restricted match still refuses without consulting the allowed list. A deployment with neither list configured still performs no directory work at all — preserved deliberately, with a test, rather than by accident.

| Configuration | User resolutions before | after |
|---|---|---|
| Shipped (3 restricted, 0 allowed) | 3 | **1** |
| 3 restricted + 2 allowed | 5 | **1** |
| Neither list | 0 | 0 |

### Why a separate interface

The opt-in is a new `IGroupMembershipResolver` rather than a member on `IGroupMembershipTester`.

I first tried a default interface method, on the theory that a default body makes it non-breaking. It does not: **a mocking framework auto-implements interface members whether or not they have a default body**, so every `Mock<IPasswordChangeProvider>.As<IGroupMembershipTester>()` returned `null` for the new method and the existing `GroupMembershipPolicyTests` failed with `NullReferenceException`. Keeping it a separate interface means a provider opts in and everything else — implementers, test doubles, the Debug provider — is untouched and falls back to the per-group path.

## Semantics preserved

Both providers keep their existing behavior exactly: a match is definitive the moment it is found, a negative answer still requires every lookup that could have matched to have completed, and a direct `memberOf` match still skips the supplementary searches on LDAP.

On AD the two enumerations are materialized into names in one pass so the `PrincipalContext` and `UserPrincipal` are disposed immediately rather than held open across the policy's evaluation. That costs one `GetGroups` in the case where a match in the authorization groups would previously have short-circuited it — once per request, against N-fold savings on everything else. A group principal with no `Name` fails the enumeration rather than being skipped, since dropping it could turn a deny-list match into a miss.

## Tests

- `GroupMembershipParityTests` (the outcome matrix) and `GroupMembershipUndeterminedTests` (fail-closed) are **unchanged and still pass**.
- New `PreAuthenticationDirectoryLoadTests` counts the directory work of a single request through the real policy and provider: one user resolution for the shipped deny list, one even with both lists configured, none when neither is configured, and no supplementary searches after a direct match.
- New `CachedDomainMinimumLengthTests` covers the TTL, expiry, and that a failed or absent lookup is retried and logged every time rather than cached.
- The AD source audit now spans resolution and evaluation separately, and additionally asserts the expensive calls appear only in the once-per-request resolution and never in the per-name answer.

Suite: **584 tests** across all four projects (was 572; +12). The AD provider was compiled with the guarded code via the forced Windows build, and the new methods confirmed present in the emitted assembly.

Two defects were caught during development and are worth noting as evidence the checks work: the forced Windows compile caught a wrong parameter type (`GetAuthorizationGroups()` returns `PrincipalSearchResult<Principal>`, not `PrincipalCollection`), and the first draft called `FindUser` outside the translating try/catch on the LDAP side, which would have let an `LdapException` escape untranslated.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation update
- [ ] Testing/CI harness

## Checklist
- [x] All new code compiles under .NET 8 — LDAP and Common normally; AD via the forced Windows build.
- [x] `dotnet test` passes locally — 584 tests, all four projects.
- [x] No external network calls are made in unit tests.
- [x] Documentation (if applicable) is updated — rationale lives on the new interfaces and the cache; no routing behavior changed, so `docs/error-routing-matrix.md` is unaffected.
- [x] Debug provider is gated by `#if DEBUG` and cannot be enabled in Production — untouched; it implements neither membership interface.
- [ ] (Optional) Example e2e test runs against the Docker Compose test stack — the LDAP smoke test exercises these paths and its assertions are unchanged, which is the point: the observable results are identical.

## Note

Expect `AD Provider Smoke Test on Windows Latest` to be red. It fails on `master` independently — its `smblds-ad` container never starts, so the cleanup step exits 1. Diagnosed on #56; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsJRsb3rUAuacypogW9ZEN

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsJRsb3rUAuacypogW9ZEN)_