### PR TITLE
Experiment: route to the podman bridge and see whether Kerberos follows

### DIFF
--- a/.github/workflows/ad-provider-smoke-test.yml
+++ b/.github/workflows/ad-provider-smoke-test.yml
@@ -58,28 +58,27 @@ jobs:
           sed -i 's/\r$//' "${SEED_SCRIPT}"
           chmod +x "${SEED_SCRIPT}"
 
-          # 88 (Kerberos) and 464 (kpasswd) are deliberately NOT published, and
-          # the reason is worth stating because they were published for a while.
+          # 88 (Kerberos) and 464 (kpasswd) are republished as part of a
+          # TIME-BOXED EXPERIMENT, together with the static route added on the
+          # Windows side further down. The two are one logical unit: the route
+          # alone changes nothing observable, and republishing these ports alone
+          # reproduces a known breakage. If the experiment fails they are removed
+          # together.
           #
-          # They went in for the password change, on the theory that ADSI was
-          # timing out on unreachable transports. That was disproved: with all
-          # five ports open the request still failed in 11.18s against 11.4s
-          # before, so the time was never port timeouts, and the change fails for
-          # a reason still unidentified.
+          # The known breakage, from the last time these were published: making
+          # the hosts entries routable so the DC Locator could work also made the
+          # KDC findable, at which point Negotiate began preferring Kerberos,
+          # failed, and did NOT fall back to NTLM -- so every bind broke,
+          # including the minPwdLength read that had been passing. Expect a broad
+          # red rather than a targeted one if that recurs; it is not a new fault.
           #
-          # Leaving them published then caused an actual regression. Once the
-          # hosts entries pointed at a routable address (below) so the DC Locator
-          # could work, a reachable KDC meant Negotiate began attempting Kerberos
-          # instead of NTLM -- and Kerberos cannot succeed here: Samba registers
-          # its SPN for the DC's FQDN, and the KDC's own A record resolves to the
-          # container-internal 10.88.x.x that Windows cannot route to. Negotiate
-          # then failed outright rather than falling back, and every bind started
-          # returning 0x8007052E ERROR_LOGON_FAILURE -- breaking the minPwdLength
-          # read that had been passing.
-          #
-          # Without a KDC to find, Negotiate uses NTLM, which works. If Kerberos
-          # is ever wanted here it needs SPN and realm configuration on the
-          # runner, not merely an open port.
+          # The hypothesis being tested: DNS SRV responses carry glue A records in
+          # the additional section, so when the Kerberos client resolves
+          # _kerberos._tcp.example.com it can take dc.example.com's accompanying
+          # 10.88.x.x address directly, never performing the separate lookup the
+          # hosts file would have intercepted -- and then dials an address Windows
+          # cannot route to. If that is the mechanism, a route fixes it. Windows
+          # does not need the container on its network, only a way to reach it.
           #
           # 389 is published for BOTH protocols, and the /udp is not incidental.
           # podman publishes TCP only when no protocol is given, so "-p 389:389"
@@ -144,11 +143,36 @@ jobs:
             --privileged \
             -p 389:389/tcp -p 389:389/udp -p 636:636 \
             -p 3268:3268 -p 3269:3269 \
+            -p 88:88/tcp -p 88:88/udp \
+            -p 464:464/tcp -p 464:464/udp \
             -p ${WSL_IP}:53:53/udp -p ${WSL_IP}:53:53/tcp \
             -e DOMAIN="example.com" \
             -e DOMAINPASS="AdminPassword123!" \
             -e NOCOMPLEXITY="true" \
             docker.io/nowsci/samba-domain:latest
+
+          # EXPERIMENT (time-boxed). Windows does not need the container on its
+          # network, only a route to it. The WSL VM already forwards, because
+          # podman requires ip_forward.
+          #
+          # The subnet is READ rather than assumed: netavark defaults to
+          # 10.88.0.0/16, but a hardcoded value that quietly stopped matching
+          # would produce a confusing negative result and this experiment is
+          # only worth running if its negative is trustworthy.
+          NETWORK_FILE="$(wslpath '${{ github.workspace }}')/podman-network.txt"
+
+          PODMAN_SUBNET="$(podman network inspect podman --format '{{range .Subnets}}{{.Subnet}}{{end}}' 2>/dev/null)"
+          if [ -z "${PODMAN_SUBNET}" ]; then
+            # Older/other backends report a different shape; fall back to JSON.
+            PODMAN_SUBNET="$(podman network inspect podman 2>/dev/null | grep -o '"subnet"[^,]*' | head -1 | sed 's/.*: *"//; s/"//')"
+          fi
+
+          CONTAINER_IP="$(podman inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' samba-ad 2>/dev/null)"
+
+          echo "podman bridge subnet : ${PODMAN_SUBNET:-<unknown>}"
+          echo "container address    : ${CONTAINER_IP:-<unknown>}"
+
+          printf '%s\n%s\n' "${PODMAN_SUBNET}" "${CONTAINER_IP}" > "${NETWORK_FILE}"
 
       - name: Wait for Samba AD DC Provisioning
         shell: wsl-bash {0}
@@ -272,6 +296,105 @@ jobs:
                   Write-Host "$name did not resolve: $($_.Exception.Message)"
               }
           }
+
+          # --- EXPERIMENT: static route to the podman bridge ------------------
+          # Half of a time-boxed pair; the other half is republishing 88/464.
+          # Windows does not need the container on its network, only a route to
+          # it, and the WSL VM already forwards because podman requires
+          # ip_forward. If Kerberos has been dialling the container's own
+          # 10.88.x.x address taken from a DNS glue record, this is what makes
+          # that address reachable.
+          #
+          # Subnet and container address are read from podman, never hardcoded.
+          $networkFile = Join-Path $env:GITHUB_WORKSPACE "podman-network.txt"
+          $podmanSubnet = $null
+          $containerIp = $null
+          if (Test-Path $networkFile) {
+              $networkFacts = @(Get-Content $networkFile)
+              if ($networkFacts.Count -ge 1) { $podmanSubnet = $networkFacts[0].Trim() }
+              if ($networkFacts.Count -ge 2) { $containerIp = $networkFacts[1].Trim() }
+          }
+
+          Write-Host "=== podman network facts ==="
+          Write-Host "  subnet    : $(if ($podmanSubnet) { $podmanSubnet } else { '<not reported>' })"
+          Write-Host "  container : $(if ($containerIp) { $containerIp } else { '<not reported>' })"
+
+          if ($podmanSubnet) {
+              try {
+                  New-NetRoute -DestinationPrefix $podmanSubnet -NextHop $wslIp `
+                    -InterfaceAlias (Get-NetIPAddress -IPAddress $wslIp -ErrorAction Stop).InterfaceAlias `
+                    -RouteMetric 1 -ErrorAction Stop | Out-Null
+                  Write-Host "  route added: $podmanSubnet via $wslIp"
+              }
+              catch {
+                  # A route that cannot be added is a Stage 1 failure and the
+                  # probe below will say so; it must not fail the step here.
+                  Write-Host "  route not added: $($_.Exception.Message)"
+              }
+              Write-Host "=== routes matching the bridge ==="
+              Get-NetRoute -ErrorAction SilentlyContinue |
+                Where-Object { $_.DestinationPrefix -eq $podmanSubnet } |
+                Format-Table DestinationPrefix,NextHop,InterfaceAlias,RouteMetric |
+                Out-String | Write-Host
+          }
+          else {
+              Write-Host "  no subnet reported; skipping the route (Stage 1 will fail and say so)"
+          }
+
+          # Stage 1: is the bridge reachable at all? No Kerberos involved, so a
+          # failure here is a routing problem and nothing else.
+          Write-Host "=== EXPERIMENT Stage 1: TCP to the container address ==="
+          if ($containerIp) {
+              foreach ($port in @(389, 88)) {
+                  try {
+                      $client = New-Object System.Net.Sockets.TcpClient
+                      $connect = $client.BeginConnect($containerIp, $port, $null, $null)
+                      if ($connect.AsyncWaitHandle.WaitOne(5000, $false) -and $client.Connected) {
+                          Write-Host "  Stage 1: ${containerIp}:${port} REACHABLE"
+                      }
+                      else {
+                          Write-Host "  Stage 1: ${containerIp}:${port} NOT reachable"
+                      }
+                      $client.Close()
+                  }
+                  catch {
+                      Write-Host "  Stage 1: ${containerIp}:${port} NOT reachable: $($_.Exception.Message)"
+                  }
+              }
+          }
+          else {
+              Write-Host "  Stage 1: skipped, no container address reported"
+          }
+
+          # Stage 2: does an EXPLICIT Kerberos bind succeed? AuthType.Kerberos,
+          # not Negotiate, so NTLM cannot satisfy it -- a Negotiate success would
+          # prove nothing about Kerberos, and this investigation has twice
+          # produced a fix whose stated rationale was wrong.
+          Write-Host "=== EXPERIMENT Stage 2: explicit Kerberos bind ==="
+          try {
+              Add-Type -AssemblyName System.DirectoryServices.Protocols
+              $identifier = New-Object System.DirectoryServices.Protocols.LdapDirectoryIdentifier("example.com", 389)
+              $connection = New-Object System.DirectoryServices.Protocols.LdapConnection($identifier)
+              $connection.SessionOptions.ProtocolVersion = 3
+              $connection.SessionOptions.Sealing = $true
+              $connection.SessionOptions.Signing = $true
+              $connection.AuthType = [System.DirectoryServices.Protocols.AuthType]::Kerberos
+              $connection.Credential = New-Object System.Net.NetworkCredential(
+                  "Administrator", "AdminPassword123!", "EXAMPLE")
+              $connection.Timeout = [TimeSpan]::FromSeconds(20)
+              $connection.Bind()
+              Write-Host "  Stage 2: Kerberos bind to example.com:389 SUCCEEDED"
+              $connection.Dispose()
+          }
+          catch {
+              # The exact error decides the outcome: a KDC error naming the
+              # principal is a different answer from a timeout.
+              Write-Host "  Stage 2: Kerberos bind FAILED: $($_.Exception.GetType().Name): $($_.Exception.Message)"
+              if ($_.Exception.InnerException) {
+                  Write-Host "  Stage 2: inner: $($_.Exception.InnerException.Message)"
+              }
+          }
+          # --- end EXPERIMENT --------------------------------------------------
 
           # NRPT sends only *.example.com queries to the container's DNS, leaving
           # the runner's own resolution (GitHub API, package restore) untouched.

--- a/.github/workflows/ad-provider-smoke-test.yml
+++ b/.github/workflows/ad-provider-smoke-test.yml
@@ -58,27 +58,52 @@ jobs:
           sed -i 's/\r$//' "${SEED_SCRIPT}"
           chmod +x "${SEED_SCRIPT}"
 
-          # 88 (Kerberos) and 464 (kpasswd) are republished as part of a
-          # TIME-BOXED EXPERIMENT, together with the static route added on the
-          # Windows side further down. The two are one logical unit: the route
-          # alone changes nothing observable, and republishing these ports alone
-          # reproduces a known breakage. If the experiment fails they are removed
-          # together.
+          # 88 (Kerberos) and 464 (kpasswd) are deliberately NOT published, and
+          # the reason is worth stating because they were published for a while.
           #
-          # The known breakage, from the last time these were published: making
-          # the hosts entries routable so the DC Locator could work also made the
-          # KDC findable, at which point Negotiate began preferring Kerberos,
-          # failed, and did NOT fall back to NTLM -- so every bind broke,
-          # including the minPwdLength read that had been passing. Expect a broad
-          # red rather than a targeted one if that recurs; it is not a new fault.
+          # They went in for the password change, on the theory that ADSI was
+          # timing out on unreachable transports. That was disproved: with all
+          # five ports open the request still failed in 11.18s against 11.4s
+          # before, so the time was never port timeouts, and the change fails for
+          # a reason still unidentified.
           #
-          # The hypothesis being tested: DNS SRV responses carry glue A records in
-          # the additional section, so when the Kerberos client resolves
-          # _kerberos._tcp.example.com it can take dc.example.com's accompanying
-          # 10.88.x.x address directly, never performing the separate lookup the
-          # hosts file would have intercepted -- and then dials an address Windows
-          # cannot route to. If that is the mechanism, a route fixes it. Windows
-          # does not need the container on its network, only a way to reach it.
+          # Leaving them published then caused an actual regression. Once the
+          # hosts entries pointed at a routable address (below) so the DC Locator
+          # could work, a reachable KDC meant Negotiate began attempting Kerberos
+          # instead of NTLM -- and Kerberos cannot succeed here: Samba registers
+          # its SPN for the DC's FQDN, and the KDC's own A record resolves to the
+          # container-internal 10.88.x.x that Windows cannot route to. Negotiate
+          # then failed outright rather than falling back, and every bind started
+          # returning 0x8007052E ERROR_LOGON_FAILURE -- breaking the minPwdLength
+          # read that had been passing.
+          #
+          # Without a KDC to find, Negotiate uses NTLM, which works.
+          #
+          # The obvious next move -- route Windows to the podman bridge so the
+          # container's own address becomes reachable -- has been TESTED AND
+          # REJECTED. Do not retry it. The theory was that a Kerberos client
+          # takes dc.example.com's 10.88.x.x address straight from the glue A
+          # record in an SRV response, never performing the lookup the hosts file
+          # would have intercepted, and so dials somewhere unroutable. The route
+          # was added and demonstrably worked:
+          #
+          #   route added: 10.88.0.0/16 via 172.27.120.101
+          #                (vEthernet (WSL (Hyper-V firewall)))
+          #   Stage 1: 10.88.0.2:389 REACHABLE
+          #   Stage 1: 10.88.0.2:88  REACHABLE
+          #
+          # And an explicit AuthType.Kerberos bind -- which NTLM cannot satisfy,
+          # so the result means what it says -- still failed:
+          #
+          #   Stage 2: Kerberos bind FAILED: "A local error occurred."
+          #
+          # Reachability was therefore never the blocker. That error is the
+          # client failing before it reaches the wire: a machine that is not
+          # domain-joined has no EXAMPLE.COM realm mapping, so the Kerberos
+          # package cannot request a ticket at all. Making Kerberos work here
+          # needs realm and SPN configuration on the runner, which is a larger
+          # change than this test justifies -- and Task 2 removes the dependency
+          # that motivated it, from production as well as CI.
           #
           # 389 is published for BOTH protocols, and the /udp is not incidental.
           # podman publishes TCP only when no protocol is given, so "-p 389:389"
@@ -143,36 +168,11 @@ jobs:
             --privileged \
             -p 389:389/tcp -p 389:389/udp -p 636:636 \
             -p 3268:3268 -p 3269:3269 \
-            -p 88:88/tcp -p 88:88/udp \
-            -p 464:464/tcp -p 464:464/udp \
             -p ${WSL_IP}:53:53/udp -p ${WSL_IP}:53:53/tcp \
             -e DOMAIN="example.com" \
             -e DOMAINPASS="AdminPassword123!" \
             -e NOCOMPLEXITY="true" \
             docker.io/nowsci/samba-domain:latest
-
-          # EXPERIMENT (time-boxed). Windows does not need the container on its
-          # network, only a route to it. The WSL VM already forwards, because
-          # podman requires ip_forward.
-          #
-          # The subnet is READ rather than assumed: netavark defaults to
-          # 10.88.0.0/16, but a hardcoded value that quietly stopped matching
-          # would produce a confusing negative result and this experiment is
-          # only worth running if its negative is trustworthy.
-          NETWORK_FILE="$(wslpath '${{ github.workspace }}')/podman-network.txt"
-
-          PODMAN_SUBNET="$(podman network inspect podman --format '{{range .Subnets}}{{.Subnet}}{{end}}' 2>/dev/null)"
-          if [ -z "${PODMAN_SUBNET}" ]; then
-            # Older/other backends report a different shape; fall back to JSON.
-            PODMAN_SUBNET="$(podman network inspect podman 2>/dev/null | grep -o '"subnet"[^,]*' | head -1 | sed 's/.*: *"//; s/"//')"
-          fi
-
-          CONTAINER_IP="$(podman inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' samba-ad 2>/dev/null)"
-
-          echo "podman bridge subnet : ${PODMAN_SUBNET:-<unknown>}"
-          echo "container address    : ${CONTAINER_IP:-<unknown>}"
-
-          printf '%s\n%s\n' "${PODMAN_SUBNET}" "${CONTAINER_IP}" > "${NETWORK_FILE}"
 
       - name: Wait for Samba AD DC Provisioning
         shell: wsl-bash {0}
@@ -296,116 +296,6 @@ jobs:
                   Write-Host "$name did not resolve: $($_.Exception.Message)"
               }
           }
-
-          # --- EXPERIMENT: static route to the podman bridge ------------------
-          # Half of a time-boxed pair; the other half is republishing 88/464.
-          # Windows does not need the container on its network, only a route to
-          # it, and the WSL VM already forwards because podman requires
-          # ip_forward. If Kerberos has been dialling the container's own
-          # 10.88.x.x address taken from a DNS glue record, this is what makes
-          # that address reachable.
-          #
-          # Subnet and container address are read from podman, never hardcoded.
-          $networkFile = Join-Path $env:GITHUB_WORKSPACE "podman-network.txt"
-          $podmanSubnet = $null
-          $containerIp = $null
-          if (Test-Path $networkFile) {
-              $networkFacts = @(Get-Content $networkFile)
-              if ($networkFacts.Count -ge 1) { $podmanSubnet = $networkFacts[0].Trim() }
-              if ($networkFacts.Count -ge 2) { $containerIp = $networkFacts[1].Trim() }
-          }
-
-          Write-Host "=== podman network facts ==="
-          Write-Host "  subnet    : $(if ($podmanSubnet) { $podmanSubnet } else { '<not reported>' })"
-          Write-Host "  container : $(if ($containerIp) { $containerIp } else { '<not reported>' })"
-
-          if ($podmanSubnet) {
-              try {
-                  # The interface is found by asking Windows how it reaches the
-                  # WSL VM, not by looking $wslIp up as a local address. That
-                  # lookup cannot work: $wslIp is the VM's own address, which
-                  # lives inside the VM and is not configured on any Windows
-                  # adapter -- the Windows end of the vEthernet (WSL) link has a
-                  # different address. Find-NetRoute answers the question that
-                  # actually matters, which is which interface carries traffic to
-                  # the VM, and the bridge route then follows the same path.
-                  $routeToVm = Find-NetRoute -RemoteIPAddress $wslIp -ErrorAction Stop | Select-Object -First 1
-                  Write-Host "  reaching $wslIp via interface $($routeToVm.InterfaceIndex) ($($routeToVm.InterfaceAlias))"
-
-                  New-NetRoute -DestinationPrefix $podmanSubnet -NextHop $wslIp `
-                    -InterfaceIndex $routeToVm.InterfaceIndex `
-                    -RouteMetric 1 -ErrorAction Stop | Out-Null
-                  Write-Host "  route added: $podmanSubnet via $wslIp"
-              }
-              catch {
-                  # A route that cannot be added is a Stage 1 failure and the
-                  # probe below will say so; it must not fail the step here.
-                  Write-Host "  route not added: $($_.Exception.Message)"
-              }
-              Write-Host "=== routes matching the bridge ==="
-              Get-NetRoute -ErrorAction SilentlyContinue |
-                Where-Object { $_.DestinationPrefix -eq $podmanSubnet } |
-                Format-Table DestinationPrefix,NextHop,InterfaceAlias,RouteMetric |
-                Out-String | Write-Host
-          }
-          else {
-              Write-Host "  no subnet reported; skipping the route (Stage 1 will fail and say so)"
-          }
-
-          # Stage 1: is the bridge reachable at all? No Kerberos involved, so a
-          # failure here is a routing problem and nothing else.
-          Write-Host "=== EXPERIMENT Stage 1: TCP to the container address ==="
-          if ($containerIp) {
-              foreach ($port in @(389, 88)) {
-                  try {
-                      $client = New-Object System.Net.Sockets.TcpClient
-                      $connect = $client.BeginConnect($containerIp, $port, $null, $null)
-                      if ($connect.AsyncWaitHandle.WaitOne(5000, $false) -and $client.Connected) {
-                          Write-Host "  Stage 1: ${containerIp}:${port} REACHABLE"
-                      }
-                      else {
-                          Write-Host "  Stage 1: ${containerIp}:${port} NOT reachable"
-                      }
-                      $client.Close()
-                  }
-                  catch {
-                      Write-Host "  Stage 1: ${containerIp}:${port} NOT reachable: $($_.Exception.Message)"
-                  }
-              }
-          }
-          else {
-              Write-Host "  Stage 1: skipped, no container address reported"
-          }
-
-          # Stage 2: does an EXPLICIT Kerberos bind succeed? AuthType.Kerberos,
-          # not Negotiate, so NTLM cannot satisfy it -- a Negotiate success would
-          # prove nothing about Kerberos, and this investigation has twice
-          # produced a fix whose stated rationale was wrong.
-          Write-Host "=== EXPERIMENT Stage 2: explicit Kerberos bind ==="
-          try {
-              Add-Type -AssemblyName System.DirectoryServices.Protocols
-              $identifier = New-Object System.DirectoryServices.Protocols.LdapDirectoryIdentifier("example.com", 389)
-              $connection = New-Object System.DirectoryServices.Protocols.LdapConnection($identifier)
-              $connection.SessionOptions.ProtocolVersion = 3
-              $connection.SessionOptions.Sealing = $true
-              $connection.SessionOptions.Signing = $true
-              $connection.AuthType = [System.DirectoryServices.Protocols.AuthType]::Kerberos
-              $connection.Credential = New-Object System.Net.NetworkCredential(
-                  "Administrator", "AdminPassword123!", "EXAMPLE")
-              $connection.Timeout = [TimeSpan]::FromSeconds(20)
-              $connection.Bind()
-              Write-Host "  Stage 2: Kerberos bind to example.com:389 SUCCEEDED"
-              $connection.Dispose()
-          }
-          catch {
-              # The exact error decides the outcome: a KDC error naming the
-              # principal is a different answer from a timeout.
-              Write-Host "  Stage 2: Kerberos bind FAILED: $($_.Exception.GetType().Name): $($_.Exception.Message)"
-              if ($_.Exception.InnerException) {
-                  Write-Host "  Stage 2: inner: $($_.Exception.InnerException.Message)"
-              }
-          }
-          # --- end EXPERIMENT --------------------------------------------------
 
           # NRPT sends only *.example.com queries to the container's DNS, leaving
           # the runner's own resolution (GitHub API, package restore) untouched.

--- a/.github/workflows/ad-provider-smoke-test.yml
+++ b/.github/workflows/ad-provider-smoke-test.yml
@@ -321,8 +321,19 @@ jobs:
 
           if ($podmanSubnet) {
               try {
+                  # The interface is found by asking Windows how it reaches the
+                  # WSL VM, not by looking $wslIp up as a local address. That
+                  # lookup cannot work: $wslIp is the VM's own address, which
+                  # lives inside the VM and is not configured on any Windows
+                  # adapter -- the Windows end of the vEthernet (WSL) link has a
+                  # different address. Find-NetRoute answers the question that
+                  # actually matters, which is which interface carries traffic to
+                  # the VM, and the bridge route then follows the same path.
+                  $routeToVm = Find-NetRoute -RemoteIPAddress $wslIp -ErrorAction Stop | Select-Object -First 1
+                  Write-Host "  reaching $wslIp via interface $($routeToVm.InterfaceIndex) ($($routeToVm.InterfaceAlias))"
+
                   New-NetRoute -DestinationPrefix $podmanSubnet -NextHop $wslIp `
-                    -InterfaceAlias (Get-NetIPAddress -IPAddress $wslIp -ErrorAction Stop).InterfaceAlias `
+                    -InterfaceIndex $routeToVm.InterfaceIndex `
                     -RouteMetric 1 -ErrorAction Stop | Out-Null
                   Write-Host "  route added: $podmanSubnet via $wslIp"
               }


### PR DESCRIPTION
**Time-boxed experiment with an explicit stop condition — not a change to drive to green.** Task 2 (security groups only) removes the forest dependency from production regardless; this only settles whether Kerberos can work in this topology at all. A clear negative closes a question that has been open for several rounds and is worth as much as a positive.

## The changes — one logical unit, one file

| # | Change |
|---|---|
| 1 | Static route on Windows to the podman bridge subnet, via the `$wslIp` already computed for the hosts entries and NRPT rule |
| 2 | 88 and 464 republished, tcp and udp, as before they were removed |
| 3 | Two-stage discriminating probe |

The route alone changes nothing observable; republishing the ports alone reproduces a known breakage. They stand or fall together and would be reverted together.

Everything else is untouched: hosts entries at `$wslIp`, the NRPT rule, `LdapHostnames` at `dc.example.com`, UDP 389, the CA trust, and the existing sealed-bind and LDAPS probes. No provider code, no group configuration, no assertion.

## The hypothesis

DNS SRV responses carry glue A records in the additional section. A Kerberos client resolving `_kerberos._tcp.example.com` can take `dc.example.com`'s accompanying `10.88.x.x` address straight from the response, never performing the separate lookup the hosts file would have intercepted — and then dials an address Windows cannot route to.

If that's the mechanism, a route is enough. Windows doesn't need the container on its network, only a way to reach it, and the WSL VM already forwards because podman requires `ip_forward`.

**The subnet and container address are read from `podman network inspect` / `podman inspect`, never hardcoded.** The netavark default is `10.88.0.0/16`, but a hardcoded value that quietly stopped matching would produce a confusing negative — and this is only worth running if a negative can be trusted.

## The probe

The existing bind diagnostics use `Negotiate`, which falls back to NTLM, so a success there would say nothing about Kerberos. This investigation has already twice produced a fix whose stated rationale turned out wrong, so the probe is built to be unsatisfiable by the wrong mechanism:

- **Stage 1** — plain TCP connect to the container's own address on 389 and 88. Tests the route in isolation, no Kerberos involved.
- **Stage 2** — `LdapConnection` to `example.com:389` with `AuthType.Kerberos` set explicitly. No Negotiate, so **NTLM cannot satisfy it**. Reports the exact error, because a KDC error naming the principal is a different answer from a timeout.

Both stages are diagnostics and cannot fail the job on their own.

## Exit criteria

| Stage 1 | Stage 2 | Action |
|---|---|---|
| fails | — | Iterate on route/firewall (Hyper-V firewall on the WSL adapter; podman default-network isolation). If still failing, stop. |
| passes | fails | **Stop.** Route works, Kerberos has a different blocker. Record the exact error and revert. |
| passes | passes | Proceed to the follow-on in a **separate** commit: `LdapHostnames` back to `example.com`, confirm the sealed-bind probe to `example.com:389` succeeds, re-check `Forest.GetForest()`. |

**Hard limit: four rounds after the route is confirmed working; six total.** Then revert in one commit and move to Task 2.

## Expected failure mode

If Kerberos becomes reachable but cannot succeed, Negotiate fails outright rather than falling back and **every bind breaks** — including `minPwdLength` and the group legs that currently pass. That is the state the previous removal of these ports reverted. Expect a broad red, not a targeted one; it is not a new fault and shouldn't cost a round to diagnose.

Whatever the outcome, Stage 1 and Stage 2 results and any `Forest.GetForest()` state change will be recorded verbatim.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [x] Testing/CI harness (time-boxed experiment)

## Checklist
- [x] Workflow YAML parses; 37 steps; shell syntax clean on every bash/wsl-bash step.
- [x] One file changed — no provider code, no configuration, no assertions.
- [x] Subnet and container address read at runtime, not hardcoded.
- [x] Both probe stages are non-fatal diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsJRsb3rUAuacypogW9ZEN

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsJRsb3rUAuacypogW9ZEN)_